### PR TITLE
Improve README with spelling fixes and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@ Welcome to the _Roku LT Operating System_ open source distribution.
 
 You may view the <a href="https://go.roku.com/roku-lt-os-videos">LT Open Source instructional videos</a> and read the <a href="https://blog.roku.com/developer/roku-lt-os">LT Open Source announcement</a> to learn more.
 
+Before building LT OS for ESP32, ensure the pyserial Python module is installed. The bundled esptool.py requires it; otherwise you may see errors about pyserial not being installed. On Debian/Ubuntu Linux, install it with:
+```
+% sudo apt install python3-serial
+```
+On Fedora/RHEL/CentOS, install it with:
+```
+% sudo dnf install python3-pyserial
+```
+On macOS, install it with:
+```
+% pip3 install pyserial
+```
+On Windows, install it with:
+```
+% py -m pip install pyserial
+```
+
 To build LT OS for ESP32:
 ```
 % cd /path-to-lt-sdk/lt-firmware-example
@@ -16,7 +33,7 @@ To flash, clean:
 % make FlashFirmware
 % make clean
 ```
-To perform first time initialziation of all partitions of the Flash (build first):
+To perform first-time initialization of all partitions of the flash (build first):
 ```
 % LT_FLASH=all make FlashFirmware
 ```
@@ -37,4 +54,10 @@ To run Linux build:
 % sudo ./ltrun LTSystemShell
 ```
 
-To obtain an inexpensive ESP32 development platform, go to amazon.com and search "ESP32 Cam". They are available in 2-packs for ~$20.00.
+For reference only, and not an endorsement, some example ESP32 development boards are:
+- [Espressif ESP32-DevKitC](https://www.espressif.com/en/products/devkits/esp32-devkitc/overview)
+- [Adafruit HUZZAH32 - ESP32 Feather Board (pre-soldered)](https://www.adafruit.com/product/3591)
+- [SparkFun ESP32 Thing](https://www.sparkfun.com/sparkfun-esp32-thing.html)
+- Don's advice is another option: [Amazon search for ESP32 camera boards](https://www.amazon.com/s?k=ESP32+cam)
+
+Availability, pricing, and features may vary by seller and region.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,6 @@ For reference only, and not an endorsement, some example ESP32 development board
 - [Espressif ESP32-DevKitC](https://www.espressif.com/en/products/devkits/esp32-devkitc/overview)
 - [Adafruit HUZZAH32 - ESP32 Feather Board (pre-soldered)](https://www.adafruit.com/product/3591)
 - [SparkFun ESP32 Thing](https://www.sparkfun.com/sparkfun-esp32-thing.html)
-- Don's advice is another option: [Amazon search for ESP32 camera boards](https://www.amazon.com/s?k=ESP32+cam)
+- [Amazon search for ESP32 camera boards](https://www.amazon.com/s?k=ESP32+cam)
 
 Availability, pricing, and features may vary by seller and region.


### PR DESCRIPTION
This pull request updates the `README.md` to improve setup instructions and clarify ESP32 hardware options. The most important changes are grouped below:

**Documentation improvements:**

* Added instructions for installing the `pyserial` Python module, which is required for building LT OS for ESP32. Platform-specific installation commands are provided for Debian/Ubuntu, Fedora/RHEL/CentOS, macOS, and Windows.
* Fixed a typo and clarified the instructions for first-time initialization of all flash partitions.

**Hardware recommendations:**

* Replaced the generic Amazon search recommendation with a list of specific ESP32 development boards, including links to official and third-party vendors. Added a note that these are for reference only and not endorsements, and clarified that availability and pricing may vary.