### PR TITLE
Fix dependency handling and propagate quiet mode in LT builds

### DIFF
--- a/lt/lt/build/Makefile
+++ b/lt/lt/build/Makefile
@@ -896,7 +896,11 @@ ifeq (1, $(LT_QUIET))
     LT_META_GOALS += quiet
     MAKECMDGOALS := $(strip $(subst quiet,,$(MAKECMDGOALS)))
 
-    LT_QUIET_CMD        :=
+    ifeq (listlibraries,$(findstring listlibraries,$(MAKECMDGOALS)))
+        LT_QUIET_CMD    := @echo > /dev/null
+    else
+        LT_QUIET_CMD    :=
+    endif
     LT_EXEC_CMD         := @
     LT_GNU_QUIET_ARG    := --quiet
     LT_UNZIP_FLAGS      := -q


### PR DESCRIPTION
In his instructional video, [Debugging and Stack Analysis in Roku LT OS](https://youtu.be/lz7-swzCqxE?si=EotMWBYD1_r2pgFZ&t=1639) (around 28:12), @RokuDon ran into this Make build error.

> make[1]: *** No rule to make target 'ARBOLATE' needed by ... LTFirmwareImage.elf'.  Stop.
> make: *** [.../lt/lt/build/Makefile:1873: Esp_MasterFirmwareImage]: Error 2

This happens after changing `ENABLE_LT_CALLSITE_IN_RELEASE_MODE` from 0 to 1 in `lt/lt/include/lt/LTTypes.h` then running  `make quiet` . Re-running `make quiet` a second time successfully completes the build. However, Make should be able to build correctly and completely in one round.

These Makefile changes resolve this specific Make build error for me, but please test and verify in your cases as well.


