### PR TITLE
Add ADC HAL files

### DIFF
--- a/lt/platforms/st/build/project/stm32_sdk.mk
+++ b/lt/platforms/st/build/project/stm32_sdk.mk
@@ -29,6 +29,8 @@ LT_PROJECT_SOURCE_FILES += CM7/Core/Src/syscalls.c
 LT_PROJECT_SOURCE_FILES += CM7/Core/Startup/startup_stm32h755zitx.s
 LT_PROJECT_SOURCE_FILES += Drivers/BSP/STM32H7xx_Nucleo/stm32h7xx_nucleo.c
 LT_PROJECT_SOURCE_FILES += Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal.c
+LT_PROJECT_SOURCE_FILES += Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_adc.c
+LT_PROJECT_SOURCE_FILES += Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_adc_ex.c
 LT_PROJECT_SOURCE_FILES += Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_cortex.c
 LT_PROJECT_SOURCE_FILES += Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_dma.c
 LT_PROJECT_SOURCE_FILES += Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_dma_ex.c
@@ -59,3 +61,4 @@ include $(LT_PROJECT_RULES_MAKEFILE)
 #   LOG
 ###############################################################################
 #   10-Jul-2026	augustus    created
+#   12-Aug-2026	connor      added ADC HAL module (stm32h7xx_hal_adc, _adc_ex)

--- a/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/CM7/Core/Inc/stm32h7xx_hal_conf.h
+++ b/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/CM7/Core/Inc/stm32h7xx_hal_conf.h
@@ -34,7 +34,7 @@
   */
 #define HAL_MODULE_ENABLED
 
-  /* #define HAL_ADC_MODULE_ENABLED   */
+#define HAL_ADC_MODULE_ENABLED
 /* #define HAL_FDCAN_MODULE_ENABLED   */
 /* #define HAL_FMAC_MODULE_ENABLED   */
 /* #define HAL_CEC_MODULE_ENABLED   */

--- a/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h
+++ b/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h
@@ -1,0 +1,2034 @@
+/**
+  ******************************************************************************
+  * @file    stm32h7xx_hal_adc.h
+  * @author  MCD Application Team
+  * @brief   Header file of ADC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32H7xx_HAL_ADC_H
+#define STM32H7xx_HAL_ADC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32h7xx_hal_def.h"
+
+/* Include low level driver */
+#include "stm32h7xx_ll_adc.h"
+
+/** @addtogroup STM32H7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ADC_Exported_Types ADC Exported Types
+  * @{
+  */
+
+/**
+  * @brief  ADC group regular oversampling structure definition
+  */
+typedef struct
+{
+  uint32_t Ratio;                         /*!< Configures the oversampling ratio. */
+#if defined(ADC_VER_V5_V90)
+                                           /* On devices STM32H72xx and STM32H73xx, this parameter can be a value from 1 to 1023 for ADC1/2 or a value of @ref ADC_HAL_EC_OVS_RATIO  for ADC3*/    
+#else
+                                           /*This parameter can be a value of @ref ADC_HAL_EC_OVS_RATIO */
+#endif
+
+  uint32_t RightBitShift;                 /*!< Configures the division coefficient for the Oversampler.
+                                               This parameter can be a value of @ref ADC_HAL_EC_OVS_SHIFT */
+
+  uint32_t TriggeredMode;                 /*!< Selects the regular triggered oversampling mode.
+                                               This parameter can be a value of @ref ADC_HAL_EC_OVS_DISCONT_MODE */
+
+  uint32_t OversamplingStopReset;         /*!< Selects the regular oversampling mode.
+                                               The oversampling is either temporary stopped or reset upon an injected
+                                               sequence interruption.
+                                               If oversampling is enabled on both regular and injected groups, this parameter
+                                               is discarded and forced to setting "ADC_REGOVERSAMPLING_RESUMED_MODE"
+                                               (the oversampling buffer is zeroed during injection sequence).
+                                               This parameter can be a value of @ref ADC_HAL_EC_OVS_SCOPE_REG */
+
+} ADC_OversamplingTypeDef;
+
+/**
+  * @brief  Structure definition of ADC instance and ADC group regular.
+  * @note   Parameters of this structure are shared within 2 scopes:
+  *          - Scope entire ADC (affects ADC groups regular and injected): ClockPrescaler, Resolution, DataAlign,
+  *            ScanConvMode, EOCSelection, LowPowerAutoWait.
+  *          - Scope ADC group regular: ContinuousConvMode, NbrOfConversion, DiscontinuousConvMode, NbrOfDiscConversion,
+  *            ExternalTrigConv, ExternalTrigConvEdge, DMAContinuousRequests, Overrun, OversamplingMode, Oversampling.
+  * @note   The setting of these parameters by function HAL_ADC_Init() is conditioned to ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled
+  *          - For all parameters except 'LowPowerAutoWait', 'DMAContinuousRequests' and 'Oversampling': ADC enabled without conversion on going on group regular.
+  *          - For parameters 'LowPowerAutoWait' and 'DMAContinuousRequests': ADC enabled without conversion on going on groups regular and injected.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behavior in case of intended action to update another parameter
+  *         (which fulfills the ADC state condition) on the fly).
+  */
+typedef struct
+{
+  uint32_t ClockPrescaler;        /*!< Select ADC clock source (synchronous clock derived from APB clock or asynchronous clock derived from system clock or PLL (Refer to reference manual for list of clocks available)) and clock prescaler.
+                                       This parameter can be a value of @ref ADC_HAL_EC_COMMON_CLOCK_SOURCE.
+                                       Note: The ADC clock configuration is common to all ADC instances.
+                                       Note: In case of usage of channels on injected group, ADC frequency should be lower than AHB clock frequency /4 for resolution 12 or 10 bits,
+                                             AHB clock frequency /3 for resolution 8 bits, AHB clock frequency /2 for resolution 6 bits.
+                                       Note: In case of synchronous clock mode based on HCLK/1, the configuration must be enabled only
+                                             if the system clock has a 50% duty clock cycle (APB prescaler configured inside RCC
+                                             must be bypassed and PCLK clock must have 50% duty cycle). Refer to reference manual for details.
+                                       Note: In case of usage of asynchronous clock, the selected clock must be preliminarily enabled at RCC top level.
+                                       Note: This parameter can be modified only if all ADC instances are disabled. */
+
+  uint32_t Resolution;            /*!< Configure the ADC resolution.
+                                       This parameter can be a value of @ref ADC_HAL_EC_RESOLUTION */
+
+#if defined(ADC_VER_V5_V90)
+  uint32_t DataAlign;             /*!< Specify ADC data alignment in conversion data register (right or left).
+                                       Refer to reference manual for alignments formats versus resolutions.
+                                       This parameter can be a value of @ref ADC_HAL_EC_DATA_ALIGN
+                                       This parameter is reserved for ADC3 on devices STM32H72xx and STM32H73xx*/
+#endif
+
+  uint32_t ScanConvMode;          /*!< Configure the sequencer of ADC groups regular and injected.
+                                       This parameter can be associated to parameter 'DiscontinuousConvMode' to have main sequence subdivided in successive parts.
+                                       If disabled: Conversion is performed in single mode (one channel converted, the one defined in rank 1).
+                                                    Parameters 'NbrOfConversion' and 'InjectedNbrOfConversion' are discarded (equivalent to set to 1).
+                                       If enabled:  Conversions are performed in sequence mode (multiple ranks defined by 'NbrOfConversion' or 'InjectedNbrOfConversion' and rank of each channel in sequencer).
+                                                    Scan direction is upward: from rank 1 to rank 'n'.
+                                       This parameter can be a value of @ref ADC_Scan_mode */
+
+  uint32_t EOCSelection;          /*!< Specify which EOC (End Of Conversion) flag is used for conversion by polling and interruption: end of unitary conversion or end of sequence conversions.
+                                       This parameter can be a value of @ref ADC_EOCSelection. */
+
+  FunctionalState LowPowerAutoWait; /*!< Select the dynamic low power Auto Delay: new conversion start only when the previous
+                                       conversion (for ADC group regular) or previous sequence (for ADC group injected) has been retrieved by user software,
+                                       using function HAL_ADC_GetValue() or HAL_ADCEx_InjectedGetValue().
+                                       This feature automatically adapts the frequency of ADC conversions triggers to the speed of the system that reads the data. Moreover, this avoids risk of overrun
+                                       for low frequency applications.
+                                       This parameter can be set to ENABLE or DISABLE.
+                                       Note: It is not recommended to use with interruption or DMA (HAL_ADC_Start_IT(), HAL_ADC_Start_DMA()) since these modes have to clear immediately the EOC flag (by CPU to free the IRQ pending event or by DMA).
+                                                       Auto wait will work but fort a very short time, discarding its intended benefit (except specific case of high load of CPU or DMA transfers which can justify usage of auto wait).
+                                                       Do use with polling: 1. Start conversion with HAL_ADC_Start(), 2. Later on, when ADC conversion data is needed:
+                                                       and use HAL_ADC_GetValue() to retrieve conversion result and trig another conversion (in case of usage of injected group, 
+                                                       use the equivalent functions HAL_ADCExInjected_Start(), HAL_ADCEx_InjectedGetValue(), ...). */
+
+  FunctionalState ContinuousConvMode; /*!< Specify whether the conversion is performed in single mode (one conversion) or continuous mode for ADC group regular,
+                                       after the first ADC conversion start trigger occurred (software start or external trigger).
+                                       This parameter can be set to ENABLE or DISABLE. */
+
+  uint32_t NbrOfConversion;       /*!< Specify the number of ranks that will be converted within the regular group sequencer.
+                                       To use the regular group sequencer and convert several ranks, parameter 'ScanConvMode' must be enabled.
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 16.
+                                       Note: This parameter must be modified when no conversion is on going on regular group (ADC disabled, or ADC enabled without
+                                       continuous mode or external trigger that could launch a conversion). */
+
+  FunctionalState DiscontinuousConvMode; /*!< Specify whether the conversions sequence of ADC group regular is performed in Complete-sequence/Discontinuous-sequence
+                                       (main sequence subdivided in successive parts).
+                                       Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
+                                       Discontinuous mode can be enabled only if continuous mode is disabled. If continuous mode is enabled, this parameter setting is discarded.
+                                       This parameter can be set to ENABLE or DISABLE. */
+
+  uint32_t NbrOfDiscConversion;   /*!< Specifies the number of discontinuous conversions in which the main sequence of ADC group regular (parameter NbrOfConversion) will be subdivided.
+                                       If parameter 'DiscontinuousConvMode' is disabled, this parameter is discarded.
+                                       This parameter must be a number between Min_Data = 1 and Max_Data = 8. */
+
+  uint32_t ExternalTrigConv;      /*!< Select the external event source used to trigger ADC group regular conversion start.
+                                       If set to ADC_SOFTWARE_START, external triggers are disabled and software trigger is used instead.
+                                       This parameter can be a value of @ref ADC_regular_external_trigger_source.
+                                       Caution: external trigger source is common to all ADC instances. */
+
+  uint32_t ExternalTrigConvEdge;  /*!< Select the external event edge used to trigger ADC group regular conversion start.
+                                       If trigger source is set to ADC_SOFTWARE_START, this parameter is discarded.
+                                       This parameter can be a value of @ref ADC_regular_external_trigger_edge */
+
+  uint32_t ConversionDataManagement; /*!< Specifies whether the Data conversion data is managed: using the DMA (oneshot or circular), or stored in the DR register or transferred to DFSDM register.
+                                       Note: In continuous mode, DMA must be configured in circular mode. Otherwise an overrun will be triggered when DMA buffer maximum pointer is reached.
+                                       This parameter can be a value of @ref ADC_ConversionDataManagement.
+                                       Note: This parameter must be modified when no conversion is on going on both regular and injected groups
+                                       (ADC disabled, or ADC enabled without continuous mode or external trigger that could launch a conversion).*/
+#if defined(ADC_VER_V5_V90)
+  /*Note: On devices STM32H72xx and STM32H73xx, this parameter is specific to ADC3 only. */
+
+  uint32_t SamplingMode;          /*!< Select the sampling mode to be used for ADC group regular conversion.
+                                       This parameter can be a value of @ref ADC_regular_sampling_mode.
+                                       Note:
+                                            - On devices STM32H72xx and STM32H73xx, this parameter is specific to ADC3 only. */
+
+  FunctionalState DMAContinuousRequests; /*!< Specify whether the DMA requests are performed in one shot mode (DMA transfer stops when number of conversions is reached)
+                                       or in continuous mode (DMA transfer unlimited, whatever number of conversions).
+                                       This parameter can be set to ENABLE or DISABLE.
+                                       Notes:
+                                             - In continuous mode, DMA must be configured in circular mode. Otherwise an overrun will be triggered when DMA buffer maximum pointer is reached.
+                                             - Specific to ADC3 only on devices STM32H72xx and STM32H73xx */
+#endif
+
+  uint32_t Overrun;               /*!< Select the behavior in case of overrun: data overwritten or preserved (default).
+                                       This parameter applies to ADC group regular only.
+                                       This parameter can be a value of @ref ADC_HAL_EC_REG_OVR_DATA_BEHAVIOR.
+                                       Note: In case of overrun set to data preserved and usage with programming model with interruption (HAL_Start_IT()): ADC IRQ handler has to clear
+                                       end of conversion flags, this induces the release of the preserved data. If needed, this data can be saved in function
+                                       HAL_ADC_ConvCpltCallback(), placed in user program code (called before end of conversion flags clear).
+                                       Note: Error reporting with respect to the conversion mode:
+                                             - Usage with ADC conversion by polling for event or interruption: Error is reported only if overrun is set to data preserved. If overrun is set to data
+                                               overwritten, user can willingly not read all the converted data, this is not considered as an erroneous case.
+                                             - Usage with ADC conversion by DMA: Error is reported whatever overrun setting (DMA is expected to process all data from data register). */
+
+  uint32_t LeftBitShift;             /*!< Configures the left shifting applied to the final result with or without oversampling.
+                                          This parameter can be a value of @ref ADCEx_Left_Bit_Shift */
+  FunctionalState OversamplingMode;       /*!< Specify whether the oversampling feature is enabled or disabled.
+                                               This parameter can be set to ENABLE or DISABLE.
+                                               Note: This parameter can be modified only if there is no conversion is ongoing on ADC groups regular and injected */
+
+  ADC_OversamplingTypeDef Oversampling;   /*!< Specify the Oversampling parameters.
+                                               Caution: this setting overwrites the previous oversampling configuration if oversampling is already enabled. */
+
+} ADC_InitTypeDef;
+
+/**
+  * @brief  Structure definition of ADC channel for regular group
+  * @note   The setting of these parameters by function HAL_ADC_ConfigChannel() is conditioned to ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled (this is the only possible ADC state to modify parameter 'SingleDiff')
+  *          - For all except parameters 'SamplingTime', 'Offset', 'OffsetNumber': ADC enabled without conversion on going on regular group.
+  *          - For parameters 'SamplingTime', 'Offset', 'OffsetNumber': ADC enabled without conversion on going on regular and injected groups.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behavior in case of intended action to update another parameter (which fulfills the ADC state condition)
+  *         on the fly).
+  */
+typedef struct
+{
+  uint32_t Channel;                /*!< Specify the channel to configure into ADC regular group.
+                                        This parameter can be a value of @ref ADC_HAL_EC_CHANNEL
+                                        Note: Depending on devices and ADC instances, some channels may not be available on device package pins. Refer to device datasheet for channels availability. */
+
+  uint32_t Rank;                   /*!< Specify the rank in the regular group sequencer.
+                                        This parameter can be a value of @ref ADC_HAL_EC_REG_SEQ_RANKS
+                                        Note: to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by
+                                        the new channel setting (or parameter number of conversions adjusted) */
+
+  uint32_t SamplingTime;           /*!< Sampling time value to be set for the selected channel.
+                                        Unit: ADC clock cycles
+                                        Conversion time is the addition of sampling time and processing time
+                                        (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
+                                        This parameter can be a value of @ref ADC_HAL_EC_CHANNEL_SAMPLINGTIME
+                                        Caution: This parameter applies to a channel that can be used into regular and/or injected group.
+                                                 It overwrites the last setting.
+                                        Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                              sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                              Refer to device datasheet for timings values. */
+
+  uint32_t SingleDiff;             /*!< Select single-ended or differential input.
+                                        In differential mode: Differential measurement is carried out between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
+                                                              Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
+                                        This parameter must be a value of @ref ADC_HAL_EC_CHANNEL_SINGLE_DIFF_ENDING
+                                        Caution: This parameter applies to a channel that can be used in a regular and/or injected group.
+                                                 It overwrites the last setting.
+                                        Note: Refer to Reference Manual to ensure the selected channel is available in differential mode.
+                                        Note: When configuring a channel 'i' in differential mode, the channel 'i+1' is not usable separately.
+                                        Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                              If ADC is enabled, this parameter setting is bypassed without error reporting (as it can be the expected behavior in case
+                                        of another parameter update on the fly) */
+
+  uint32_t OffsetNumber;           /*!< Select the offset number
+                                        This parameter can be a value of @ref ADC_HAL_EC_OFFSET_NB
+                                        Caution: Only one offset is allowed per channel. This parameter overwrites the last setting. */
+
+  uint32_t Offset;                 /*!< Define the offset to be subtracted from the raw converted data.
+                                        Offset value must be a positive number.
+                                        Maximum value depends on ADC resolution and oversampling ratio (in case of oversampling used).
+                                        This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0x3FFFC00 (corresponding to resolution 16 bit and oversampling ratio 1024).
+                                        Note: This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled
+                                              without continuous mode or external trigger that could launch a conversion). */
+
+  FunctionalState OffsetRightShift;   /*!< Define the Right-shift data after Offset correction.
+                                        This parameter is applied only for 16-bit or 8-bit resolution.
+                                        This parameter can be set to ENABLE or DISABLE.*/
+#if defined(ADC_VER_V5_V90)
+  uint32_t OffsetSign;                /*!< Define if the offset should be subtracted (negative sign) or added (positive sign) from or to the raw converted data.
+                                        This parameter can be a value of @ref ADCEx_OffsetSign.
+                                        Note: 
+                                              - This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled
+                                                without continuous mode or external trigger that could launch a conversion). 
+                                              - Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+  FunctionalState OffsetSaturation;   /*!< Define if the offset should be saturated upon under or over flow.
+                                        This parameter value can be ENABLE or DISABLE.
+                                        Note: 
+                                              - This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled
+                                                without continuous mode or external trigger that could launch a conversion). 
+                                              - Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#endif
+  FunctionalState OffsetSignedSaturation; /*!< Specify whether the Signed saturation feature is used or not.
+                                             This parameter is applied only for 16-bit or 8-bit resolution.
+                                             This parameter can be set to ENABLE or DISABLE. */
+
+} ADC_ChannelConfTypeDef;
+
+/**
+  * @brief  Structure definition of ADC analog watchdog
+  * @note   The setting of these parameters by function HAL_ADC_AnalogWDGConfig() is conditioned to ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled or ADC enabled without conversion on going on ADC groups regular and injected.
+  */
+typedef struct
+{
+  uint32_t WatchdogNumber;    /*!< Select which ADC analog watchdog is monitoring the selected channel.
+                                   For Analog Watchdog 1: Only 1 channel can be monitored (or overall group of channels by setting parameter 'WatchdogMode')
+                                   For Analog Watchdog 2 and 3: Several channels can be monitored (by successive calls of 'HAL_ADC_AnalogWDGConfig()' for each channel)
+                                   This parameter can be a value of @ref ADC_HAL_EC_AWD_NUMBER. */
+
+  uint32_t WatchdogMode;      /*!< Configure the ADC analog watchdog mode: single/all/none channels.
+                                   For Analog Watchdog 1: Configure the ADC analog watchdog mode: single channel or all channels, ADC groups regular and-or injected.
+                                   For Analog Watchdog 2 and 3: Several channels can be monitored by applying successively the AWD init structure. Channels on ADC group regular and injected are not differentiated: Set value 'ADC_ANALOGWATCHDOG_SINGLE_xxx' to monitor 1 channel, value 'ADC_ANALOGWATCHDOG_ALL_xxx' to monitor all channels, 'ADC_ANALOGWATCHDOG_NONE' to monitor no channel.
+                                   This parameter can be a value of @ref ADC_analog_watchdog_mode. */
+
+  uint32_t Channel;           /*!< Select which ADC channel to monitor by analog watchdog.
+                                   For Analog Watchdog 1: this parameter has an effect only if parameter 'WatchdogMode' is configured on single channel (only 1 channel can be monitored).
+                                   For Analog Watchdog 2 and 3: Several channels can be monitored. To use this feature, call successively the function HAL_ADC_AnalogWDGConfig() for each channel to be added (or removed with value 'ADC_ANALOGWATCHDOG_NONE').
+                                   This parameter can be a value of @ref ADC_HAL_EC_CHANNEL. */
+
+  FunctionalState ITMode;     /*!< Specify whether the analog watchdog is configured in interrupt or polling mode.
+                                   This parameter can be set to ENABLE or DISABLE */
+
+  uint32_t HighThreshold;     /*!< Configure the ADC analog watchdog High threshold value.
+                                   Depending of ADC resolution selected (16, 14, 12, 10, 8 bits), this parameter must be a number
+                                   between Min_Data = 0x000 and Max_Data = 0xFFFF, 0x3FFF, 0xFFF, 0x3FF or 0xFF respectively.
+                                   Note: Analog watchdog 2 and 3 are limited to a resolution of 8 bits: if ADC resolution is 12 bits
+                                         the 4 LSB are ignored, if ADC resolution is 10 bits the 2 LSB are ignored.
+                                   Note: If ADC oversampling is enabled, ADC analog watchdog thresholds are
+                                         impacted: the comparison of analog watchdog thresholds is done
+                                         on oversampling intermediate computation (after ratio, before shift
+                                         application): intermediate register bitfield [32:7] (26 most significant bits). */
+
+  uint32_t LowThreshold;      /*!< Configures the ADC analog watchdog Low threshold value.
+                                   Depending of ADC resolution selected (16, 14, 12, 10, 8 bits), this parameter must be a number
+                                   between Min_Data = 0x000 and Max_Data = 0xFFFF, 0x3FFF, 0xFFF, 0x3FF or 0xFF respectively.
+                                   Note: Analog watchdog 2 and 3 are limited to a resolution of 8 bits: if ADC resolution is 12 bits
+                                         the 4 LSB are ignored, if ADC resolution is 10 bits the 2 LSB are ignored.
+                                   Note: If ADC oversampling is enabled, ADC analog watchdog thresholds are
+                                         impacted: the comparison of analog watchdog thresholds is done
+                                         on oversampling intermediate computation (after ratio, before shift
+                                         application): intermediate register bitfield [32:7] (26 most significant bits). */
+#if defined(ADC_VER_V5_V90)
+  uint32_t FilteringConfig;   /*!< Specify whether filtering should be use and the number of samples to consider.
+                                   Before setting flag or raising interrupt, analog watchdog can wait to have several
+                                   consecutive out-of-window samples. This parameter allows to configure this number.
+                                   This parameter only applies to Analog watchdog 1. For others, use value ADC_AWD_FILTERING_NONE.
+                                   This parameter can be a value of @ref ADC_analog_watchdog_filtering_config. Applicable for ADC3 on devices STM32H72xx and STM32H73xx. */
+#endif
+} ADC_AnalogWDGConfTypeDef;
+
+/**
+  * @brief  ADC group injected contexts queue configuration
+  * @note   Structure intended to be used only through structure "ADC_HandleTypeDef"
+  */
+typedef struct
+{
+  uint32_t ContextQueue;                 /*!< Injected channel configuration context: build-up over each
+                                              HAL_ADCEx_InjectedConfigChannel() call to finally initialize
+                                              JSQR register at HAL_ADCEx_InjectedConfigChannel() last call */
+
+  uint32_t ChannelCount;                 /*!< Number of channels in the injected sequence */
+} ADC_InjectionConfigTypeDef;
+
+/** @defgroup ADC_States ADC States
+  * @{
+  */
+
+/**
+  * @brief  HAL ADC state machine: ADC states definition (bitfields)
+  * @note   ADC state machine is managed by bitfields, state must be compared
+  *         with bit by bit.
+  *         For example:
+  *           " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_REG_BUSY) != 0UL) "
+  *           " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD1) != 0UL) "
+  */
+/* States of ADC global scope */
+#define HAL_ADC_STATE_RESET             (0x00000000UL)   /*!< ADC not yet initialized or disabled */
+#define HAL_ADC_STATE_READY             (0x00000001UL)   /*!< ADC peripheral ready for use */
+#define HAL_ADC_STATE_BUSY_INTERNAL     (0x00000002UL)   /*!< ADC is busy due to an internal process (initialization, calibration) */
+#define HAL_ADC_STATE_TIMEOUT           (0x00000004UL)   /*!< TimeOut occurrence */
+
+/* States of ADC errors */
+#define HAL_ADC_STATE_ERROR_INTERNAL    (0x00000010UL)   /*!< Internal error occurrence */
+#define HAL_ADC_STATE_ERROR_CONFIG      (0x00000020UL)   /*!< Configuration error occurrence */
+#define HAL_ADC_STATE_ERROR_DMA         (0x00000040UL)   /*!< DMA error occurrence */
+
+/* States of ADC group regular */
+#define HAL_ADC_STATE_REG_BUSY          (0x00000100UL)   /*!< A conversion on ADC group regular is ongoing or can occur (either by continuous mode,
+                                                              external trigger, low power auto power-on (if feature available), multimode ADC master control (if feature available)) */
+#define HAL_ADC_STATE_REG_EOC           (0x00000200UL)   /*!< Conversion data available on group regular */
+#define HAL_ADC_STATE_REG_OVR           (0x00000400UL)   /*!< Overrun occurrence */
+#define HAL_ADC_STATE_REG_EOSMP         (0x00000800UL)   /*!< Not available on this STM32 series: End Of Sampling flag raised  */
+
+/* States of ADC group injected */
+#define HAL_ADC_STATE_INJ_BUSY          (0x00001000UL)   /*!< A conversion on ADC group injected is ongoing or can occur (either by auto-injection mode,
+                                                              external trigger, low power auto power-on (if feature available), multimode ADC master control (if feature available)) */
+#define HAL_ADC_STATE_INJ_EOC           (0x00002000UL)   /*!< Conversion data available on group injected */
+#define HAL_ADC_STATE_INJ_JQOVF         (0x00004000UL)   /*!< Injected queue overflow occurrence */
+
+/* States of ADC analog watchdogs */
+#define HAL_ADC_STATE_AWD1              (0x00010000UL)   /*!< Out-of-window occurrence of ADC analog watchdog 1 */
+#define HAL_ADC_STATE_AWD2              (0x00020000UL)   /*!< Out-of-window occurrence of ADC analog watchdog 2 */
+#define HAL_ADC_STATE_AWD3              (0x00040000UL)   /*!< Out-of-window occurrence of ADC analog watchdog 3 */
+
+/* States of ADC multi-mode */
+#define HAL_ADC_STATE_MULTIMODE_SLAVE   (0x00100000UL)   /*!< ADC in multimode slave state, controlled by another ADC master (when feature available) */
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  ADC handle Structure definition
+  */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+typedef struct __ADC_HandleTypeDef
+#else
+typedef struct
+#endif
+{
+  ADC_TypeDef                   *Instance;              /*!< Register base address */
+  ADC_InitTypeDef               Init;                   /*!< ADC initialization parameters and regular conversions setting */
+  DMA_HandleTypeDef             *DMA_Handle;            /*!< Pointer DMA Handler */
+  HAL_LockTypeDef               Lock;                   /*!< ADC locking object */
+  __IO uint32_t                 State;                  /*!< ADC communication state (bitmap of ADC states) */
+  __IO uint32_t                 ErrorCode;              /*!< ADC Error code */
+  ADC_InjectionConfigTypeDef    InjectionConfig ;       /*!< ADC injected channel configuration build-up structure */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+  void (* ConvCpltCallback)(struct __ADC_HandleTypeDef *hadc);              /*!< ADC conversion complete callback */
+  void (* ConvHalfCpltCallback)(struct __ADC_HandleTypeDef *hadc);          /*!< ADC conversion DMA half-transfer callback */
+  void (* LevelOutOfWindowCallback)(struct __ADC_HandleTypeDef *hadc);      /*!< ADC analog watchdog 1 callback */
+  void (* ErrorCallback)(struct __ADC_HandleTypeDef *hadc);                 /*!< ADC error callback */
+  void (* InjectedConvCpltCallback)(struct __ADC_HandleTypeDef *hadc);      /*!< ADC group injected conversion complete callback */
+  void (* InjectedQueueOverflowCallback)(struct __ADC_HandleTypeDef *hadc); /*!< ADC group injected context queue overflow callback */
+  void (* LevelOutOfWindow2Callback)(struct __ADC_HandleTypeDef *hadc);     /*!< ADC analog watchdog 2 callback */
+  void (* LevelOutOfWindow3Callback)(struct __ADC_HandleTypeDef *hadc);     /*!< ADC analog watchdog 3 callback */
+  void (* EndOfSamplingCallback)(struct __ADC_HandleTypeDef *hadc);         /*!< ADC end of sampling callback */
+  void (* MspInitCallback)(struct __ADC_HandleTypeDef *hadc);               /*!< ADC Msp Init callback */
+  void (* MspDeInitCallback)(struct __ADC_HandleTypeDef *hadc);             /*!< ADC Msp DeInit callback */
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+} ADC_HandleTypeDef;
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+/**
+  * @brief  HAL ADC Callback ID enumeration definition
+  */
+typedef enum
+{
+  HAL_ADC_CONVERSION_COMPLETE_CB_ID     = 0x00U,  /*!< ADC conversion complete callback ID */
+  HAL_ADC_CONVERSION_HALF_CB_ID         = 0x01U,  /*!< ADC conversion DMA half-transfer callback ID */
+  HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID   = 0x02U,  /*!< ADC analog watchdog 1 callback ID */
+  HAL_ADC_ERROR_CB_ID                   = 0x03U,  /*!< ADC error callback ID */
+  HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID = 0x04U,  /*!< ADC group injected conversion complete callback ID */
+  HAL_ADC_INJ_QUEUE_OVEFLOW_CB_ID       = 0x05U,  /*!< ADC group injected context queue overflow callback ID */
+  HAL_ADC_LEVEL_OUT_OF_WINDOW_2_CB_ID   = 0x06U,  /*!< ADC analog watchdog 2 callback ID */
+  HAL_ADC_LEVEL_OUT_OF_WINDOW_3_CB_ID   = 0x07U,  /*!< ADC analog watchdog 3 callback ID */
+  HAL_ADC_END_OF_SAMPLING_CB_ID         = 0x08U,  /*!< ADC end of sampling callback ID */
+  HAL_ADC_MSPINIT_CB_ID                 = 0x09U,  /*!< ADC Msp Init callback ID          */
+  HAL_ADC_MSPDEINIT_CB_ID               = 0x0AU   /*!< ADC Msp DeInit callback ID        */
+} HAL_ADC_CallbackIDTypeDef;
+
+/**
+  * @brief  HAL ADC Callback pointer definition
+  */
+typedef  void (*pADC_CallbackTypeDef)(ADC_HandleTypeDef *hadc); /*!< pointer to a ADC callback function */
+
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Constants ADC Exported Constants
+  * @{
+  */
+
+/** @defgroup ADC_Error_Code ADC Error Code
+  * @{
+  */
+#define HAL_ADC_ERROR_NONE              (0x00U)   /*!< No error                                    */
+#define HAL_ADC_ERROR_INTERNAL          (0x01U)   /*!< ADC peripheral internal error (problem of clocking,
+                                                       enable/disable, erroneous state, ...)       */
+#define HAL_ADC_ERROR_OVR               (0x02U)   /*!< Overrun error                               */
+#define HAL_ADC_ERROR_DMA               (0x04U)   /*!< DMA transfer error                          */
+#define HAL_ADC_ERROR_JQOVF             (0x08U)   /*!< Injected context queue overflow error       */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+#define HAL_ADC_ERROR_INVALID_CALLBACK  (0x10U)   /*!< Invalid Callback error */
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_COMMON_CLOCK_SOURCE  ADC common - Clock source
+  * @{
+  */
+#define ADC_CLOCK_SYNC_PCLK_DIV1           (LL_ADC_CLOCK_SYNC_PCLK_DIV1)  /*!< ADC synchronous clock derived from AHB clock without prescaler */
+#define ADC_CLOCK_SYNC_PCLK_DIV2           (LL_ADC_CLOCK_SYNC_PCLK_DIV2)  /*!< ADC synchronous clock derived from AHB clock with prescaler division by 2 */
+#define ADC_CLOCK_SYNC_PCLK_DIV4           (LL_ADC_CLOCK_SYNC_PCLK_DIV4)  /*!< ADC synchronous clock derived from AHB clock with prescaler division by 4 */
+
+#define ADC_CLOCK_ASYNC_DIV1               (LL_ADC_CLOCK_ASYNC_DIV1)      /*!< ADC asynchronous clock without prescaler */
+#define ADC_CLOCK_ASYNC_DIV2               (LL_ADC_CLOCK_ASYNC_DIV2)      /*!< ADC asynchronous clock with prescaler division by 2   */
+#define ADC_CLOCK_ASYNC_DIV4               (LL_ADC_CLOCK_ASYNC_DIV4)      /*!< ADC asynchronous clock with prescaler division by 4   */
+#define ADC_CLOCK_ASYNC_DIV6               (LL_ADC_CLOCK_ASYNC_DIV6)      /*!< ADC asynchronous clock with prescaler division by 6   */
+#define ADC_CLOCK_ASYNC_DIV8               (LL_ADC_CLOCK_ASYNC_DIV8)      /*!< ADC asynchronous clock with prescaler division by 8   */
+#define ADC_CLOCK_ASYNC_DIV10              (LL_ADC_CLOCK_ASYNC_DIV10)     /*!< ADC asynchronous clock with prescaler division by 10  */
+#define ADC_CLOCK_ASYNC_DIV12              (LL_ADC_CLOCK_ASYNC_DIV12)     /*!< ADC asynchronous clock with prescaler division by 12  */
+#define ADC_CLOCK_ASYNC_DIV16              (LL_ADC_CLOCK_ASYNC_DIV16)     /*!< ADC asynchronous clock with prescaler division by 16  */
+#define ADC_CLOCK_ASYNC_DIV32              (LL_ADC_CLOCK_ASYNC_DIV32)     /*!< ADC asynchronous clock with prescaler division by 32  */
+#define ADC_CLOCK_ASYNC_DIV64              (LL_ADC_CLOCK_ASYNC_DIV64)     /*!< ADC asynchronous clock with prescaler division by 64  */
+#define ADC_CLOCK_ASYNC_DIV128             (LL_ADC_CLOCK_ASYNC_DIV128)    /*!< ADC asynchronous clock with prescaler division by 128 */
+#define ADC_CLOCK_ASYNC_DIV256             (LL_ADC_CLOCK_ASYNC_DIV256)    /*!< ADC asynchronous clock with prescaler division by 256 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_RESOLUTION  ADC instance - Resolution
+  * @{
+  */
+#define ADC_RESOLUTION_16B                 (LL_ADC_RESOLUTION_16B)  /*!< ADC resolution 16 bits, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+#define ADC_RESOLUTION_14B                 (LL_ADC_RESOLUTION_14B)  /*!< ADC resolution 14 bits, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2  */
+#define ADC_RESOLUTION_12B                 (LL_ADC_RESOLUTION_12B)  /*!< ADC resolution 12 bits */
+#define ADC_RESOLUTION_10B                 (LL_ADC_RESOLUTION_10B)  /*!< ADC resolution 10 bits */
+#define ADC_RESOLUTION_8B                  (LL_ADC_RESOLUTION_8B)   /*!< ADC resolution  8 bits */
+
+#if defined (ADC_VER_V5_X)
+#define ADC_RESOLUTION_14B_OPT             (LL_ADC_RESOLUTION_14B_OPT) /*!< ADC resolution 14 bits optimized for power consumption, available on for devices revision V only */
+#define ADC_RESOLUTION_12B_OPT             (LL_ADC_RESOLUTION_12B_OPT) /*!< ADC resolution 12 bits optimized for power consumption, available on for devices revision V only */
+#endif
+
+#if defined(ADC_VER_V5_V90)
+#define ADC_RESOLUTION_6B                  (LL_ADC_RESOLUTION_6B)   /*!< ADC resolution  6 bits, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3  */
+#endif  /* ADC_VER_V5_V90 */
+/**
+  * @}
+  */
+
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_HAL_EC_DATA_ALIGN ADC conversion data alignment
+  * @{
+  */
+#define ADC3_DATAALIGN_RIGHT                (LL_ADC_DATA_ALIGN_RIGHT)      /*!< ADC conversion data alignment: right aligned (alignment on data register LSB bit 0)*/
+#define ADC3_DATAALIGN_LEFT                 (LL_ADC_DATA_ALIGN_LEFT)       /*!< ADC conversion data alignment: left aligned (alignment on data register MSB bit 15)*/
+/**
+  * @}
+  */
+#endif
+
+/** @defgroup ADC_Scan_mode ADC sequencer scan mode
+  * @{
+  */
+#define ADC_SCAN_DISABLE         (0x00000000UL)       /*!< Scan mode disabled */
+#define ADC_SCAN_ENABLE          (0x00000001UL)       /*!< Scan mode enabled  */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_regular_external_trigger_source ADC group regular trigger source
+  * @{
+  */
+/* ADC group regular trigger sources for all ADC instances */
+#define ADC_SOFTWARE_START            (LL_ADC_REG_TRIG_SOFTWARE)                 /*!< ADC group regular conversion trigger internal: SW start. */
+#define ADC_EXTERNALTRIG_T1_CC1       (LL_ADC_REG_TRIG_EXT_TIM1_CH1)             /*!< ADC group regular conversion trigger from external peripheral: TIM1 channel 1 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T1_CC2       (LL_ADC_REG_TRIG_EXT_TIM1_CH2)             /*!< ADC group regular conversion trigger from external peripheral: TIM1 channel 2 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T1_CC3       (LL_ADC_REG_TRIG_EXT_TIM1_CH3)             /*!< ADC group regular conversion trigger from external peripheral: TIM1 channel 3 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T2_CC2       (LL_ADC_REG_TRIG_EXT_TIM2_CH2)             /*!< ADC group regular conversion trigger from external peripheral: TIM2 channel 2 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T3_TRGO      (LL_ADC_REG_TRIG_EXT_TIM3_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM3 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T4_CC4       (LL_ADC_REG_TRIG_EXT_TIM4_CH4)             /*!< ADC group regular conversion trigger from external peripheral: TIM4 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_EXT_IT11     (LL_ADC_REG_TRIG_EXT_EXTI_LINE11)          /*!< ADC group regular conversion trigger from external peripheral: external interrupt line 11 event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T8_TRGO      (LL_ADC_REG_TRIG_EXT_TIM8_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM8 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T8_TRGO2     (LL_ADC_REG_TRIG_EXT_TIM8_TRGO2)           /*!< ADC group regular conversion trigger from external peripheral: TIM8 TRGO2 event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T1_TRGO      (LL_ADC_REG_TRIG_EXT_TIM1_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM1 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T1_TRGO2     (LL_ADC_REG_TRIG_EXT_TIM1_TRGO2)           /*!< ADC group regular conversion trigger from external peripheral: TIM1 TRGO2 event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T2_TRGO      (LL_ADC_REG_TRIG_EXT_TIM2_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM2 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T4_TRGO      (LL_ADC_REG_TRIG_EXT_TIM4_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM4 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T6_TRGO      (LL_ADC_REG_TRIG_EXT_TIM6_TRGO)            /*!< ADC group regular conversion trigger from external peripheral: TIM6 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T15_TRGO     (LL_ADC_REG_TRIG_EXT_TIM15_TRGO)           /*!< ADC group regular conversion trigger from external peripheral: TIM15 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_T3_CC4       (LL_ADC_REG_TRIG_EXT_TIM3_CH4)             /*!< ADC group regular conversion trigger from external peripheral: TIM3 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_HR1_ADCTRG1  (LL_ADC_REG_TRIG_EXT_HRTIM_TRG1)           /*!< ADC group regular conversion trigger from external peripheral: HRTIM TRG1 event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_HR1_ADCTRG3  (LL_ADC_REG_TRIG_EXT_HRTIM_TRG3)           /*!< ADC group regular conversion trigger from external peripheral: HRTIM TRG3 event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_LPTIM1_OUT   (LL_ADC_REG_TRIG_EXT_LPTIM1_OUT)           /*!< ADC group regular conversion trigger from external peripheral: LPTIM1 OUT event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_LPTIM2_OUT   (LL_ADC_REG_TRIG_EXT_LPTIM2_OUT)           /*!< ADC group regular conversion trigger from external peripheral: LPTIM2 OUT event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIG_LPTIM3_OUT   (LL_ADC_REG_TRIG_EXT_LPTIM3_OUT)           /*!< ADC group regular conversion trigger from external peripheral: LPTIM3 event OUT. Trigger edge set to rising edge (default setting). */
+#if defined(TIM23)
+#define ADC_EXTERNALTRIG_T23_TRGO     (LL_ADC_REG_TRIG_EXT_TIM23_TRGO)           /*!< ADC group regular conversion trigger from external peripheral: TIM23 TRGO event. Trigger edge set to rising edge (default setting). */
+#endif /*TIM23*/
+#if defined(TIM24)
+#define ADC_EXTERNALTRIG_T24_TRGO     (LL_ADC_REG_TRIG_EXT_TIM24_TRGO)           /*!< ADC group regular conversion trigger from external peripheral: TIM24 TRGO event. Trigger edge set to rising edge (default setting). */
+#endif /*TIM24*/
+/**
+  * @}
+  */
+
+/** @defgroup ADC_regular_external_trigger_edge ADC group regular trigger edge (when external trigger is selected)
+  * @{
+  */
+#define ADC_EXTERNALTRIGCONVEDGE_NONE           (0x00000000UL)                      /*!< Regular conversions hardware trigger detection disabled */
+#define ADC_EXTERNALTRIGCONVEDGE_RISING         (LL_ADC_REG_TRIG_EXT_RISING)        /*!< ADC group regular conversion trigger polarity set to rising edge */
+#define ADC_EXTERNALTRIGCONVEDGE_FALLING        (LL_ADC_REG_TRIG_EXT_FALLING)       /*!< ADC group regular conversion trigger polarity set to falling edge */
+#define ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING  (LL_ADC_REG_TRIG_EXT_RISINGFALLING) /*!< ADC group regular conversion trigger polarity set to both rising and falling edges */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_regular_sampling_mode ADC group regular sampling mode
+  * @{
+  */
+#define ADC_SAMPLING_MODE_NORMAL                (0x00000000UL)      /*!< ADC conversions sampling phase duration is defined using  @ref ADC_HAL_EC_CHANNEL_SAMPLINGTIME */
+#define ADC_SAMPLING_MODE_BULB                  (ADC3_CFGR2_BULB)    /*!< ADC conversions sampling phase starts immediately after end of conversion, and stops upon trigger event.
+                                                                                Notes: 
+                                                                                      - First conversion is using minimal sampling time (see @ref ADC_HAL_EC_CHANNEL_SAMPLINGTIME) 
+                                                                                      - Applicable for ADC3 on devices STM32H72xx and STM32H73xx  */
+#define ADC_SAMPLING_MODE_TRIGGER_CONTROLED     (ADC3_CFGR2_SMPTRIG) /*!< ADC conversions sampling phase is controlled by trigger events:
+                                                                                 Trigger rising edge  = start sampling
+                                                                                 Trigger falling edge = stop sampling and start conversion 
+                                                                                 Note: Applicable for ADC3 on devices STM32H72xx and STM32H73xx  */
+/**
+  * @}
+  */
+#endif
+
+/** @defgroup ADC_EOCSelection ADC sequencer end of unitary conversion or sequence conversions
+  * @{
+  */
+#define ADC_EOC_SINGLE_CONV         (ADC_ISR_EOC)                 /*!< End of unitary conversion flag  */
+#define ADC_EOC_SEQ_CONV            (ADC_ISR_EOS)                 /*!< End of sequence conversions flag    */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_REG_OVR_DATA_BEHAVIOR  ADC group regular - Overrun behavior on conversion data
+  * @{
+  */
+#define ADC_OVR_DATA_PRESERVED             (LL_ADC_REG_OVR_DATA_PRESERVED)    /*!< ADC group regular behavior in case of overrun: data preserved */
+#define ADC_OVR_DATA_OVERWRITTEN           (LL_ADC_REG_OVR_DATA_OVERWRITTEN)  /*!< ADC group regular behavior in case of overrun: data overwritten */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_REG_SEQ_RANKS  ADC group regular - Sequencer ranks
+  * @{
+  */
+#define ADC_REGULAR_RANK_1                 (LL_ADC_REG_RANK_1)  /*!< ADC group regular sequencer rank 1 */
+#define ADC_REGULAR_RANK_2                 (LL_ADC_REG_RANK_2)  /*!< ADC group regular sequencer rank 2 */
+#define ADC_REGULAR_RANK_3                 (LL_ADC_REG_RANK_3)  /*!< ADC group regular sequencer rank 3 */
+#define ADC_REGULAR_RANK_4                 (LL_ADC_REG_RANK_4)  /*!< ADC group regular sequencer rank 4 */
+#define ADC_REGULAR_RANK_5                 (LL_ADC_REG_RANK_5)  /*!< ADC group regular sequencer rank 5 */
+#define ADC_REGULAR_RANK_6                 (LL_ADC_REG_RANK_6)  /*!< ADC group regular sequencer rank 6 */
+#define ADC_REGULAR_RANK_7                 (LL_ADC_REG_RANK_7)  /*!< ADC group regular sequencer rank 7 */
+#define ADC_REGULAR_RANK_8                 (LL_ADC_REG_RANK_8)  /*!< ADC group regular sequencer rank 8 */
+#define ADC_REGULAR_RANK_9                 (LL_ADC_REG_RANK_9)  /*!< ADC group regular sequencer rank 9 */
+#define ADC_REGULAR_RANK_10                (LL_ADC_REG_RANK_10) /*!< ADC group regular sequencer rank 10 */
+#define ADC_REGULAR_RANK_11                (LL_ADC_REG_RANK_11) /*!< ADC group regular sequencer rank 11 */
+#define ADC_REGULAR_RANK_12                (LL_ADC_REG_RANK_12) /*!< ADC group regular sequencer rank 12 */
+#define ADC_REGULAR_RANK_13                (LL_ADC_REG_RANK_13) /*!< ADC group regular sequencer rank 13 */
+#define ADC_REGULAR_RANK_14                (LL_ADC_REG_RANK_14) /*!< ADC group regular sequencer rank 14 */
+#define ADC_REGULAR_RANK_15                (LL_ADC_REG_RANK_15) /*!< ADC group regular sequencer rank 15 */
+#define ADC_REGULAR_RANK_16                (LL_ADC_REG_RANK_16) /*!< ADC group regular sequencer rank 16 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_CHANNEL_SAMPLINGTIME  Channel - Sampling time
+  * @{
+  */
+#define ADC_SAMPLETIME_1CYCLE_5          (LL_ADC_SAMPLINGTIME_1CYCLE_5)     /*!< Sampling time 1.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+#define ADC_SAMPLETIME_2CYCLES_5         (LL_ADC_SAMPLINGTIME_2CYCLES_5)    /*!< Sampling time 2.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+#define ADC_SAMPLETIME_8CYCLES_5         (LL_ADC_SAMPLINGTIME_8CYCLES_5)    /*!< Sampling time 8.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+#define ADC_SAMPLETIME_16CYCLES_5        (LL_ADC_SAMPLINGTIME_16CYCLES_5)   /*!< Sampling time 16.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+#define ADC_SAMPLETIME_32CYCLES_5        (LL_ADC_SAMPLINGTIME_32CYCLES_5)   /*!< Sampling time 32.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+#define ADC_SAMPLETIME_64CYCLES_5        (LL_ADC_SAMPLINGTIME_64CYCLES_5)   /*!< Sampling time 64.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+#define ADC_SAMPLETIME_387CYCLES_5       (LL_ADC_SAMPLINGTIME_387CYCLES_5)  /*!< Sampling time 387.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+#define ADC_SAMPLETIME_810CYCLES_5       (LL_ADC_SAMPLINGTIME_810CYCLES_5)  /*!< Sampling time 810.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC1, ADC2 */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_HAL_EC_CHANNEL_SAMPLINGTIME  Channel - Sampling time
+  * @{
+  */
+#define ADC3_SAMPLETIME_2CYCLES_5         (LL_ADC_SAMPLINGTIME_ADC3_2CYCLES_5)    /*!< Sampling time 2.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+#define ADC3_SAMPLETIME_6CYCLES_5         (LL_ADC_SAMPLINGTIME_ADC3_6CYCLES_5)    /*!< Sampling time 6.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+#define ADC3_SAMPLETIME_12CYCLES_5        (LL_ADC_SAMPLINGTIME_ADC3_12CYCLES_5)   /*!< Sampling time 12.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+#define ADC3_SAMPLETIME_24CYCLES_5        (LL_ADC_SAMPLINGTIME_ADC3_24CYCLES_5)   /*!< Sampling time 24.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+#define ADC3_SAMPLETIME_47CYCLES_5        (LL_ADC_SAMPLINGTIME_ADC3_47CYCLES_5)   /*!< Sampling time 47.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+#define ADC3_SAMPLETIME_92CYCLES_5        (LL_ADC_SAMPLINGTIME_ADC3_92CYCLES_5)   /*!< Sampling time 92.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+#define ADC3_SAMPLETIME_247CYCLES_5       (LL_ADC_SAMPLINGTIME_ADC3_247CYCLES_5)  /*!< Sampling time 247.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+#define ADC3_SAMPLETIME_640CYCLES_5       (LL_ADC_SAMPLINGTIME_ADC3_640CYCLES_5)  /*!< Sampling time 640.5 ADC clock cycles, On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+#define ADC3_SAMPLETIME_3CYCLES_5         (ADC_SMPR1_SMPPLUS | LL_ADC_SAMPLINGTIME_ADC3_2CYCLES_5) /*!< Sampling time 3.5 ADC clock cycles. If selected, this sampling time replaces all sampling time 2.5 ADC clock cycles. These 2 sampling times cannot be used simultaneously. 
+                                                                                                        On devices STM32H72xx and STM32H73xx, parameter available only on ADC instance: ADC3 */
+/**
+  * @}
+  */
+#endif
+
+/** @defgroup ADCEx_Calibration_Mode   ADC Extended Calibration mode offset mode or linear mode
+  * @{
+  */
+#define ADC_CALIB_OFFSET                   (LL_ADC_CALIB_OFFSET)
+#define ADC_CALIB_OFFSET_LINEARITY         (LL_ADC_CALIB_OFFSET_LINEARITY)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_CHANNEL  ADC instance - Channel number
+  * @{
+  */
+/* Note: VrefInt, TempSensor and Vbat internal channels are not available on  */
+/*        all ADC instances (refer to Reference Manual).                      */
+#define ADC_CHANNEL_0                      (LL_ADC_CHANNEL_0)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN0  */
+#define ADC_CHANNEL_1                      (LL_ADC_CHANNEL_1)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN1  */
+#define ADC_CHANNEL_2                      (LL_ADC_CHANNEL_2)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN2  */
+#define ADC_CHANNEL_3                      (LL_ADC_CHANNEL_3)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN3  */
+#define ADC_CHANNEL_4                      (LL_ADC_CHANNEL_4)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN4  */
+#define ADC_CHANNEL_5                      (LL_ADC_CHANNEL_5)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN5  */
+#define ADC_CHANNEL_6                      (LL_ADC_CHANNEL_6)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN6  */
+#define ADC_CHANNEL_7                      (LL_ADC_CHANNEL_7)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN7  */
+#define ADC_CHANNEL_8                      (LL_ADC_CHANNEL_8)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN8  */
+#define ADC_CHANNEL_9                      (LL_ADC_CHANNEL_9)               /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN9  */
+#define ADC_CHANNEL_10                     (LL_ADC_CHANNEL_10)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN10 */
+#define ADC_CHANNEL_11                     (LL_ADC_CHANNEL_11)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN11 */
+#define ADC_CHANNEL_12                     (LL_ADC_CHANNEL_12)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN12 */
+#define ADC_CHANNEL_13                     (LL_ADC_CHANNEL_13)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN13 */
+#define ADC_CHANNEL_14                     (LL_ADC_CHANNEL_14)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN14 */
+#define ADC_CHANNEL_15                     (LL_ADC_CHANNEL_15)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN15 */
+#define ADC_CHANNEL_16                     (LL_ADC_CHANNEL_16)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN16 */
+#define ADC_CHANNEL_17                     (LL_ADC_CHANNEL_17)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN17 */
+#define ADC_CHANNEL_18                     (LL_ADC_CHANNEL_18)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN18 */
+#define ADC_CHANNEL_19                     (LL_ADC_CHANNEL_19)              /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN19 */
+#define ADC_CHANNEL_VREFINT                (LL_ADC_CHANNEL_VREFINT)         /*!< ADC internal channel connected to VrefInt: Internal voltage reference, channel specific to ADC3. */
+#define ADC_CHANNEL_TEMPSENSOR             (LL_ADC_CHANNEL_TEMPSENSOR)      /*!< ADC internal channel connected to Temperature sensor, channel specific to ADC3. */
+#define ADC_CHANNEL_VBAT                   (LL_ADC_CHANNEL_VBAT)            /*!< ADC internal channel connected to Vbat/4: Vbat voltage through a divider ladder of factor 1/4 to have Vbat always below Vdda, channel specific to ADC3. */
+#define ADC_CHANNEL_DAC1CH1_ADC2           (LL_ADC_CHANNEL_DAC1CH1_ADC2)    /*!< ADC internal channel connected to DAC1 channel 1, channel specific to ADC2 */
+#define ADC_CHANNEL_DAC1CH2_ADC2           (LL_ADC_CHANNEL_DAC1CH2_ADC2)    /*!< ADC internal channel connected to DAC1 channel 2, channel specific to ADC2 */
+#if defined (LL_ADC_CHANNEL_DAC2CH1_ADC2)
+#define ADC_CHANNEL_DAC2CH1_ADC2           (LL_ADC_CHANNEL_DAC2CH1_ADC2)    /*!< ADC internal channel connected to DAC2 channel 1, channel specific to ADC2 */
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup ADC_ConversionDataManagement ADC Conversion Data Management
+  * @{
+  */
+#define ADC_CONVERSIONDATA_DR                  ((uint32_t)0x00000000)                            /*!< Regular Conversion data stored in DR register only  */
+#define ADC_CONVERSIONDATA_DFSDM               ((uint32_t)ADC_CFGR_DMNGT_1)                      /*!< DFSDM mode selected */
+#define ADC_CONVERSIONDATA_DMA_ONESHOT         ((uint32_t)ADC_CFGR_DMNGT_0)                      /*!< DMA one shot mode selected */
+#define ADC_CONVERSIONDATA_DMA_CIRCULAR        ((uint32_t)(ADC_CFGR_DMNGT_0 | ADC_CFGR_DMNGT_1)) /*!< DMA circular mode selected */
+/**
+  * @}
+  */
+/** @defgroup ADC_HAL_EC_AWD_NUMBER Analog watchdog - Analog watchdog number
+  * @{
+  */
+#define ADC_ANALOGWATCHDOG_1               (LL_ADC_AWD1) /*!< ADC analog watchdog number 1 */
+#define ADC_ANALOGWATCHDOG_2               (LL_ADC_AWD2) /*!< ADC analog watchdog number 2 */
+#define ADC_ANALOGWATCHDOG_3               (LL_ADC_AWD3) /*!< ADC analog watchdog number 3 */
+/**
+  * @}
+  */
+
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_analog_watchdog_filtering_config ADC Analog Watchdog filtering configuration
+  * @{
+  */
+#define ADC3_AWD_FILTERING_NONE          (0x00000000UL)                                                   /*!< ADC analog watchdog no filtering, one out-of-window sample is needed to raise flag or interrupt. Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_AWD_FILTERING_2SAMPLES      ((ADC3_TR1_AWDFILT_0))                                           /*!< ADC analog watchdog 2 consecutives out-of-window samples are needed to raise flag or interrupt. Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_AWD_FILTERING_3SAMPLES      ((ADC3_TR1_AWDFILT_1))                                           /*!< ADC analog watchdog 3 consecutives out-of-window samples are needed to raise flag or interrupt. Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_AWD_FILTERING_4SAMPLES      ((ADC3_TR1_AWDFILT_1 | ADC3_TR1_AWDFILT_0))                      /*!< ADC analog watchdog 4 consecutives out-of-window samples are needed to raise flag or interrupt. Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_AWD_FILTERING_5SAMPLES      ((ADC3_TR1_AWDFILT_2))                                           /*!< ADC analog watchdog 5 consecutives out-of-window samples are needed to raise flag or interrupt. Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_AWD_FILTERING_6SAMPLES      ((ADC3_TR1_AWDFILT_2 | ADC3_TR1_AWDFILT_0))                      /*!< ADC analog watchdog 6 consecutives out-of-window samples are needed to raise flag or interrupt. Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_AWD_FILTERING_7SAMPLES      ((ADC3_TR1_AWDFILT_2 | ADC3_TR1_AWDFILT_1))                      /*!< ADC analog watchdog 7 consecutives out-of-window samples are needed to raise flag or interrupt. Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_AWD_FILTERING_8SAMPLES      ((ADC3_TR1_AWDFILT_2 | ADC3_TR1_AWDFILT_1 | ADC3_TR1_AWDFILT_0)) /*!< ADC analog watchdog 8 consecutives out-of-window samples are needed to raise flag or interrupt. Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+/**
+  * @}
+  */
+#endif
+
+/** @defgroup ADC_analog_watchdog_mode ADC Analog Watchdog Mode
+  * @{
+  */
+#define ADC_ANALOGWATCHDOG_NONE                 (0x00000000UL)                                          /*!< No analog watchdog selected                                             */
+#define ADC_ANALOGWATCHDOG_SINGLE_REG           (ADC_CFGR_AWD1SGL | ADC_CFGR_AWD1EN)                    /*!< Analog watchdog applied to a regular group single channel               */
+#define ADC_ANALOGWATCHDOG_SINGLE_INJEC         (ADC_CFGR_AWD1SGL | ADC_CFGR_JAWD1EN)                   /*!< Analog watchdog applied to an injected group single channel             */
+#define ADC_ANALOGWATCHDOG_SINGLE_REGINJEC      (ADC_CFGR_AWD1SGL | ADC_CFGR_AWD1EN | ADC_CFGR_JAWD1EN) /*!< Analog watchdog applied to a regular and injected groups single channel */
+#define ADC_ANALOGWATCHDOG_ALL_REG              (ADC_CFGR_AWD1EN)                                       /*!< Analog watchdog applied to regular group all channels                   */
+#define ADC_ANALOGWATCHDOG_ALL_INJEC            (ADC_CFGR_JAWD1EN)                                      /*!< Analog watchdog applied to injected group all channels                  */
+#define ADC_ANALOGWATCHDOG_ALL_REGINJEC         (ADC_CFGR_AWD1EN | ADC_CFGR_JAWD1EN)                    /*!< Analog watchdog applied to regular and injected groups all channels     */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_HAL_EC_OVS_RATIO  Oversampling - Ratio
+  * @{
+  */
+#define ADC3_OVERSAMPLING_RATIO_2           (LL_ADC_OVS_RATIO_2)    /*!< ADC oversampling ratio of 2 (2 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_4           (LL_ADC_OVS_RATIO_4)    /*!< ADC oversampling ratio of 4 (4 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_8           (LL_ADC_OVS_RATIO_8)    /*!< ADC oversampling ratio of 8 (8 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_16          (LL_ADC_OVS_RATIO_16)   /*!< ADC oversampling ratio of 16 (16 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_32          (LL_ADC_OVS_RATIO_32)   /*!< ADC oversampling ratio of 32 (32 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_64          (LL_ADC_OVS_RATIO_64)   /*!< ADC oversampling ratio of 64 (64 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_128         (LL_ADC_OVS_RATIO_128)  /*!< ADC oversampling ratio of 128 (128 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_256         (LL_ADC_OVS_RATIO_256)  /*!< ADC oversampling ratio of 256 (256 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_512         (LL_ADC_OVS_RATIO_512)  /*!< ADC oversampling ratio of 256 (256 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+#define ADC3_OVERSAMPLING_RATIO_1024        (LL_ADC_OVS_RATIO_1024) /*!< ADC oversampling ratio of 256 (256 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift). Applicable for ADC3 on devices STM32H72xx and STM32H73xx */
+/**
+  * @}
+  */
+#endif
+
+/** @defgroup ADC_HAL_EC_OVS_SHIFT  Oversampling - Data shift
+  * @{
+  */
+#define ADC_RIGHTBITSHIFT_NONE             (LL_ADC_OVS_SHIFT_NONE)    /*!< ADC oversampling no shift (sum of the ADC conversions data is not divided to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_1                (LL_ADC_OVS_SHIFT_RIGHT_1) /*!< ADC oversampling shift of 1 (sum of the ADC conversions data is divided by 2 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_2                (LL_ADC_OVS_SHIFT_RIGHT_2) /*!< ADC oversampling shift of 2 (sum of the ADC conversions data is divided by 4 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_3                (LL_ADC_OVS_SHIFT_RIGHT_3) /*!< ADC oversampling shift of 3 (sum of the ADC conversions data is divided by 8 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_4                (LL_ADC_OVS_SHIFT_RIGHT_4) /*!< ADC oversampling shift of 4 (sum of the ADC conversions data is divided by 16 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_5                (LL_ADC_OVS_SHIFT_RIGHT_5) /*!< ADC oversampling shift of 5 (sum of the ADC conversions data is divided by 32 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_6                (LL_ADC_OVS_SHIFT_RIGHT_6) /*!< ADC oversampling shift of 6 (sum of the ADC conversions data is divided by 64 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_7                (LL_ADC_OVS_SHIFT_RIGHT_7) /*!< ADC oversampling shift of 7 (sum of the ADC conversions data is divided by 128 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_8                (LL_ADC_OVS_SHIFT_RIGHT_8) /*!< ADC oversampling shift of 8 (sum of the ADC conversions data is divided by 256 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_9                (LL_ADC_OVS_SHIFT_RIGHT_9) /*!< ADC oversampling shift of 9 (sum of the ADC conversions data is divided by 512 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_10               (LL_ADC_OVS_SHIFT_RIGHT_10)/*!< ADC oversampling shift of 10 (sum of the ADC conversions data is divided by 1024 to result as the ADC oversampling conversion data) */
+#define ADC_RIGHTBITSHIFT_11               (LL_ADC_OVS_SHIFT_RIGHT_11)/*!< ADC oversampling shift of 11 (sum of the ADC conversions data is divided by 2048 to result as the ADC oversampling conversion data) */
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Left_Bit_Shift   ADC Extended Oversampling left Shift
+  * @{
+  */
+#define ADC_LEFTBITSHIFT_NONE  (LL_ADC_LEFT_BIT_SHIFT_NONE)   /*!<  ADC No bit shift */
+#define ADC_LEFTBITSHIFT_1     (LL_ADC_LEFT_BIT_SHIFT_1)      /*!<  ADC 1 bit shift  */
+#define ADC_LEFTBITSHIFT_2     (LL_ADC_LEFT_BIT_SHIFT_2)      /*!<  ADC 2 bits shift */
+#define ADC_LEFTBITSHIFT_3     (LL_ADC_LEFT_BIT_SHIFT_3)      /*!<  ADC 3 bits shift */
+#define ADC_LEFTBITSHIFT_4     (LL_ADC_LEFT_BIT_SHIFT_4)      /*!<  ADC 4 bits shift */
+#define ADC_LEFTBITSHIFT_5     (LL_ADC_LEFT_BIT_SHIFT_5)      /*!<  ADC 5 bits shift */
+#define ADC_LEFTBITSHIFT_6     (LL_ADC_LEFT_BIT_SHIFT_6)      /*!<  ADC 6 bits shift */
+#define ADC_LEFTBITSHIFT_7     (LL_ADC_LEFT_BIT_SHIFT_7)      /*!<  ADC 7 bits shift */
+#define ADC_LEFTBITSHIFT_8     (LL_ADC_LEFT_BIT_SHIFT_8)      /*!<  ADC 8 bits shift */
+#define ADC_LEFTBITSHIFT_9     (LL_ADC_LEFT_BIT_SHIFT_9)      /*!<  ADC 9 bits shift */
+#define ADC_LEFTBITSHIFT_10    (LL_ADC_LEFT_BIT_SHIFT_10)     /*!<  ADC 10 bits shift */
+#define ADC_LEFTBITSHIFT_11    (LL_ADC_LEFT_BIT_SHIFT_11)     /*!<  ADC 11 bits shift */
+#define ADC_LEFTBITSHIFT_12    (LL_ADC_LEFT_BIT_SHIFT_12)     /*!<  ADC 12 bits shift */
+#define ADC_LEFTBITSHIFT_13    (LL_ADC_LEFT_BIT_SHIFT_13)     /*!<  ADC 13 bits shift */
+#define ADC_LEFTBITSHIFT_14    (LL_ADC_LEFT_BIT_SHIFT_14)     /*!<  ADC 14 bits shift */
+#define ADC_LEFTBITSHIFT_15    (LL_ADC_LEFT_BIT_SHIFT_15)     /*!<  ADC 15 bits shift */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_OVS_DISCONT_MODE  Oversampling - Discontinuous mode
+  * @{
+  */
+#define ADC_TRIGGEREDMODE_SINGLE_TRIGGER   (LL_ADC_OVS_REG_CONT)          /*!< ADC oversampling discontinuous mode: continuous mode (all conversions of oversampling ratio are done from 1 trigger) */
+#define ADC_TRIGGEREDMODE_MULTI_TRIGGER    (LL_ADC_OVS_REG_DISCONT)       /*!< ADC oversampling discontinuous mode: discontinuous mode (each conversion of oversampling ratio needs a trigger) */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_OVS_SCOPE_REG  Oversampling - Oversampling scope for ADC group regular
+  * @{
+  */
+#define ADC_REGOVERSAMPLING_CONTINUED_MODE    (LL_ADC_OVS_GRP_REGULAR_CONTINUED) /*!< Oversampling buffer maintained during injection sequence */
+#define ADC_REGOVERSAMPLING_RESUMED_MODE      (LL_ADC_OVS_GRP_REGULAR_RESUMED)   /*!< Oversampling buffer zeroed during injection sequence     */
+/**
+  * @}
+  */
+
+
+/** @defgroup ADC_Event_type ADC Event type
+  * @{
+  */
+#define ADC_EOSMP_EVENT          (ADC_FLAG_EOSMP) /*!< ADC End of Sampling event */
+#define ADC_AWD1_EVENT           (ADC_FLAG_AWD1)  /*!< ADC Analog watchdog 1 event (main analog watchdog, present on all STM32 series) */
+#define ADC_AWD2_EVENT           (ADC_FLAG_AWD2)  /*!< ADC Analog watchdog 2 event (additional analog watchdog, not present on all STM32 series) */
+#define ADC_AWD3_EVENT           (ADC_FLAG_AWD3)  /*!< ADC Analog watchdog 3 event (additional analog watchdog, not present on all STM32 series) */
+#define ADC_OVR_EVENT            (ADC_FLAG_OVR)   /*!< ADC overrun event */
+#define ADC_JQOVF_EVENT          (ADC_FLAG_JQOVF) /*!< ADC Injected Context Queue Overflow event */
+/**
+  * @}
+  */
+#define ADC_AWD_EVENT            ADC_AWD1_EVENT      /*!< ADC Analog watchdog 1 event: Naming for compatibility with other STM32 devices having only one analog watchdog */
+
+/** @defgroup ADC_interrupts_definition ADC interrupts definition
+  * @{
+  */
+#define ADC_IT_RDY           ADC_IER_ADRDYIE    /*!< ADC Ready interrupt source */
+#define ADC_IT_EOSMP         ADC_IER_EOSMPIE    /*!< ADC End of sampling interrupt source */
+#define ADC_IT_EOC           ADC_IER_EOCIE      /*!< ADC End of regular conversion interrupt source */
+#define ADC_IT_EOS           ADC_IER_EOSIE      /*!< ADC End of regular sequence of conversions interrupt source */
+#define ADC_IT_OVR           ADC_IER_OVRIE      /*!< ADC overrun interrupt source */
+#define ADC_IT_JEOC          ADC_IER_JEOCIE     /*!< ADC End of injected conversion interrupt source */
+#define ADC_IT_JEOS          ADC_IER_JEOSIE     /*!< ADC End of injected sequence of conversions interrupt source */
+#define ADC_IT_AWD1          ADC_IER_AWD1IE     /*!< ADC Analog watchdog 1 interrupt source (main analog watchdog) */
+#define ADC_IT_AWD2          ADC_IER_AWD2IE     /*!< ADC Analog watchdog 2 interrupt source (additional analog watchdog) */
+#define ADC_IT_AWD3          ADC_IER_AWD3IE     /*!< ADC Analog watchdog 3 interrupt source (additional analog watchdog) */
+#define ADC_IT_JQOVF         ADC_IER_JQOVFIE    /*!< ADC Injected Context Queue Overflow interrupt source */
+
+#define ADC_IT_AWD           ADC_IT_AWD1        /*!< ADC Analog watchdog 1 interrupt source: naming for compatibility with other STM32 devices having only one analog watchdog */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_flags_definition ADC flags definition
+  * @{
+  */
+#define ADC_FLAG_RDY           ADC_ISR_ADRDY    /*!< ADC Ready flag */
+#define ADC_FLAG_EOSMP         ADC_ISR_EOSMP    /*!< ADC End of Sampling flag */
+#define ADC_FLAG_EOC           ADC_ISR_EOC      /*!< ADC End of Regular Conversion flag */
+#define ADC_FLAG_EOS           ADC_ISR_EOS      /*!< ADC End of Regular sequence of Conversions flag */
+#define ADC_FLAG_OVR           ADC_ISR_OVR      /*!< ADC overrun flag */
+#define ADC_FLAG_JEOC          ADC_ISR_JEOC     /*!< ADC End of Injected Conversion flag */
+#define ADC_FLAG_JEOS          ADC_ISR_JEOS     /*!< ADC End of Injected sequence of Conversions flag */
+#define ADC_FLAG_AWD1          ADC_ISR_AWD1     /*!< ADC Analog watchdog 1 flag (main analog watchdog) */
+#define ADC_FLAG_AWD2          ADC_ISR_AWD2     /*!< ADC Analog watchdog 2 flag (additional analog watchdog) */
+#define ADC_FLAG_AWD3          ADC_ISR_AWD3     /*!< ADC Analog watchdog 3 flag (additional analog watchdog) */
+#define ADC_FLAG_JQOVF         ADC_ISR_JQOVF    /*!< ADC Injected Context Queue Overflow flag */
+#define ADC_FLAG_LDORDY        ADC_ISR_LDORDY   /*!< ADC LDO output voltage ready bit */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+
+/** @defgroup ADC_Private_Macros ADC Private Macros
+  * @{
+  */
+/* Macro reserved for internal HAL driver usage, not intended to be used in   */
+/* code of final user.                                                        */
+
+/**
+  * @brief Verify the ADC data conversion setting.
+  * @param DATA : programmed DATA conversion mode.
+  * @retval SET (DATA is a valid value) or RESET (DATA is invalid)
+  */
+#define IS_ADC_CONVERSIONDATAMGT(DATA)                                         \
+   ((((DATA) == ADC_CONVERSIONDATA_DR))          || \
+    (((DATA) == ADC_CONVERSIONDATA_DFSDM))       || \
+    (((DATA) == ADC_CONVERSIONDATA_DMA_ONESHOT)) || \
+    (((DATA) == ADC_CONVERSIONDATA_DMA_CIRCULAR)))
+
+/**
+  * @brief Return resolution bits in CFGR register RES[1:0] field.
+  * @param __HANDLE__ ADC handle
+  * @retval Value of bitfield RES in CFGR register.
+  */
+#define ADC_GET_RESOLUTION(__HANDLE__)                                         \
+  (LL_ADC_GetResolution((__HANDLE__)->Instance))
+
+/**
+  * @brief Clear ADC error code (set it to no error code "HAL_ADC_ERROR_NONE").
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#define ADC_CLEAR_ERRORCODE(__HANDLE__) ((__HANDLE__)->ErrorCode = HAL_ADC_ERROR_NONE)
+
+/**
+  * @brief Verification of ADC state: enabled or disabled.
+  * @param __HANDLE__ ADC handle
+  * @retval SET (ADC enabled) or RESET (ADC disabled)
+  */
+#define ADC_IS_ENABLE(__HANDLE__)                                                    \
+       (( ((((__HANDLE__)->Instance->CR) & (ADC_CR_ADEN | ADC_CR_ADDIS)) == ADC_CR_ADEN) && \
+          ((((__HANDLE__)->Instance->ISR) & ADC_FLAG_RDY) == ADC_FLAG_RDY)                  \
+        ) ? SET : RESET)
+
+/**
+  * @brief Check if conversion is on going on regular group.
+  * @param __HANDLE__ ADC handle
+  * @retval Value "0" (no conversion is on going) or value "1" (conversion is on going)
+  */
+#define ADC_IS_CONVERSION_ONGOING_REGULAR(__HANDLE__)                          \
+  (LL_ADC_REG_IsConversionOngoing((__HANDLE__)->Instance))
+
+/**
+  * @brief Check if ADC clock mode is synchronous
+  * @param __HANDLE__: ADC handle
+  * @retval SET (clock mode is synchronous) or RESET (clock mode is asynchronous)
+  */
+#if defined (ADC3)
+#define ADC_IS_SYNCHRONOUS_CLOCK_MODE(__HANDLE__)                                   \
+       (((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2))? \
+     ((ADC12_COMMON->CCR & ADC_CCR_CKMODE) != 0UL)                              \
+     :((((ADC3_COMMON)->CCR) & ADC_CCR_CKMODE) != 0UL))
+#else
+#define ADC_IS_SYNCHRONOUS_CLOCK_MODE(__HANDLE__)     ((ADC12_COMMON->CCR & ADC_CCR_CKMODE) != 0UL)
+
+#endif
+
+/**
+  * @brief Simultaneously clear and set specific bits of the handle State.
+  * @note  ADC_STATE_CLR_SET() macro is merely aliased to generic macro MODIFY_REG(),
+  *        the first parameter is the ADC handle State, the second parameter is the
+  *        bit field to clear, the third and last parameter is the bit field to set.
+  * @retval None
+  */
+#define ADC_STATE_CLR_SET MODIFY_REG
+
+/**
+  * @brief Verify that a given value is aligned with the ADC resolution range.
+  * @param __RESOLUTION__ ADC resolution (16, 14, 12, 10 or 8 bits).
+  * @param __ADC_VALUE__ value checked against the resolution.
+  * @retval SET (__ADC_VALUE__ in line with __RESOLUTION__) or RESET (__ADC_VALUE__ not in line with __RESOLUTION__)
+  */
+#define IS_ADC_RANGE(__RESOLUTION__, __ADC_VALUE__) \
+  ((__ADC_VALUE__) <= __LL_ADC_DIGITAL_SCALE(__RESOLUTION__))
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief Verify that a given value is aligned with the ADC resolution range. Applicable for ADC3 on devices STM32H72xx and STM32H73xx.
+  * @param __RESOLUTION__ ADC resolution (12, 10, 8 or 6 bits).
+  * @param __ADC_VALUE__ value checked against the resolution.
+  * @retval SET (__ADC_VALUE__ in line with __RESOLUTION__) or RESET (__ADC_VALUE__ not in line with __RESOLUTION__)
+  */
+#define IS_ADC3_RANGE(__RESOLUTION__, __ADC_VALUE__) \
+  ((__ADC_VALUE__) <= __LL_ADC3_DIGITAL_SCALE(__RESOLUTION__))
+#endif
+/**
+  * @brief Verify the length of the scheduled regular conversions group.
+  * @param __LENGTH__ number of programmed conversions.
+  * @retval SET (__LENGTH__ is within the maximum number of possible programmable regular conversions) or RESET (__LENGTH__ is null or too large)
+  */
+#define IS_ADC_REGULAR_NB_CONV(__LENGTH__) (((__LENGTH__) >= (1UL)) && ((__LENGTH__) <= (16UL)))
+
+
+/**
+  * @brief Verify the number of scheduled regular conversions in discontinuous mode.
+  * @param NUMBER number of scheduled regular conversions in discontinuous mode.
+  * @retval SET (NUMBER is within the maximum number of regular conversions in discontinuous mode) or RESET (NUMBER is null or too large)
+  */
+#define IS_ADC_REGULAR_DISCONT_NUMBER(NUMBER) (((NUMBER) >= (1UL)) && ((NUMBER) <= (8UL)))
+
+
+/**
+  * @brief Verify the ADC clock setting.
+  * @param __ADC_CLOCK__ programmed ADC clock.
+  * @retval SET (__ADC_CLOCK__ is a valid value) or RESET (__ADC_CLOCK__ is invalid)
+  */
+#define IS_ADC_CLOCKPRESCALER(__ADC_CLOCK__) (((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV1) || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV2) || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_SYNC_PCLK_DIV4) || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV1)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV2)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV4)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV6)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV8)     || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV10)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV12)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV16)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV32)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV64)    || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV128)   || \
+                                              ((__ADC_CLOCK__) == ADC_CLOCK_ASYNC_DIV256) )
+
+/**
+  * @brief Verify the ADC resolution setting.
+  * @param __RESOLUTION__ programmed ADC resolution.
+  * @retval SET (__RESOLUTION__ is a valid value) or RESET (__RESOLUTION__ is invalid)
+  */
+#if defined(ADC_VER_V5_V90)
+#define IS_ADC_RESOLUTION(__RESOLUTION__) (((__RESOLUTION__) == ADC_RESOLUTION_16B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_14B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_12B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_10B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_8B)  || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_6B)    )
+#elif defined (ADC_VER_V5_X)
+#define IS_ADC_RESOLUTION(__RESOLUTION__) (((__RESOLUTION__) == ADC_RESOLUTION_16B)     || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_14B)     || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_14B_OPT) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_12B)     || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_12B_OPT) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_10B)     || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_8B)    )
+#else /* ADC_VER_V5_3 */
+#define IS_ADC_RESOLUTION(__RESOLUTION__) (((__RESOLUTION__) == ADC_RESOLUTION_16B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_14B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_12B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_10B) || \
+                                           ((__RESOLUTION__) == ADC_RESOLUTION_8B)    )
+#endif /* ADC_VER_V5_V90*/
+
+/**
+  * @brief Verify the ADC resolution setting when limited to 8 bits.
+  * @param __RESOLUTION__ programmed ADC resolution when limited to 8 bits.
+  * @retval SET (__RESOLUTION__ is a valid value) or RESET (__RESOLUTION__ is invalid)
+  */
+#define IS_ADC_RESOLUTION_8_BITS(__RESOLUTION__) (((__RESOLUTION__) == ADC_RESOLUTION_8B))
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief Verify the ADC converted data alignment. Applicable for ADC3 on devices STM32H72xx and STM32H73xx. 
+  * @param __ALIGN__ programmed ADC converted data alignment.
+  * @retval SET (__ALIGN__ is a valid value) or RESET (__ALIGN__ is invalid)
+  */
+#define IS_ADC3_DATA_ALIGN(__ALIGN__) (((__ALIGN__) == ADC3_DATAALIGN_RIGHT) || \
+                                       ((__ALIGN__) == ADC3_DATAALIGN_LEFT)    )
+
+/**
+  * @brief Verify the ADC regular conversions external trigger.
+  * @param __SAMPLINGMODE__ programmed ADC regular conversions external trigger.
+  * @retval SET (__SAMPLINGMODE__ is a valid value) or RESET (__SAMPLINGMODE__ is invalid)
+  */
+#define IS_ADC3_SAMPLINGMODE(__SAMPLINGMODE__) (((__SAMPLINGMODE__) == ADC_SAMPLING_MODE_NORMAL)          || \
+                                                ((__SAMPLINGMODE__) == ADC_SAMPLING_MODE_BULB)            || \
+                                                ((__SAMPLINGMODE__) == ADC_SAMPLING_MODE_TRIGGER_CONTROLED)  )
+
+#endif
+
+/**
+  * @brief Verify the ADC scan mode.
+  * @param __SCAN_MODE__ programmed ADC scan mode.
+  * @retval SET (__SCAN_MODE__ is valid) or RESET (__SCAN_MODE__ is invalid)
+  */
+#define IS_ADC_SCAN_MODE(__SCAN_MODE__) (((__SCAN_MODE__) == ADC_SCAN_DISABLE) || \
+                                         ((__SCAN_MODE__) == ADC_SCAN_ENABLE)    )
+
+/**
+  * @brief Verify the ADC edge trigger setting for regular group.
+  * @param __EDGE__ programmed ADC edge trigger setting.
+  * @retval SET (__EDGE__ is a valid value) or RESET (__EDGE__ is invalid)
+  */
+#define IS_ADC_EXTTRIG_EDGE(__EDGE__) (((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_NONE)         || \
+                                       ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_RISING)       || \
+                                       ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_FALLING)      || \
+                                       ((__EDGE__) == ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING)  )
+
+/**
+  * @brief Verify the ADC regular conversions external trigger.
+  * @param __REGTRIG__ programmed ADC regular conversions external trigger.
+  * @retval SET (__REGTRIG__ is a valid value) or RESET (__REGTRIG__ is invalid)
+  */
+#if defined(ADC_VER_V5_V90)
+#define IS_ADC_EXTTRIG(__REGTRIG__) (((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC1)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC2)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC3)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T2_CC2)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T3_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T4_CC4)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_EXT_IT11)      || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T8_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T8_TRGO2)      || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_TRGO2)      || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T2_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T4_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T6_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T15_TRGO)      || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T3_CC4)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_HR1_ADCTRG1)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_HR1_ADCTRG3)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_LPTIM1_OUT)    || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_LPTIM2_OUT)    || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_LPTIM3_OUT)    || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T23_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T24_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_SOFTWARE_START)           )
+#else
+#define IS_ADC_EXTTRIG(__REGTRIG__) (((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC1)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC2)        || \
+                                    ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_CC3)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T2_CC2)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T3_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T4_CC4)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_EXT_IT11)      || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T8_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T8_TRGO2)      || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T1_TRGO2)      || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T2_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T4_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T6_TRGO)       || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T15_TRGO)      || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_T3_CC4)        || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_HR1_ADCTRG1)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_HR1_ADCTRG3)   || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_LPTIM1_OUT)    || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_LPTIM2_OUT)    || \
+                                     ((__REGTRIG__) == ADC_EXTERNALTRIG_LPTIM3_OUT)    || \
+                                     ((__REGTRIG__) == ADC_SOFTWARE_START)           )
+#endif /* ADC_VER_V5_V90*/
+
+
+/**
+  * @brief Verify the ADC regular conversions check for converted data availability.
+  * @param __EOC_SELECTION__ converted data availability check.
+  * @retval SET (__EOC_SELECTION__ is a valid value) or RESET (__EOC_SELECTION__ is invalid)
+  */
+#define IS_ADC_EOC_SELECTION(__EOC_SELECTION__) (((__EOC_SELECTION__) == ADC_EOC_SINGLE_CONV)    || \
+                                                 ((__EOC_SELECTION__) == ADC_EOC_SEQ_CONV)  )
+
+/**
+  * @brief Verify the ADC regular conversions overrun handling.
+  * @param __OVR__ ADC regular conversions overrun handling.
+  * @retval SET (__OVR__ is a valid value) or RESET (__OVR__ is invalid)
+  */
+#define IS_ADC_OVERRUN(__OVR__) (((__OVR__) == ADC_OVR_DATA_PRESERVED)  || \
+                                 ((__OVR__) == ADC_OVR_DATA_OVERWRITTEN)  )
+
+/**
+  * @brief Verify the ADC conversions sampling time.
+  * @param __TIME__ ADC conversions sampling time.
+  * @retval SET (__TIME__ is a valid value) or RESET (__TIME__ is invalid)
+  */
+#define IS_ADC_SAMPLE_TIME(__TIME__) (((__TIME__) == ADC_SAMPLETIME_1CYCLE_5)    || \
+                                      ((__TIME__) == ADC_SAMPLETIME_2CYCLES_5)   || \
+                                      ((__TIME__) == ADC_SAMPLETIME_8CYCLES_5)   || \
+                                      ((__TIME__) == ADC_SAMPLETIME_16CYCLES_5)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_32CYCLES_5)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_64CYCLES_5)  || \
+                                      ((__TIME__) == ADC_SAMPLETIME_387CYCLES_5) || \
+                                      ((__TIME__) == ADC_SAMPLETIME_810CYCLES_5)   )
+
+/**
+  * @brief Verify the ADC regular channel setting.
+  * @param  __CHANNEL__ programmed ADC regular channel.
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC_REGULAR_RANK(__CHANNEL__) (((__CHANNEL__) == ADC_REGULAR_RANK_1 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_2 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_3 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_4 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_5 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_6 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_7 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_8 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_9 ) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_10) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_11) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_12) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_13) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_14) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_15) || \
+                                          ((__CHANNEL__) == ADC_REGULAR_RANK_16)   )
+
+/**
+  * @}
+  */
+
+
+/* Private constants ---------------------------------------------------------*/
+
+/** @defgroup ADC_Private_Constants ADC Private Constants
+  * @{
+  */
+
+/* Fixed timeout values for ADC conversion (including sampling time)        */
+/* Maximum sampling time is 810.5 ADC clock cycle        */
+/* Maximum conversion time is 16.5 + Maximum sampling time                  */
+/*                       or 16.5  + 810.5 = 827 ADC clock cycles            */
+/* Minimum ADC Clock frequency is 0.35 MHz                                  */
+/* Maximum conversion time is                                               */
+/*              827 / 0.35 MHz = 2.36 ms                                    */
+
+#define ADC_STOP_CONVERSION_TIMEOUT     ( 5UL)     /*!< ADC stop time-out value */
+
+/* Delay for temperature sensor stabilization time.                         */
+/* Maximum delay is 120us (refer device datasheet, parameter tSTART).       */
+/* Unit: us                                                                 */
+#define ADC_TEMPSENSOR_DELAY_US         (LL_ADC_DELAY_TEMPSENSOR_STAB_US)
+
+/* Delay for ADC voltage regulator startup time                               */
+/*  Maximum delay is 10 microseconds                                          */
+/* (refer device RM, parameter Tadcvreg_stup).                                */
+#define ADC_STAB_DELAY_US               (10UL)     /*!< ADC voltage regulator startup time */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Macros ADC Exported Macros
+  * @{
+  */
+/* Macro for internal HAL driver usage, and possibly can be used into code of */
+/* final user.                                                                */
+
+/** @defgroup ADC_HAL_EM_HANDLE_IT_FLAG HAL ADC macro to manage HAL ADC handle, IT and flags.
+  * @{
+  */
+
+/** @brief  Reset ADC handle state.
+  * @param __HANDLE__ ADC handle
+  * @retval None
+  */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+#define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__)                               \
+  do{                                                                          \
+     (__HANDLE__)->State = HAL_ADC_STATE_RESET;                               \
+     (__HANDLE__)->MspInitCallback = NULL;                                     \
+     (__HANDLE__)->MspDeInitCallback = NULL;                                   \
+    } while(0)
+#else
+#define __HAL_ADC_RESET_HANDLE_STATE(__HANDLE__)                               \
+  ((__HANDLE__)->State = HAL_ADC_STATE_RESET)
+#endif
+
+/**
+  * @brief Enable ADC interrupt.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC Interrupt
+  *        This parameter can be one of the following values:
+  *            @arg @ref ADC_IT_RDY    ADC Ready interrupt source
+  *            @arg @ref ADC_IT_EOSMP  ADC End of Sampling interrupt source
+  *            @arg @ref ADC_IT_EOC    ADC End of Regular Conversion interrupt source
+  *            @arg @ref ADC_IT_EOS    ADC End of Regular sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_OVR    ADC overrun interrupt source
+  *            @arg @ref ADC_IT_JEOC   ADC End of Injected Conversion interrupt source
+  *            @arg @ref ADC_IT_JEOS   ADC End of Injected sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_AWD1   ADC Analog watchdog 1 interrupt source (main analog watchdog)
+  *            @arg @ref ADC_IT_AWD2   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_AWD3   ADC Analog watchdog 3 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_JQOVF  ADC Injected Context Queue Overflow interrupt source.
+  * @retval None
+  */
+#define __HAL_ADC_ENABLE_IT(__HANDLE__, __INTERRUPT__)                         \
+  (((__HANDLE__)->Instance->IER) |= (__INTERRUPT__))
+
+/**
+  * @brief Disable ADC interrupt.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC Interrupt
+  *        This parameter can be one of the following values:
+  *            @arg @ref ADC_IT_RDY    ADC Ready interrupt source
+  *            @arg @ref ADC_IT_EOSMP  ADC End of Sampling interrupt source
+  *            @arg @ref ADC_IT_EOC    ADC End of Regular Conversion interrupt source
+  *            @arg @ref ADC_IT_EOS    ADC End of Regular sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_OVR    ADC overrun interrupt source
+  *            @arg @ref ADC_IT_JEOC   ADC End of Injected Conversion interrupt source
+  *            @arg @ref ADC_IT_JEOS   ADC End of Injected sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_AWD1   ADC Analog watchdog 1 interrupt source (main analog watchdog)
+  *            @arg @ref ADC_IT_AWD2   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_AWD3   ADC Analog watchdog 3 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_JQOVF  ADC Injected Context Queue Overflow interrupt source.
+  * @retval None
+  */
+#define __HAL_ADC_DISABLE_IT(__HANDLE__, __INTERRUPT__)                        \
+  (((__HANDLE__)->Instance->IER) &= ~(__INTERRUPT__))
+
+/** @brief  Checks if the specified ADC interrupt source is enabled or disabled.
+  * @param __HANDLE__ ADC handle
+  * @param __INTERRUPT__ ADC interrupt source to check
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_IT_RDY    ADC Ready interrupt source
+  *            @arg @ref ADC_IT_EOSMP  ADC End of Sampling interrupt source
+  *            @arg @ref ADC_IT_EOC    ADC End of Regular Conversion interrupt source
+  *            @arg @ref ADC_IT_EOS    ADC End of Regular sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_OVR    ADC overrun interrupt source
+  *            @arg @ref ADC_IT_JEOC   ADC End of Injected Conversion interrupt source
+  *            @arg @ref ADC_IT_JEOS   ADC End of Injected sequence of Conversions interrupt source
+  *            @arg @ref ADC_IT_AWD1   ADC Analog watchdog 1 interrupt source (main analog watchdog)
+  *            @arg @ref ADC_IT_AWD2   ADC Analog watchdog 2 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_AWD3   ADC Analog watchdog 3 interrupt source (additional analog watchdog)
+  *            @arg @ref ADC_IT_JQOVF  ADC Injected Context Queue Overflow interrupt source.
+  * @retval State of interruption (SET or RESET)
+  */
+#define __HAL_ADC_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)                     \
+  (((__HANDLE__)->Instance->IER & (__INTERRUPT__)) == (__INTERRUPT__))
+
+/**
+  * @brief Check whether the specified ADC flag is set or not.
+  * @param __HANDLE__ ADC handle
+  * @param __FLAG__ ADC flag
+  *        This parameter can be one of the following values:
+  *            @arg @ref ADC_FLAG_RDY     ADC Ready flag
+  *            @arg @ref ADC_FLAG_EOSMP   ADC End of Sampling flag
+  *            @arg @ref ADC_FLAG_EOC     ADC End of Regular Conversion flag
+  *            @arg @ref ADC_FLAG_EOS     ADC End of Regular sequence of Conversions flag
+  *            @arg @ref ADC_FLAG_OVR     ADC overrun flag
+  *            @arg @ref ADC_FLAG_JEOC    ADC End of Injected Conversion flag
+  *            @arg @ref ADC_FLAG_JEOS    ADC End of Injected sequence of Conversions flag
+  *            @arg @ref ADC_FLAG_AWD1    ADC Analog watchdog 1 flag (main analog watchdog)
+  *            @arg @ref ADC_FLAG_AWD2    ADC Analog watchdog 2 flag (additional analog watchdog)
+  *            @arg @ref ADC_FLAG_AWD3    ADC Analog watchdog 3 flag (additional analog watchdog)
+  *            @arg @ref ADC_FLAG_JQOVF   ADC Injected Context Queue Overflow flag
+  *            @arg @ref ADC_FLAG_LDORDY  ADC LDO output voltage ready bit.
+  * @retval State of flag (TRUE or FALSE).
+  */
+#define __HAL_ADC_GET_FLAG(__HANDLE__, __FLAG__)                               \
+  ((((__HANDLE__)->Instance->ISR) & (__FLAG__)) == (__FLAG__))
+
+/**
+  * @brief Clear the specified ADC flag.
+  * @param __HANDLE__ ADC handle
+  * @param __FLAG__ ADC flag
+  *        This parameter can be one of the following values:
+  *            @arg @ref ADC_FLAG_RDY     ADC Ready flag
+  *            @arg @ref ADC_FLAG_EOSMP   ADC End of Sampling flag
+  *            @arg @ref ADC_FLAG_EOC     ADC End of Regular Conversion flag
+  *            @arg @ref ADC_FLAG_EOS     ADC End of Regular sequence of Conversions flag
+  *            @arg @ref ADC_FLAG_OVR     ADC overrun flag
+  *            @arg @ref ADC_FLAG_JEOC    ADC End of Injected Conversion flag
+  *            @arg @ref ADC_FLAG_JEOS    ADC End of Injected sequence of Conversions flag
+  *            @arg @ref ADC_FLAG_AWD1    ADC Analog watchdog 1 flag (main analog watchdog)
+  *            @arg @ref ADC_FLAG_AWD2    ADC Analog watchdog 2 flag (additional analog watchdog)
+  *            @arg @ref ADC_FLAG_AWD3    ADC Analog watchdog 3 flag (additional analog watchdog)
+  *            @arg @ref ADC_FLAG_JQOVF   ADC Injected Context Queue Overflow flag.
+  * @retval None
+  */
+/* Note: bit cleared bit by writing 1 (writing 0 has no effect on any bit of register ISR) */
+#define __HAL_ADC_CLEAR_FLAG(__HANDLE__, __FLAG__)                             \
+  (((__HANDLE__)->Instance->ISR) = (__FLAG__))
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EM_HELPER_MACRO HAL ADC helper macro
+  * @{
+  */
+
+/**
+  * @brief  Helper macro to get ADC channel number in decimal format
+  *         from literals ADC_CHANNEL_x.
+  * @note   Example:
+  *           __HAL_ADC_CHANNEL_TO_DECIMAL_NB(ADC_CHANNEL_4)
+  *           will return decimal number "4".
+  * @note   The input can be a value from functions where a channel
+  *         number is returned, either defined with number
+  *         or with bitfield (only one bit must be set).
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref ADC_CHANNEL_0           (3)
+  *         @arg @ref ADC_CHANNEL_1           (3)
+  *         @arg @ref ADC_CHANNEL_2           (3)
+  *         @arg @ref ADC_CHANNEL_3           (3)
+  *         @arg @ref ADC_CHANNEL_4           (3)
+  *         @arg @ref ADC_CHANNEL_5           (3)
+  *         @arg @ref ADC_CHANNEL_6
+  *         @arg @ref ADC_CHANNEL_7
+  *         @arg @ref ADC_CHANNEL_8
+  *         @arg @ref ADC_CHANNEL_9
+  *         @arg @ref ADC_CHANNEL_10
+  *         @arg @ref ADC_CHANNEL_11
+  *         @arg @ref ADC_CHANNEL_12
+  *         @arg @ref ADC_CHANNEL_13
+  *         @arg @ref ADC_CHANNEL_14
+  *         @arg @ref ADC_CHANNEL_15
+  *         @arg @ref ADC_CHANNEL_16
+  *         @arg @ref ADC_CHANNEL_17
+  *         @arg @ref ADC_CHANNEL_18
+  *         @arg @ref ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval Value between Min_Data=0 and Max_Data=18
+  */
+#define __HAL_ADC_CHANNEL_TO_DECIMAL_NB(__CHANNEL__)                           \
+         __LL_ADC_CHANNEL_TO_DECIMAL_NB((__CHANNEL__))
+
+/**
+  * @brief  Helper macro to get ADC channel in literal format ADC_CHANNEL_x
+  *         from number in decimal format.
+  * @note   Example:
+  *           __HAL_ADC_DECIMAL_NB_TO_CHANNEL(4)
+  *           will return a data equivalent to "ADC_CHANNEL_4".
+  * @param  __DECIMAL_NB__ Value between Min_Data=0 and Max_Data=18
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref ADC_CHANNEL_0           (3)
+  *         @arg @ref ADC_CHANNEL_1           (3)
+  *         @arg @ref ADC_CHANNEL_2           (3)
+  *         @arg @ref ADC_CHANNEL_3           (3)
+  *         @arg @ref ADC_CHANNEL_4           (3)
+  *         @arg @ref ADC_CHANNEL_5           (3)
+  *         @arg @ref ADC_CHANNEL_6
+  *         @arg @ref ADC_CHANNEL_7
+  *         @arg @ref ADC_CHANNEL_8
+  *         @arg @ref ADC_CHANNEL_9
+  *         @arg @ref ADC_CHANNEL_10
+  *         @arg @ref ADC_CHANNEL_11
+  *         @arg @ref ADC_CHANNEL_12
+  *         @arg @ref ADC_CHANNEL_13
+  *         @arg @ref ADC_CHANNEL_14
+  *         @arg @ref ADC_CHANNEL_15
+  *         @arg @ref ADC_CHANNEL_16
+  *         @arg @ref ADC_CHANNEL_17
+  *         @arg @ref ADC_CHANNEL_18
+  *         @arg @ref ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).\n
+  *         (1, 2) For ADC channel read back from ADC register,
+  *                comparison with internal channel parameter to be done
+  *                using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
+  */
+#define __HAL_ADC_DECIMAL_NB_TO_CHANNEL(__DECIMAL_NB__)                        \
+         __LL_ADC_DECIMAL_NB_TO_CHANNEL((__DECIMAL_NB__))
+
+/**
+  * @brief  Helper macro to determine whether the selected channel
+  *         corresponds to literal definitions of driver.
+  * @note   The different literal definitions of ADC channels are:
+  *         - ADC internal channel:
+  *           ADC_CHANNEL_VREFINT, ADC_CHANNEL_TEMPSENSOR, ...
+  *         - ADC external channel (channel connected to a GPIO pin):
+  *           ADC_CHANNEL_1, ADC_CHANNEL_2, ...
+  * @note   The channel parameter must be a value defined from literal
+  *         definition of a ADC internal channel (ADC_CHANNEL_VREFINT,
+  *         ADC_CHANNEL_TEMPSENSOR, ...),
+  *         ADC external channel (ADC_CHANNEL_1, ADC_CHANNEL_2, ...),
+  *         must not be a value from functions where a channel number is
+  *         returned from ADC registers,
+  *         because internal and external channels share the same channel
+  *         number in ADC registers. The differentiation is made only with
+  *         parameters definitions of driver.
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref ADC_CHANNEL_0           (3)
+  *         @arg @ref ADC_CHANNEL_1           (3)
+  *         @arg @ref ADC_CHANNEL_2           (3)
+  *         @arg @ref ADC_CHANNEL_3           (3)
+  *         @arg @ref ADC_CHANNEL_4           (3)
+  *         @arg @ref ADC_CHANNEL_5           (3)
+  *         @arg @ref ADC_CHANNEL_6
+  *         @arg @ref ADC_CHANNEL_7
+  *         @arg @ref ADC_CHANNEL_8
+  *         @arg @ref ADC_CHANNEL_9
+  *         @arg @ref ADC_CHANNEL_10
+  *         @arg @ref ADC_CHANNEL_11
+  *         @arg @ref ADC_CHANNEL_12
+  *         @arg @ref ADC_CHANNEL_13
+  *         @arg @ref ADC_CHANNEL_14
+  *         @arg @ref ADC_CHANNEL_15
+  *         @arg @ref ADC_CHANNEL_16
+  *         @arg @ref ADC_CHANNEL_17
+  *         @arg @ref ADC_CHANNEL_18
+  *         @arg @ref ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval Value "0" if the channel corresponds to a parameter definition of a ADC external channel (channel connected to a GPIO pin).
+  *         Value "1" if the channel corresponds to a parameter definition of a ADC internal channel.
+  */
+#define __HAL_ADC_IS_CHANNEL_INTERNAL(__CHANNEL__)                             \
+         __LL_ADC_IS_CHANNEL_INTERNAL((__CHANNEL__))
+
+/**
+  * @brief  Helper macro to convert a channel defined from parameter
+  *         definition of a ADC internal channel (ADC_CHANNEL_VREFINT,
+  *         ADC_CHANNEL_TEMPSENSOR, ...),
+  *         to its equivalent parameter definition of a ADC external channel
+  *         (ADC_CHANNEL_1, ADC_CHANNEL_2, ...).
+  * @note   The channel parameter can be, additionally to a value
+  *         defined from parameter definition of a ADC internal channel
+  *         (ADC_CHANNEL_VREFINT, ADC_CHANNEL_TEMPSENSOR, ...),
+  *         a value defined from parameter definition of
+  *         ADC external channel (ADC_CHANNEL_1, ADC_CHANNEL_2, ...)
+  *         or a value from functions where a channel number is returned
+  *         from ADC registers.
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref ADC_CHANNEL_0           (3)
+  *         @arg @ref ADC_CHANNEL_1           (3)
+  *         @arg @ref ADC_CHANNEL_2           (3)
+  *         @arg @ref ADC_CHANNEL_3           (3)
+  *         @arg @ref ADC_CHANNEL_4           (3)
+  *         @arg @ref ADC_CHANNEL_5           (3)
+  *         @arg @ref ADC_CHANNEL_6
+  *         @arg @ref ADC_CHANNEL_7
+  *         @arg @ref ADC_CHANNEL_8
+  *         @arg @ref ADC_CHANNEL_9
+  *         @arg @ref ADC_CHANNEL_10
+  *         @arg @ref ADC_CHANNEL_11
+  *         @arg @ref ADC_CHANNEL_12
+  *         @arg @ref ADC_CHANNEL_13
+  *         @arg @ref ADC_CHANNEL_14
+  *         @arg @ref ADC_CHANNEL_15
+  *         @arg @ref ADC_CHANNEL_16
+  *         @arg @ref ADC_CHANNEL_17
+  *         @arg @ref ADC_CHANNEL_18
+  *         @arg @ref ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref ADC_CHANNEL_0
+  *         @arg @ref ADC_CHANNEL_1
+  *         @arg @ref ADC_CHANNEL_2
+  *         @arg @ref ADC_CHANNEL_3
+  *         @arg @ref ADC_CHANNEL_4
+  *         @arg @ref ADC_CHANNEL_5
+  *         @arg @ref ADC_CHANNEL_6
+  *         @arg @ref ADC_CHANNEL_7
+  *         @arg @ref ADC_CHANNEL_8
+  *         @arg @ref ADC_CHANNEL_9
+  *         @arg @ref ADC_CHANNEL_10
+  *         @arg @ref ADC_CHANNEL_11
+  *         @arg @ref ADC_CHANNEL_12
+  *         @arg @ref ADC_CHANNEL_13
+  *         @arg @ref ADC_CHANNEL_14
+  *         @arg @ref ADC_CHANNEL_15
+  *         @arg @ref ADC_CHANNEL_16
+  *         @arg @ref ADC_CHANNEL_17
+  *         @arg @ref ADC_CHANNEL_18
+  */
+#define __HAL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL(__CHANNEL__)                    \
+         __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL((__CHANNEL__))
+
+/**
+  * @brief  Helper macro to determine whether the internal channel
+  *         selected is available on the ADC instance selected.
+  * @note   The channel parameter must be a value defined from parameter
+  *         definition of a ADC internal channel (ADC_CHANNEL_VREFINT,
+  *         ADC_CHANNEL_TEMPSENSOR, ...),
+  *         must not be a value defined from parameter definition of
+  *         ADC external channel (ADC_CHANNEL_1, ADC_CHANNEL_2, ...)
+  *         or a value from functions where a channel number is
+  *         returned from ADC registers,
+  *         because internal and external channels share the same channel
+  *         number in ADC registers. The differentiation is made only with
+  *         parameters definitions of driver.
+  * @param  __ADC_INSTANCE__ ADC instance
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.
+  * @retval Value "0" if the internal channel selected is not available on the ADC instance selected.
+  *         Value "1" if the internal channel selected is available on the ADC instance selected.
+  */
+#define __HAL_ADC_IS_CHANNEL_INTERNAL_AVAILABLE(__ADC_INSTANCE__, __CHANNEL__)  \
+         __LL_ADC_IS_CHANNEL_INTERNAL_AVAILABLE((__ADC_INSTANCE__), (__CHANNEL__))
+
+/**
+  * @brief  Helper macro to get the ADC multimode conversion data of ADC master
+  *         or ADC slave from raw value with both ADC conversion data concatenated.
+  * @note   This macro is intended to be used when multimode transfer by DMA
+  *         is enabled: refer to function @ref LL_ADC_SetMultiDMATransfer().
+  *         In this case the transferred data need to processed with this macro
+  *         to separate the conversion data of ADC master and ADC slave.
+  * @param  __ADC_MULTI_MASTER_SLAVE__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_MASTER
+  *         @arg @ref LL_ADC_MULTI_SLAVE
+  * @param  __ADC_MULTI_CONV_DATA__ Value between Min_Data=0x000 and Max_Data=0xFFF
+  * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
+  */
+#define __HAL_ADC_MULTI_CONV_DATA_MASTER_SLAVE(__ADC_MULTI_MASTER_SLAVE__, __ADC_MULTI_CONV_DATA__)  \
+         __LL_ADC_MULTI_CONV_DATA_MASTER_SLAVE((__ADC_MULTI_MASTER_SLAVE__), (__ADC_MULTI_CONV_DATA__))
+
+/**
+  * @brief  Helper macro to select the ADC common instance
+  *         to which is belonging the selected ADC instance.
+  * @note   ADC common register instance can be used for:
+  *         - Set parameters common to several ADC instances
+  *         - Multimode (for devices with several ADC instances)
+  *         Refer to functions having argument "ADCxy_COMMON" as parameter.
+  * @param  __ADCx__ ADC instance
+  * @retval ADC common register instance
+  */
+#define __HAL_ADC_COMMON_INSTANCE(__ADCx__)                                    \
+         __LL_ADC_COMMON_INSTANCE((__ADCx__))
+
+/**
+  * @brief  Helper macro to check if all ADC instances sharing the same
+  *         ADC common instance are disabled.
+  * @note   This check is required by functions with setting conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled.
+  *         Refer to functions having argument "ADCxy_COMMON" as parameter.
+  * @note   On devices with only 1 ADC common instance, parameter of this macro
+  *         is useless and can be ignored (parameter kept for compatibility
+  *         with devices featuring several ADC common instances).
+  * @param  __ADCXY_COMMON__ ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval Value "0" if all ADC instances sharing the same ADC common instance
+  *         are disabled.
+  *         Value "1" if at least one ADC instance sharing the same ADC common instance
+  *         is enabled.
+  */
+#define __HAL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__ADCXY_COMMON__)              \
+         __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE((__ADCXY_COMMON__))
+
+/**
+  * @brief  Helper macro to define the ADC conversion data full-scale digital
+  *         value corresponding to the selected ADC resolution.
+  * @note   ADC conversion data full-scale corresponds to voltage range
+  *         determined by analog voltage references Vref+ and Vref-
+  *         (refer to reference manual).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref ADC_RESOLUTION_16B
+  *         @arg @ref ADC_RESOLUTION_14B
+  *         @arg @ref ADC_RESOLUTION_12B
+  *         @arg @ref ADC_RESOLUTION_10B
+  *         @arg @ref ADC_RESOLUTION_8B
+  * @retval ADC conversion data full-scale digital value
+  */
+#define __HAL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__)                             \
+         __LL_ADC_DIGITAL_SCALE((__ADC_RESOLUTION__))
+
+/**
+  * @brief  Helper macro to convert the ADC conversion data from
+  *         a resolution to another resolution.
+  * @param  __DATA__ ADC conversion data to be converted
+  * @param  __ADC_RESOLUTION_CURRENT__ Resolution of to the data to be converted
+  *         This parameter can be one of the following values:
+  *         @arg @ref ADC_RESOLUTION_16B
+  *         @arg @ref ADC_RESOLUTION_14B
+  *         @arg @ref ADC_RESOLUTION_12B
+  *         @arg @ref ADC_RESOLUTION_10B
+  *         @arg @ref ADC_RESOLUTION_8B
+  * @param  __ADC_RESOLUTION_TARGET__ Resolution of the data after conversion
+  *         This parameter can be one of the following values:
+  *         @arg @ref ADC_RESOLUTION_16B
+  *         @arg @ref ADC_RESOLUTION_14B
+  *         @arg @ref ADC_RESOLUTION_12B
+  *         @arg @ref ADC_RESOLUTION_10B
+  *         @arg @ref ADC_RESOLUTION_8B
+  * @retval ADC conversion data to the requested resolution
+  */
+#define __HAL_ADC_CONVERT_DATA_RESOLUTION(__DATA__,\
+                                          __ADC_RESOLUTION_CURRENT__,\
+                                          __ADC_RESOLUTION_TARGET__)            \
+         __LL_ADC_CONVERT_DATA_RESOLUTION((__DATA__),\
+                                          (__ADC_RESOLUTION_CURRENT__),\
+                                          (__ADC_RESOLUTION_TARGET__))
+
+/**
+  * @brief  Helper macro to calculate the voltage (unit: mVolt)
+  *         corresponding to a ADC conversion data (unit: digital value).
+  * @note   Analog reference voltage (Vref+) must be either known from
+  *         user board environment or can be calculated using ADC measurement
+  *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
+  * @param  __VREFANALOG_VOLTAGE__ Analog reference voltage (unit: mV)
+  * @param  __ADC_DATA__ ADC conversion data (resolution 12 bits)
+  *                       (unit: digital value).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref ADC_RESOLUTION_16B
+  *         @arg @ref ADC_RESOLUTION_14B
+  *         @arg @ref ADC_RESOLUTION_12B
+  *         @arg @ref ADC_RESOLUTION_10B
+  *         @arg @ref ADC_RESOLUTION_8B
+  * @retval ADC conversion data equivalent voltage value (unit: mVolt)
+  */
+#define __HAL_ADC_CALC_DATA_TO_VOLTAGE(__VREFANALOG_VOLTAGE__,\
+                                       __ADC_DATA__,\
+                                       __ADC_RESOLUTION__)                     \
+         __LL_ADC_CALC_DATA_TO_VOLTAGE((__VREFANALOG_VOLTAGE__),\
+                                       (__ADC_DATA__),\
+                                       (__ADC_RESOLUTION__))
+
+/**
+  * @brief  Helper macro to calculate analog reference voltage (Vref+)
+  *         (unit: mVolt) from ADC conversion data of internal voltage
+  *         reference VrefInt.
+  * @note   Computation is using VrefInt calibration value
+  *         stored in system memory for each device during production.
+  * @note   This voltage depends on user board environment: voltage level
+  *         connected to pin Vref+.
+  *         On devices with small package, the pin Vref+ is not present
+  *         and internally bonded to pin Vdda.
+  * @note   On this STM32 series, calibration data of internal voltage reference
+  *         VrefInt corresponds to a resolution of 12 bits,
+  *         this is the recommended ADC resolution to convert voltage of
+  *         internal voltage reference VrefInt.
+  *         Otherwise, this macro performs the processing to scale
+  *         ADC conversion data to 12 bits.
+  * @param  __VREFINT_ADC_DATA__ ADC conversion data (resolution 12 bits)
+  *         of internal voltage reference VrefInt (unit: digital value).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref ADC_RESOLUTION_16B
+  *         @arg @ref ADC_RESOLUTION_14B
+  *         @arg @ref ADC_RESOLUTION_12B
+  *         @arg @ref ADC_RESOLUTION_10B
+  *         @arg @ref ADC_RESOLUTION_8B
+  * @retval Analog reference voltage (unit: mV)
+  */
+#define __HAL_ADC_CALC_VREFANALOG_VOLTAGE(__VREFINT_ADC_DATA__,\
+                                          __ADC_RESOLUTION__)                  \
+         __LL_ADC_CALC_VREFANALOG_VOLTAGE((__VREFINT_ADC_DATA__),\
+                                          (__ADC_RESOLUTION__))
+
+/**
+  * @brief  Helper macro to calculate the temperature (unit: degree Celsius)
+  *         from ADC conversion data of internal temperature sensor.
+  * @note   Computation is using temperature sensor calibration values
+  *         stored in system memory for each device during production.
+  * @note   Calculation formula:
+  *           Temperature = ((TS_ADC_DATA - TS_CAL1)
+  *                           * (TS_CAL2_TEMP - TS_CAL1_TEMP))
+  *                         / (TS_CAL2 - TS_CAL1) + TS_CAL1_TEMP
+  *           with TS_ADC_DATA = temperature sensor raw data measured by ADC
+  *                Avg_Slope = (TS_CAL2 - TS_CAL1)
+  *                            / (TS_CAL2_TEMP - TS_CAL1_TEMP)
+  *                TS_CAL1   = equivalent TS_ADC_DATA at temperature
+  *                            TEMP_DEGC_CAL1 (calibrated in factory)
+  *                TS_CAL2   = equivalent TS_ADC_DATA at temperature
+  *                            TEMP_DEGC_CAL2 (calibrated in factory)
+  *         Caution: Calculation relevancy under reserve that calibration
+  *                  parameters are correct (address and data).
+  *                  To calculate temperature using temperature sensor
+  *                  datasheet typical values (generic values less, therefore
+  *                  less accurate than calibrated values),
+  *                  use helper macro @ref __LL_ADC_CALC_TEMPERATURE_TYP_PARAMS().
+  * @note   As calculation input, the analog reference voltage (Vref+) must be
+  *         defined as it impacts the ADC LSB equivalent voltage.
+  * @note   Analog reference voltage (Vref+) must be either known from
+  *         user board environment or can be calculated using ADC measurement
+  *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
+  * @note   On this STM32 series, calibration data of temperature sensor
+  *         corresponds to a resolution of 12 bits,
+  *         this is the recommended ADC resolution to convert voltage of
+  *         temperature sensor.
+  *         Otherwise, this macro performs the processing to scale
+  *         ADC conversion data to 12 bits.
+  * @param  __VREFANALOG_VOLTAGE__  Analog reference voltage (unit: mV)
+  * @param  __TEMPSENSOR_ADC_DATA__ ADC conversion data of internal
+  *                                 temperature sensor (unit: digital value).
+  * @param  __ADC_RESOLUTION__      ADC resolution at which internal temperature
+  *                                 sensor voltage has been measured.
+  *         This parameter can be one of the following values:
+  *         @arg @ref ADC_RESOLUTION_16B
+  *         @arg @ref ADC_RESOLUTION_14B
+  *         @arg @ref ADC_RESOLUTION_12B
+  *         @arg @ref ADC_RESOLUTION_10B
+  *         @arg @ref ADC_RESOLUTION_8B
+  * @retval Temperature (unit: degree Celsius)
+  */
+#define __HAL_ADC_CALC_TEMPERATURE(__VREFANALOG_VOLTAGE__,\
+                                   __TEMPSENSOR_ADC_DATA__,\
+                                   __ADC_RESOLUTION__)                         \
+         __LL_ADC_CALC_TEMPERATURE((__VREFANALOG_VOLTAGE__),\
+                                   (__TEMPSENSOR_ADC_DATA__),\
+                                   (__ADC_RESOLUTION__))
+
+/**
+  * @brief  Helper macro to calculate the temperature (unit: degree Celsius)
+  *         from ADC conversion data of internal temperature sensor.
+  * @note   Computation is using temperature sensor typical values
+  *         (refer to device datasheet).
+  * @note   Calculation formula:
+  *           Temperature = (TS_TYP_CALx_VOLT(uV) - TS_ADC_DATA * Conversion_uV)
+  *                         / Avg_Slope + CALx_TEMP
+  *           with TS_ADC_DATA      = temperature sensor raw data measured by ADC
+  *                                   (unit: digital value)
+  *                Avg_Slope        = temperature sensor slope
+  *                                   (unit: uV/Degree Celsius)
+  *                TS_TYP_CALx_VOLT = temperature sensor digital value at
+  *                                   temperature CALx_TEMP (unit: mV)
+  *         Caution: Calculation relevancy under reserve the temperature sensor
+  *                  of the current device has characteristics in line with
+  *                  datasheet typical values.
+  *                  If temperature sensor calibration values are available on
+  *                  on this device (presence of macro __LL_ADC_CALC_TEMPERATURE()),
+  *                  temperature calculation will be more accurate using
+  *                  helper macro @ref __LL_ADC_CALC_TEMPERATURE().
+  * @note   As calculation input, the analog reference voltage (Vref+) must be
+  *         defined as it impacts the ADC LSB equivalent voltage.
+  * @note   Analog reference voltage (Vref+) must be either known from
+  *         user board environment or can be calculated using ADC measurement
+  *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
+  * @note   ADC measurement data must correspond to a resolution of 12bits
+  *         (full scale digital value 4095). If not the case, the data must be
+  *         preliminarily rescaled to an equivalent resolution of 12 bits.
+  * @param  __TEMPSENSOR_TYP_AVGSLOPE__   Device datasheet data: Temperature sensor slope typical value (unit: uV/DegCelsius).
+  *                                       On STM32H7, refer to device datasheet parameter "Avg_Slope".
+  * @param  __TEMPSENSOR_TYP_CALX_V__     Device datasheet data: Temperature sensor voltage typical value (at temperature and Vref+ defined in parameters below) (unit: mV).
+  *                                       On STM32H7, refer to device datasheet parameter "V30" (corresponding to TS_CAL1).
+  * @param  __TEMPSENSOR_CALX_TEMP__      Device datasheet data: Temperature at which temperature sensor voltage (see parameter above) is corresponding (unit: mV)
+  * @param  __VREFANALOG_VOLTAGE__        Analog voltage reference (Vref+) voltage (unit: mV)
+  * @param  __TEMPSENSOR_ADC_DATA__       ADC conversion data of internal temperature sensor (unit: digital value).
+  * @param  __ADC_RESOLUTION__            ADC resolution at which internal temperature sensor voltage has been measured.
+  *         This parameter can be one of the following values:
+  *         @arg @ref ADC_RESOLUTION_16B
+  *         @arg @ref ADC_RESOLUTION_14B
+  *         @arg @ref ADC_RESOLUTION_12B
+  *         @arg @ref ADC_RESOLUTION_10B
+  *         @arg @ref ADC_RESOLUTION_8B
+  * @retval Temperature (unit: degree Celsius)
+  */
+#define __HAL_ADC_CALC_TEMPERATURE_TYP_PARAMS(__TEMPSENSOR_TYP_AVGSLOPE__,\
+                                              __TEMPSENSOR_TYP_CALX_V__,\
+                                              __TEMPSENSOR_CALX_TEMP__,\
+                                              __VREFANALOG_VOLTAGE__,\
+                                              __TEMPSENSOR_ADC_DATA__,\
+                                              __ADC_RESOLUTION__)              \
+         __LL_ADC_CALC_TEMPERATURE_TYP_PARAMS((__TEMPSENSOR_TYP_AVGSLOPE__),\
+                                              (__TEMPSENSOR_TYP_CALX_V__),\
+                                              (__TEMPSENSOR_CALX_TEMP__),\
+                                              (__VREFANALOG_VOLTAGE__),\
+                                              (__TEMPSENSOR_ADC_DATA__),\
+                                              (__ADC_RESOLUTION__))
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Include ADC HAL Extended module */
+#include "stm32h7xx_hal_adc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup ADC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group1
+  * @brief    Initialization and Configuration functions
+  * @{
+  */
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef       HAL_ADC_Init(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADC_DeInit(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_MspInit(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_MspDeInit(ADC_HandleTypeDef *hadc);
+
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+/* Callbacks Register/UnRegister functions  ***********************************/
+HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID, pADC_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group2
+  * @brief    IO operation functions
+  * @{
+  */
+/* IO operation functions  *****************************************************/
+
+/* Blocking mode: Polling */
+HAL_StatusTypeDef       HAL_ADC_Start(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADC_Stop(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc, uint32_t Timeout);
+HAL_StatusTypeDef       HAL_ADC_PollForEvent(ADC_HandleTypeDef *hadc, uint32_t EventType, uint32_t Timeout);
+
+/* Non-blocking mode: Interruption */
+HAL_StatusTypeDef       HAL_ADC_Start_IT(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADC_Stop_IT(ADC_HandleTypeDef *hadc);
+
+/* Non-blocking mode: DMA */
+HAL_StatusTypeDef       HAL_ADC_Start_DMA(ADC_HandleTypeDef *hadc, uint32_t *pData, uint32_t Length);
+HAL_StatusTypeDef       HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc);
+
+/* ADC retrieve conversion value intended to be used with polling or interruption */
+uint32_t                HAL_ADC_GetValue(const ADC_HandleTypeDef *hadc);
+
+/* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption and DMA) */
+void                    HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc);
+/**
+  * @}
+  */
+
+/** @addtogroup ADC_Exported_Functions_Group3 Peripheral Control functions
+ *  @brief    Peripheral Control functions
+ * @{
+ */
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef       HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConfTypeDef *sConfig);
+HAL_StatusTypeDef       HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDGConfTypeDef *AnalogWDGConfig);
+
+/**
+  * @}
+  */
+
+/* Peripheral State functions *************************************************/
+/** @addtogroup ADC_Exported_Functions_Group4
+  * @{
+  */
+uint32_t                HAL_ADC_GetState(const ADC_HandleTypeDef *hadc);
+uint32_t                HAL_ADC_GetError(const ADC_HandleTypeDef *hadc);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions -----------------------------------------------------------*/
+/** @addtogroup ADC_Private_Functions ADC Private Functions
+  * @{
+  */
+HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef *hadc, uint32_t ConversionGroup);
+HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef *hadc);
+void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma);
+void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma);
+void ADC_DMAError(DMA_HandleTypeDef *hdma);
+void ADC_ConfigureBoostMode(ADC_HandleTypeDef *hadc);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* STM32H7xx_HAL_ADC_H */
+

--- a/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc_ex.h
+++ b/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc_ex.h
@@ -1,0 +1,1462 @@
+/**
+  ******************************************************************************
+  * @file    stm32h7xx_hal_adc_ex.h
+  * @author  MCD Application Team
+  * @brief   Header file of ADC HAL extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32H7xx_HAL_ADC_EX_H
+#define STM32H7xx_HAL_ADC_EX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32h7xx_hal_def.h"
+
+/** @addtogroup STM32H7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup ADCEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+/** @defgroup ADCEx_Exported_Types ADC Extended Exported Types
+  * @{
+  */
+
+/**
+  * @brief  ADC Injected Conversion Oversampling structure definition
+  */
+typedef struct
+{
+  uint32_t Ratio;                         /*!< Configures the oversampling ratio. */
+#if defined(ADC_VER_V5_V90)
+                                             /* On devices STM32H72xx and STM32H73xx this parameter can be a value from 1 to 1023 for ADC1/2 and value of @ref ADC_HAL_EC_OVS_RATIO for ADC3*/
+#else
+                                              /* This parameter can be a value of @ref ADC_HAL_EC_OVS_RATIO */
+#endif
+
+  uint32_t RightBitShift;                 /*!< Configures the division coefficient for the Oversampler.
+                                               This parameter can be a value of @ref ADC_HAL_EC_OVS_SHIFT */
+} ADC_InjOversamplingTypeDef;
+
+/**
+  * @brief  Structure definition of ADC group injected and ADC channel affected to ADC group injected
+  * @note   Parameters of this structure are shared within 2 scopes:
+  *          - Scope channel: InjectedChannel, InjectedRank, InjectedSamplingTime , InjectedSingleDiff, InjectedOffsetNumber, InjectedOffset
+  *          - Scope ADC group injected (affects all channels of injected group): InjectedNbrOfConversion, InjectedDiscontinuousConvMode,
+  *            AutoInjectedConv, QueueInjectedContext, ExternalTrigInjecConv, ExternalTrigInjecConvEdge, InjecOversamplingMode, InjecOversampling.
+  * @note   The setting of these parameters by function HAL_ADCEx_InjectedConfigChannel() is conditioned to ADC state.
+  *         ADC state can be either:
+  *          - For all parameters: ADC disabled (this is the only possible ADC state to modify parameter 'InjectedSingleDiff')
+  *          - For parameters 'InjectedDiscontinuousConvMode', 'QueueInjectedContext', 'InjecOversampling': ADC enabled without conversion on going on injected group.
+  *          - For parameters 'InjectedSamplingTime', 'InjectedOffset', 'InjectedOffsetNumber', 'AutoInjectedConv': ADC enabled without conversion on going on regular and injected groups.
+  *          - For parameters 'InjectedChannel', 'InjectedRank', 'InjectedNbrOfConversion', 'ExternalTrigInjecConv', 'ExternalTrigInjecConvEdge': ADC enabled and while conversion on going
+  *            on ADC groups regular and injected.
+  *         If ADC is not in the appropriate state to modify some parameters, these parameters setting is bypassed
+  *         without error reporting (as it can be the expected behavior in case of intended action to update another parameter (which fulfills the ADC state condition) on the fly).
+  */
+typedef struct
+{
+  uint32_t InjectedChannel;               /*!< Specifies the channel to configure into ADC group injected.
+                                               This parameter can be a value of @ref ADC_HAL_EC_CHANNEL
+                                               Note: Depending on devices and ADC instances, some channels may not be available on device package pins. Refer to device datasheet for channels availability. */
+
+  uint32_t InjectedRank;                  /*!< Specifies the rank in the ADC group injected sequencer.
+                                               This parameter must be a value of @ref ADC_INJ_SEQ_RANKS.
+                                               Note: to disable a channel or change order of conversion sequencer, rank containing a previous channel setting can be overwritten by
+                                               the new channel setting (or parameter number of conversions adjusted) */
+
+  uint32_t InjectedSamplingTime;          /*!< Sampling time value to be set for the selected channel.
+                                               Unit: ADC clock cycles.
+                                               Conversion time is the addition of sampling time and processing time
+                                               (12.5 ADC clock cycles at ADC resolution 12 bits, 10.5 cycles at 10 bits, 8.5 cycles at 8 bits, 6.5 cycles at 6 bits).
+                                               This parameter can be a value of @ref ADC_HAL_EC_CHANNEL_SAMPLINGTIME.
+                                               Caution: This parameter applies to a channel that can be used in a regular and/or injected group.
+                                                        It overwrites the last setting.
+                                               Note: In case of usage of internal measurement channels (VrefInt/Vbat/TempSensor),
+                                                     sampling time constraints must be respected (sampling time can be adjusted in function of ADC clock frequency and sampling time setting)
+                                                     Refer to device datasheet for timings values. */
+
+  uint32_t InjectedSingleDiff;            /*!< Selection of single-ended or differential input.
+                                               In differential mode: Differential measurement is between the selected channel 'i' (positive input) and channel 'i+1' (negative input).
+                                               Only channel 'i' has to be configured, channel 'i+1' is configured automatically.
+                                               This parameter must be a value of @ref ADC_HAL_EC_CHANNEL_SINGLE_DIFF_ENDING.
+                                               Caution: This parameter applies to a channel that can be used in a regular and/or injected group.
+                                                        It overwrites the last setting.
+                                               Note: Refer to Reference Manual to ensure the selected channel is available in differential mode.
+                                               Note: When configuring a channel 'i' in differential mode, the channel 'i+1' is not usable separately.
+                                               Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                               If ADC is enabled, this parameter setting is bypassed without error reporting (as it can be the expected behavior in case
+                                               of another parameter update on the fly) */
+
+  uint32_t InjectedOffsetNumber;          /*!< Selects the offset number.
+                                               This parameter can be a value of @ref ADC_HAL_EC_OFFSET_NB.
+                                               Caution: Only one offset is allowed per channel. This parameter overwrites the last setting. */
+
+  uint32_t InjectedOffset;                /*!< Defines the offset to be subtracted from the raw converted data.
+                                               Offset value must be a positive number.
+                                               Maximum value depends on ADC resolution and oversampling ratio (in case of oversampling used).
+                                               This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0x3FFFC00 (corresponding to resolution 16 bit and oversampling ratio 1024).
+                                               Note: This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled
+                                               without continuous mode or external trigger that could launch a conversion). */
+
+  uint32_t InjectedOffsetRightShift;       /*!< Specifies whether the 1 bit Right-shift feature is used or not.
+                                                This parameter is applied only for 16-bit or 8-bit resolution.
+                                                This parameter can be set to ENABLE or DISABLE. */
+#if defined(ADC_VER_V5_V90)
+  uint32_t InjectedOffsetSign;                /*!< Define if the offset should be subtracted (negative sign) or added (positive sign) from or to the raw converted data.
+                                               This parameter can be a value of @ref ADCEx_OffsetSign.
+                                               Note: 
+                                                     - This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled without continuous mode or external trigger that could launch a conversion). 
+                                                     - On devices STM32H72xx and STM32H73xx, this parameter is specific to ADC3 only. */
+  FunctionalState InjectedOffsetSaturation;   /*!< Define if the offset should be saturated upon under or over flow.
+                                               This parameter value can be ENABLE or DISABLE.
+                                               Note: 
+                                                     - This parameter must be modified when no conversion is on going on both regular and injected groups (ADC disabled, or ADC enabled without continuous mode or external trigger that could launch a conversion). 
+                                                     - On devices STM32H72xx and STM32H73xx, this parameter is specific to ADC3 only. */
+
+#endif
+
+  FunctionalState InjectedOffsetSignedSaturation;      /*!< Specifies whether the Signed saturation feature is used or not.
+                                               This parameter is applied only for 16-bit or 8-bit resolution.
+                                               This parameter can be set to ENABLE or DISABLE. */
+
+  uint32_t InjectedNbrOfConversion;       /*!< Specifies the number of ranks that will be converted within the ADC group injected sequencer.
+                                               To use the injected group sequencer and convert several ranks, parameter 'ScanConvMode' must be enabled.
+                                               This parameter must be a number between Min_Data = 1 and Max_Data = 4.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+
+  FunctionalState InjectedDiscontinuousConvMode; /*!< Specifies whether the conversions sequence of ADC group injected is performed in Complete-sequence/Discontinuous-sequence
+                                               (main sequence subdivided in successive parts).
+                                               Discontinuous mode is used only if sequencer is enabled (parameter 'ScanConvMode'). If sequencer is disabled, this parameter is discarded.
+                                               Discontinuous mode can be enabled only if continuous mode is disabled.
+                                               This parameter can be set to ENABLE or DISABLE.
+                                               Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion).
+                                               Note: For injected group, discontinuous mode converts the sequence channel by channel (discontinuous length fixed to 1 rank).
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+
+  FunctionalState AutoInjectedConv;       /*!< Enables or disables the selected ADC group injected automatic conversion after regular one
+                                               This parameter can be set to ENABLE or DISABLE.
+                                               Note: To use Automatic injected conversion, discontinuous mode must be disabled ('DiscontinuousConvMode' and 'InjectedDiscontinuousConvMode' set to DISABLE)
+                                               Note: To use Automatic injected conversion, injected group external triggers must be disabled ('ExternalTrigInjecConv' set to ADC_INJECTED_SOFTWARE_START)
+                                               Note: In case of DMA used with regular group: if DMA configured in normal mode (single shot) JAUTO will be stopped upon DMA transfer complete.
+                                                     To maintain JAUTO always enabled, DMA must be configured in circular mode.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+
+  FunctionalState QueueInjectedContext;   /*!< Specifies whether the context queue feature is enabled.
+                                               This parameter can be set to ENABLE or DISABLE.
+                                               If context queue is enabled, injected sequencer&channels configurations are queued on up to 2 contexts. If a
+                                               new injected context is set when queue is full, error is triggered by interruption and through function
+                                               'HAL_ADCEx_InjectedQueueOverflowCallback'.
+                                               Caution: This feature request that the sequence is fully configured before injected conversion start.
+                                                        Therefore, configure channels with as many calls to HAL_ADCEx_InjectedConfigChannel() as the 'InjectedNbrOfConversion' parameter.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to
+                                                        configure a channel on injected group can impact the configuration of other channels previously set.
+                                               Note: This parameter must be modified when ADC is disabled (before ADC start conversion or after ADC stop conversion). */
+
+  uint32_t ExternalTrigInjecConv;         /*!< Selects the external event used to trigger the conversion start of injected group.
+                                               If set to ADC_INJECTED_SOFTWARE_START, external triggers are disabled and software trigger is used instead.
+                                               This parameter can be a value of @ref ADC_injected_external_trigger_source.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+
+  uint32_t ExternalTrigInjecConvEdge;     /*!< Selects the external trigger edge of injected group.
+                                               This parameter can be a value of @ref ADC_injected_external_trigger_edge.
+                                               If trigger source is set to ADC_INJECTED_SOFTWARE_START, this parameter is discarded.
+                                               Caution: this setting impacts the entire injected group. Therefore, call of HAL_ADCEx_InjectedConfigChannel() to
+                                                        configure a channel on injected group can impact the configuration of other channels previously set. */
+
+  FunctionalState InjecOversamplingMode;         /*!< Specifies whether the oversampling feature is enabled or disabled.
+                                                      This parameter can be set to ENABLE or DISABLE.
+                                                      Note: This parameter can be modified only if there is no conversion is ongoing (both ADSTART and JADSTART cleared). */
+
+  ADC_InjOversamplingTypeDef  InjecOversampling; /*!< Specifies the Oversampling parameters.
+                                                      Caution: this setting overwrites the previous oversampling configuration if oversampling already enabled.
+                                                      Note: This parameter can be modified only if there is no conversion is ongoing (both ADSTART and JADSTART cleared). */
+} ADC_InjectionConfTypeDef;
+
+/**
+  * @brief  Structure definition of ADC multimode
+  * @note   The setting of these parameters by function HAL_ADCEx_MultiModeConfigChannel() is conditioned by ADCs state (both Master and Slave ADCs).
+  *         Both Master and Slave ADCs must be disabled.
+  */
+typedef struct
+{
+  uint32_t Mode;              /*!< Configures the ADC to operate in independent or multimode.
+                                   This parameter can be a value of @ref ADC_HAL_EC_MULTI_MODE. */
+
+  uint32_t DualModeData;      /*!< Configures the Dual ADC Mode Data Format:
+                                   This parameter can be a value of @ref ADCEx_Dual_Mode_Data_Format */
+
+  uint32_t TwoSamplingDelay;  /*!< Configures the Delay between 2 sampling phases.
+                                   This parameter can be a value of @ref ADC_HAL_EC_MULTI_TWOSMP_DELAY.
+                                   Delay range depends on selected resolution:
+                                   from 1 to 9 clock cycles for 16 bits,
+                                   from 1 to 9 clock cycles for 14 bits
+                                   from 1 to 8 clock cycles for 12 bits
+                                   from 1 to 6 clock cycles for 10 bits
+                                   from 1 to 6 clock cycles for 8 bits     */
+} ADC_MultiModeTypeDef;
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup ADCEx_Exported_Constants ADC Extended Exported Constants
+  * @{
+  */
+
+/** @defgroup ADC_injected_external_trigger_source ADC group injected trigger source
+  * @{
+  */
+/* ADC group regular trigger sources for all ADC instances */
+#define ADC_INJECTED_SOFTWARE_START        (LL_ADC_INJ_TRIG_SOFTWARE)            /*!< Software triggers injected group conversion start */
+#define ADC_EXTERNALTRIGINJEC_T1_TRGO      (LL_ADC_INJ_TRIG_EXT_TIM1_TRGO)       /*!< ADC group injected conversion trigger from external peripheral: TIM1 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T1_CC4       (LL_ADC_INJ_TRIG_EXT_TIM1_CH4)        /*!< ADC group injected conversion trigger from external peripheral: TIM1 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T2_TRGO      (LL_ADC_INJ_TRIG_EXT_TIM2_TRGO)       /*!< ADC group injected conversion trigger from external peripheral: TIM2 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T2_CC1       (LL_ADC_INJ_TRIG_EXT_TIM2_CH1)        /*!< ADC group injected conversion trigger from external peripheral: TIM2 channel 1 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T3_CC4       (LL_ADC_INJ_TRIG_EXT_TIM3_CH4)        /*!< ADC group injected conversion trigger from external peripheral: TIM3 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T4_TRGO      (LL_ADC_INJ_TRIG_EXT_TIM4_TRGO)       /*!< ADC group injected conversion trigger from external peripheral: TIM4 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_EXT_IT15     (LL_ADC_INJ_TRIG_EXT_EXTI_LINE15)     /*!< ADC group injected conversion trigger from external peripheral: external interrupt line 15. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T8_CC4       (LL_ADC_INJ_TRIG_EXT_TIM8_CH4)        /*!< ADC group injected conversion trigger from external peripheral: TIM8 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T1_TRGO2     (LL_ADC_INJ_TRIG_EXT_TIM1_TRGO2)      /*!< ADC group injected conversion trigger from external peripheral: TIM1 TRGO2 event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T8_TRGO      (LL_ADC_INJ_TRIG_EXT_TIM8_TRGO)       /*!< ADC group injected conversion trigger from external peripheral: TIM8 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T8_TRGO2     (LL_ADC_INJ_TRIG_EXT_TIM8_TRGO2)      /*!< ADC group injected conversion trigger from external peripheral: TIM8 TRGO2 event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T3_CC3       (LL_ADC_INJ_TRIG_EXT_TIM3_CH3)        /*!< ADC group injected conversion trigger from external peripheral: TIM3 channel 3 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T3_TRGO      (LL_ADC_INJ_TRIG_EXT_TIM3_TRGO)       /*!< ADC group injected conversion trigger from external peripheral: TIM3 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T3_CC1       (LL_ADC_INJ_TRIG_EXT_TIM3_CH1)        /*!< ADC group injected conversion trigger from external peripheral: TIM3 channel 1 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T6_TRGO      (LL_ADC_INJ_TRIG_EXT_TIM6_TRGO)       /*!< ADC group injected conversion trigger from external peripheral: TIM6 TRGO event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_T15_TRGO     (LL_ADC_INJ_TRIG_EXT_TIM15_TRGO)      /*!< ADC group injected conversion trigger from external peripheral: TIM15 TRGO event. Trigger edge set to rising edge (default setting). */
+#if defined(HRTIM1)
+#define ADC_EXTERNALTRIGINJEC_HR1_ADCTRG2  (LL_ADC_INJ_TRIG_EXT_HRTIM_TRG2)      /*!< ADC group injected conversion trigger from external peripheral: HRTIM1 TRG2 event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_HR1_ADCTRG4  (LL_ADC_INJ_TRIG_EXT_HRTIM_TRG4)      /*!< ADC group injected conversion trigger from external peripheral: HRTIM1 TRG4 event. Trigger edge set to rising edge (default setting). */
+#endif /* HRTIM1 */
+#define ADC_EXTERNALTRIGINJEC_LPTIM1_OUT   (LL_ADC_INJ_TRIG_EXT_LPTIM1_OUT)      /*!< ADC group injected conversion trigger from external peripheral: LPTIM1 OUT event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_LPTIM2_OUT   (LL_ADC_INJ_TRIG_EXT_LPTIM2_OUT)      /*!< ADC group injected conversion trigger from external peripheral: LPTIM2 OUT event. Trigger edge set to rising edge (default setting). */
+#define ADC_EXTERNALTRIGINJEC_LPTIM3_OUT   (LL_ADC_INJ_TRIG_EXT_LPTIM3_OUT)      /*!< ADC group injected conversion trigger from external peripheral: LPTIM3 OUT event. Trigger edge set to rising edge (default setting). */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_injected_external_trigger_edge ADC group injected trigger edge (when external trigger is selected)
+  * @{
+  */
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           (0x00000000UL)        /*!< Injected conversions hardware trigger detection disabled                             */
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_RISING         (ADC_JSQR_JEXTEN_0)   /*!< Injected conversions hardware trigger detection on the rising edge                   */
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_FALLING        (ADC_JSQR_JEXTEN_1)   /*!< Injected conversions hardware trigger detection on the falling edge                  */
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_RISINGFALLING  (ADC_JSQR_JEXTEN)     /*!< Injected conversions hardware trigger detection on both the rising and falling edges */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_CHANNEL_SINGLE_DIFF_ENDING  Channel - Single or differential ending
+  * @{
+  */
+#define ADC_SINGLE_ENDED                (LL_ADC_SINGLE_ENDED)         /*!< ADC channel ending set to single ended (literal also used to set calibration mode) */
+#define ADC_DIFFERENTIAL_ENDED          (LL_ADC_DIFFERENTIAL_ENDED)   /*!< ADC channel ending set to differential (literal also used to set calibration mode) */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_OFFSET_NB  ADC instance - Offset number
+  * @{
+  */
+#define ADC_OFFSET_NONE              (ADC_OFFSET_4 + 1U) /*!< ADC offset disabled: no offset correction for the selected ADC channel */
+#define ADC_OFFSET_1                 (LL_ADC_OFFSET_1) /*!< ADC offset number 1: ADC channel and offset level to which the offset programmed will be applied (independently of channel mapped on ADC group regular or group injected) */
+#define ADC_OFFSET_2                 (LL_ADC_OFFSET_2) /*!< ADC offset number 2: ADC channel and offset level to which the offset programmed will be applied (independently of channel mapped on ADC group regular or group injected) */
+#define ADC_OFFSET_3                 (LL_ADC_OFFSET_3) /*!< ADC offset number 3: ADC channel and offset level to which the offset programmed will be applied (independently of channel mapped on ADC group regular or group injected) */
+#define ADC_OFFSET_4                 (LL_ADC_OFFSET_4) /*!< ADC offset number 4: ADC channel and offset level to which the offset programmed will be applied (independently of channel mapped on ADC group regular or group injected) */
+/**
+  * @}
+  */
+
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADCEx_OffsetSign ADC Extended Offset Sign
+  * @{
+  */
+#define ADC3_OFFSET_SIGN_NEGATIVE      (0x00000000UL)          /*!< Offset sign negative, offset is subtracted */
+#define ADC3_OFFSET_SIGN_POSITIVE      (ADC3_OFR1_OFFSETPOS)   /*!< Offset sign positive, offset is added  */
+/**
+  * @}
+  */
+#endif
+
+/** @defgroup ADC_INJ_SEQ_RANKS  ADC group injected - Sequencer ranks
+  * @{
+  */
+#define ADC_INJECTED_RANK_1                (LL_ADC_INJ_RANK_1) /*!< ADC group injected sequencer rank 1 */
+#define ADC_INJECTED_RANK_2                (LL_ADC_INJ_RANK_2) /*!< ADC group injected sequencer rank 2 */
+#define ADC_INJECTED_RANK_3                (LL_ADC_INJ_RANK_3) /*!< ADC group injected sequencer rank 3 */
+#define ADC_INJECTED_RANK_4                (LL_ADC_INJ_RANK_4) /*!< ADC group injected sequencer rank 4 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_MULTI_MODE  Multimode - Mode
+  * @{
+  */
+#define ADC_MODE_INDEPENDENT               (LL_ADC_MULTI_INDEPENDENT)                                          /*!< ADC dual mode disabled (ADC independent mode) */
+#define ADC_DUALMODE_REGSIMULT             (LL_ADC_MULTI_DUAL_REG_SIMULT) /*!< ADC dual mode enabled: group regular simultaneous */
+#define ADC_DUALMODE_INTERL                (LL_ADC_MULTI_DUAL_REG_INTERL) /*!< ADC dual mode enabled: Combined group regular interleaved */
+#define ADC_DUALMODE_INJECSIMULT           (LL_ADC_MULTI_DUAL_INJ_SIMULT) /*!< ADC dual mode enabled: group injected simultaneous */
+#define ADC_DUALMODE_ALTERTRIG             (LL_ADC_MULTI_DUAL_INJ_ALTERN) /*!< ADC dual mode enabled: group injected alternate trigger. Works only with external triggers (not internal SW start) */
+#define ADC_DUALMODE_REGSIMULT_INJECSIMULT (LL_ADC_MULTI_DUAL_REG_SIM_INJ_SIM) /*!< ADC dual mode enabled: Combined group regular simultaneous + group injected simultaneous */
+#define ADC_DUALMODE_REGSIMULT_ALTERTRIG   (LL_ADC_MULTI_DUAL_REG_SIM_INJ_ALT) /*!< ADC dual mode enabled: Combined group regular simultaneous + group injected alternate trigger */
+#define ADC_DUALMODE_REGINTERL_INJECSIMULT (LL_ADC_MULTI_DUAL_REG_INT_INJ_SIM) /*!< ADC dual mode enabled: Combined group regular interleaved + group injected simultaneous */
+
+/** @defgroup ADCEx_Dual_Mode_Data_Format ADC Extended Dual Mode Data Formatting
+  * @{
+  */
+#define ADC_DUALMODEDATAFORMAT_DISABLED      (0x00000000UL)                       /*!< Dual ADC mode without data packing: ADCx_CDR and ADCx_CDR2 registers not used */
+#define ADC_DUALMODEDATAFORMAT_32_10_BITS    (ADC_CCR_DAMDF_1)                    /*!< Data formatting mode for 32 down to 10-bit resolution */
+#define ADC_DUALMODEDATAFORMAT_8_BITS        ((ADC_CCR_DAMDF_0 |ADC_CCR_DAMDF_1)) /*!< Data formatting mode for 8-bit resolution */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_MULTI_TWOSMP_DELAY  Multimode - Delay between two sampling phases
+  * @{
+  */
+#define ADC_TWOSAMPLINGDELAY_1CYCLE        (LL_ADC_MULTI_TWOSMP_DELAY_1CYCLE_5)   /*!< ADC multimode delay between two sampling phases: 1 ADC clock cycle */
+#define ADC_TWOSAMPLINGDELAY_2CYCLES       (LL_ADC_MULTI_TWOSMP_DELAY_2CYCLES_5)  /*!< ADC multimode delay between two sampling phases: 2 ADC clock cycles */
+#define ADC_TWOSAMPLINGDELAY_3CYCLES       (LL_ADC_MULTI_TWOSMP_DELAY_3CYCLES_5)  /*!< ADC multimode delay between two sampling phases: 3 ADC clock cycles */
+#define ADC_TWOSAMPLINGDELAY_4CYCLES       (LL_ADC_MULTI_TWOSMP_DELAY_4CYCLES_5)  /*!< ADC multimode delay between two sampling phases: 4 ADC clock cycles */
+#define ADC_TWOSAMPLINGDELAY_5CYCLES       (LL_ADC_MULTI_TWOSMP_DELAY_5CYCLES_5)  /*!< ADC multimode delay between two sampling phases: 5 ADC clock cycles */
+#define ADC_TWOSAMPLINGDELAY_6CYCLES       (LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES_5)  /*!< ADC multimode delay between two sampling phases: 6 ADC clock cycles */
+#define ADC_TWOSAMPLINGDELAY_7CYCLES       (LL_ADC_MULTI_TWOSMP_DELAY_7CYCLES_5)  /*!< ADC multimode delay between two sampling phases: 7 ADC clock cycles */
+#define ADC_TWOSAMPLINGDELAY_8CYCLES       (LL_ADC_MULTI_TWOSMP_DELAY_8CYCLES)   /*!< ADC multimode delay between two sampling phases: 8 ADC clock cycles */
+#define ADC_TWOSAMPLINGDELAY_9CYCLES       (LL_ADC_MULTI_TWOSMP_DELAY_9CYCLES)   /*!< ADC multimode delay between two sampling phases: 9 ADC clock cycles */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_HAL_EC_GROUPS  ADC instance - Groups
+  * @{
+  */
+#define ADC_REGULAR_GROUP                  (LL_ADC_GROUP_REGULAR)           /*!< ADC group regular (available on all STM32 devices) */
+#define ADC_INJECTED_GROUP                 (LL_ADC_GROUP_INJECTED)          /*!< ADC group injected (not available on all STM32 devices)*/
+#define ADC_REGULAR_INJECTED_GROUP         (LL_ADC_GROUP_REGULAR_INJECTED)  /*!< ADC both groups regular and injected */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_CFGR_fields ADCx CFGR fields
+  * @{
+  */
+#define ADC_CFGR_FIELDS    (ADC_CFGR_AWD1CH  | ADC_CFGR_JAUTO   | ADC_CFGR_JAWD1EN |\
+                            ADC_CFGR_AWD1EN  | ADC_CFGR_AWD1SGL | ADC_CFGR_JQM     |\
+                            ADC_CFGR_JDISCEN | ADC_CFGR_DISCNUM | ADC_CFGR_DISCEN  |\
+                            ADC_CFGR_AUTDLY  | ADC_CFGR_CONT    | ADC_CFGR_OVRMOD  |\
+                            ADC_CFGR_EXTEN   | ADC_CFGR_EXTSEL  | ADC_CFGR_ALIGN   |\
+                            ADC_CFGR_RES     | ADC_CFGR_DMACFG  | ADC_CFGR_DMAEN   )
+/**
+  * @}
+  */
+
+/** @defgroup ADC_SMPR1_fields ADCx SMPR1 fields
+  * @{
+  */
+#define ADC_SMPR1_FIELDS    (ADC_SMPR1_SMP9 | ADC_SMPR1_SMP8 | ADC_SMPR1_SMP7 |\
+                             ADC_SMPR1_SMP6 | ADC_SMPR1_SMP5 | ADC_SMPR1_SMP4 |\
+                             ADC_SMPR1_SMP3 | ADC_SMPR1_SMP2 | ADC_SMPR1_SMP1 |\
+                             ADC_SMPR1_SMP0)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_CFGR_fields_2 ADCx CFGR sub fields
+  * @{
+  */
+/* ADC_CFGR fields of parameters that can be updated when no conversion
+   (neither regular nor injected) is on-going  */
+#define ADC_CFGR_FIELDS_2  ((uint32_t)(ADC_CFGR_DMNGT | ADC_CFGR_AUTDLY))
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_CFGR_fields_2 ADCx CFGR sub fields
+  * @{
+  */
+/* ADC_CFGR fields of parameters that can be updated when no conversion
+   (neither regular nor injected) is on-going  */
+#define ADC3_CFGR_FIELDS_2  ((ADC3_CFGR_DMACFG | ADC_CFGR_AUTDLY))
+/**
+  * @}
+  */
+#endif
+
+#if defined(DFSDM1_Channel0)
+/** @defgroup ADC_HAL_EC_REG_DFSDM_TRANSFER ADC group regular - DFSDM transfer of ADC conversion data
+  * @{
+  */
+#define ADC_DFSDM_MODE_DISABLE     (0x00000000UL)                     /*!< ADC conversions are not transferred by DFSDM. */
+#define ADC_DFSDM_MODE_ENABLE      (LL_ADC_REG_DFSDM_TRANSFER_ENABLE) /*!< ADC conversion data are transferred to DFSDM for post processing. The ADC conversion data format must be 16-bit signed and right aligned, refer to reference manual. DFSDM transfer cannot be used if DMA transfer is enabled. */
+/**
+  * @}
+  */
+#endif
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup ADCEx_Exported_Macro ADC Extended Exported Macros
+  * @{
+  */
+
+/** @brief  Force ADC instance in multimode mode independent (multimode disable).
+  * @note   This macro must be used only in case of transition from multimode
+  *         to mode independent and in case of unknown previous state,
+  *         to ensure ADC configuration is in mode independent.
+  * @note   Standard way of multimode configuration change is done from
+  *         HAL ADC handle of ADC master using function
+  *         "HAL_ADCEx_MultiModeConfigChannel(..., ADC_MODE_INDEPENDENT)" )".
+  *         Usage of this macro is not the Standard way of multimode
+  *         configuration and can lead to have HAL ADC handles status
+  *         misaligned. Usage of this macro must be limited to cases
+  *         mentioned above.
+  * @param __HANDLE__ ADC handle.
+  * @retval None
+  */
+#define ADC_FORCE_MODE_INDEPENDENT(__HANDLE__)                                 \
+  LL_ADC_SetMultimode(__LL_ADC_COMMON_INSTANCE((__HANDLE__)->Instance), LL_ADC_MULTI_INDEPENDENT)
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+
+/** @defgroup ADCEx_Private_Macro_internal_HAL_driver ADC Extended Private Macros
+  * @{
+  */
+/* Macro reserved for internal HAL driver usage, not intended to be used in   */
+/* code of final user.                                                        */
+
+/**
+  * @brief Test if conversion trigger of injected group is software start
+  *        or external trigger.
+  * @param __HANDLE__ ADC handle.
+  * @retval SET (software start) or RESET (external trigger).
+  */
+#define ADC_IS_SOFTWARE_START_INJECTED(__HANDLE__)                             \
+  (((__HANDLE__)->Instance->JSQR & ADC_JSQR_JEXTEN) == 0UL)
+
+/**
+  * @brief Check if conversion is on going on regular or injected groups.
+  * @param __HANDLE__ ADC handle.
+  * @retval SET (conversion is on going) or RESET (no conversion is on going).
+  */
+#define ADC_IS_CONVERSION_ONGOING_REGULAR_INJECTED(__HANDLE__)                       \
+       (( (((__HANDLE__)->Instance->CR) & (ADC_CR_ADSTART | ADC_CR_JADSTART)) == 0UL \
+        ) ? RESET : SET)
+
+/**
+  * @brief Check if conversion is on going on injected group.
+  * @param __HANDLE__ ADC handle.
+  * @retval Value "0" (no conversion is on going) or value "1" (conversion is on going)
+  */
+#define ADC_IS_CONVERSION_ONGOING_INJECTED(__HANDLE__)                         \
+  (LL_ADC_INJ_IsConversionOngoing((__HANDLE__)->Instance))
+
+
+#if defined (ADC3)
+/**
+  * @brief Check whether or not ADC is independent.
+  * @param __HANDLE__ ADC handle.
+  * @note  When multimode feature is not available, the macro always returns SET.
+  * @retval SET (ADC is independent) or RESET (ADC is not).
+  */
+
+#define ADC_IS_INDEPENDENT(__HANDLE__)    \
+  ( ( ( ((__HANDLE__)->Instance) == ADC3) \
+    )?                                    \
+     SET                                  \
+     :                                    \
+     RESET                                \
+  )
+#endif
+
+/**
+  * @brief Set the selected injected Channel rank.
+  * @param __CHANNELNB__ Channel number.
+  * @param __RANKNB__ Rank number.
+  * @retval None
+  */
+#define ADC_JSQR_RK(__CHANNELNB__, __RANKNB__) ((((__CHANNELNB__) & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << ((__RANKNB__) & ADC_INJ_RANK_ID_JSQR_MASK))
+
+/**
+  * @brief Configure ADC injected context queue
+  * @param __INJECT_CONTEXT_QUEUE_MODE__ Injected context queue mode.
+  * @retval None
+  */
+#define ADC_CFGR_INJECT_CONTEXT_QUEUE(__INJECT_CONTEXT_QUEUE_MODE__) ((__INJECT_CONTEXT_QUEUE_MODE__) << ADC_CFGR_JQM_Pos)
+
+/**
+  * @brief Configure ADC discontinuous conversion mode for injected group
+  * @param __INJECT_DISCONTINUOUS_MODE__ Injected discontinuous mode.
+  * @retval None
+  */
+#define ADC_CFGR_INJECT_DISCCONTINUOUS(__INJECT_DISCONTINUOUS_MODE__) ((__INJECT_DISCONTINUOUS_MODE__) <<  ADC_CFGR_JDISCEN_Pos)
+
+/**
+  * @brief Configure ADC discontinuous conversion mode for regular group
+  * @param __REG_DISCONTINUOUS_MODE__ Regular discontinuous mode.
+  * @retval None
+  */
+#define ADC_CFGR_REG_DISCONTINUOUS(__REG_DISCONTINUOUS_MODE__) ((__REG_DISCONTINUOUS_MODE__) << ADC_CFGR_DISCEN_Pos)
+
+/**
+  * @brief Configure the number of discontinuous conversions for regular group.
+  * @param __NBR_DISCONTINUOUS_CONV__ Number of discontinuous conversions.
+  * @retval None
+  */
+#define ADC_CFGR_DISCONTINUOUS_NUM(__NBR_DISCONTINUOUS_CONV__) (((__NBR_DISCONTINUOUS_CONV__) - 1UL) << ADC_CFGR_DISCNUM_Pos)
+
+/**
+  * @brief Configure the ADC auto delay mode.
+  * @param __AUTOWAIT__ Auto delay bit enable or disable.
+  * @retval None
+  */
+#define ADC_CFGR_AUTOWAIT(__AUTOWAIT__) ((__AUTOWAIT__) << ADC_CFGR_AUTDLY_Pos)
+
+/**
+  * @brief Configure ADC continuous conversion mode.
+  * @param __CONTINUOUS_MODE__ Continuous mode.
+  * @retval None
+  */
+#define ADC_CFGR_CONTINUOUS(__CONTINUOUS_MODE__) ((__CONTINUOUS_MODE__) << ADC_CFGR_CONT_Pos)
+
+/**
+  * @brief Enable the ADC DMA continuous request.
+  * @param __DMACONTREQ_MODE__: DMA continuous request mode.
+  * @retval None
+  */
+#define ADC_CFGR_DMACONTREQ(__DMACONTREQ_MODE__) ((__DMACONTREQ_MODE__))
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief Configure the ADC DMA continuous request.
+  * @param __DMACONTREQ_MODE__ DMA continuous request mode.
+  * @retval None
+  */
+#define ADC3_CFGR_DMACONTREQ(__DMACONTREQ_MODE__) ((__DMACONTREQ_MODE__) <<  ADC3_CFGR_DMACFG_Pos)
+#endif
+/**
+  * @brief Configure the channel number into offset OFRx register.
+  * @param __CHANNEL__ ADC Channel.
+  * @retval None
+  */
+#define ADC_OFR_CHANNEL(__CHANNEL__) ((__CHANNEL__) << ADC_OFR1_OFFSET1_CH_Pos)
+
+/**
+  * @brief Configure the channel number into differential mode selection register.
+  * @param __CHANNEL__ ADC Channel.
+  * @retval None
+  */
+#define ADC_DIFSEL_CHANNEL(__CHANNEL__) (1UL << (__CHANNEL__))
+
+/**
+  * @brief Configure calibration factor in differential mode to be set into calibration register.
+  * @param __CALIBRATION_FACTOR__ Calibration factor value.
+  * @retval None
+  */
+#define ADC_CALFACT_DIFF_SET(__CALIBRATION_FACTOR__) (((__CALIBRATION_FACTOR__) & (ADC_CALFACT_CALFACT_D_Pos >> ADC_CALFACT_CALFACT_D_Pos) ) << ADC_CALFACT_CALFACT_D_Pos)
+
+/**
+  * @brief Calibration factor in differential mode to be retrieved from calibration register.
+  * @param __CALIBRATION_FACTOR__ Calibration factor value.
+  * @retval None
+  */
+#define ADC_CALFACT_DIFF_GET(__CALIBRATION_FACTOR__) ((__CALIBRATION_FACTOR__) >> ADC_CALFACT_CALFACT_D_Pos)
+
+/**
+  * @brief Configure the analog watchdog high threshold into registers TR1, TR2 or TR3.
+  * @param __THRESHOLD__ Threshold value.
+  * @retval None
+  */
+#define ADC_TRX_HIGHTHRESHOLD(__THRESHOLD__) ((__THRESHOLD__) << 16UL)
+
+/**
+  * @brief Configure the ADC DMA continuous request for ADC multimode.
+  * @param __DMACONTREQ_MODE__ DMA continuous request mode.
+  * @retval None
+  */
+#define ADC_CCR_MULTI_DMACONTREQ(__DMACONTREQ_MODE__) ((__DMACONTREQ_MODE__) << ADC_CCR_DMACFG_Pos)
+
+/**
+  * @brief Shift the offset in function of the selected ADC resolution.
+  * @note  Offset has to be left-aligned on bit 15, the LSB (right bits) are set to 0
+  *        If resolution 16 bits, no shift.
+  *        If resolution 14 bits, shift of 2 ranks on the left.
+  *        If resolution 12 bits, shift of 4 ranks on the left.
+  *        If resolution 10 bits, shift of 6 ranks on the left.
+  *        If resolution 8 bits, shift of 8 ranks on the left.
+  *        therefore, shift = (16 - resolution) = 16 - (16 - (((RES[2:0]) >> 2)*2))
+  * @param __HANDLE__: ADC handle
+  * @param __OFFSET__: Value to be shifted
+  * @retval None
+  */
+#if defined(ADC_VER_V5_3)
+#define ADC_OFFSET_SHIFT_RESOLUTION(__HANDLE__, __OFFSET__)                                                     \
+        (                                                                                                       \
+           ((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES_2) == 0UL)                                           \
+              ? ((__OFFSET__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                   \
+               :                                                                                                \
+               ((__OFFSET__)<<(((((__HANDLE__)->Instance->CFGR) & (ADC_CFGR_RES & 0xFFFFFFF3UL))>> 2UL )*2UL))  \
+        )
+#else
+#define ADC_OFFSET_SHIFT_RESOLUTION(__HANDLE__, __OFFSET__)                                                     \
+        (((DBGMCU->IDCODE & 0xF0000000UL) == 0x10000000UL)                                                      \
+          ? ((__OFFSET__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                       \
+             :                                                                                                  \
+            ((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES_2) == 0UL)                                          \
+              ? ((__OFFSET__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                   \
+               :                                                                                                \
+               ((__OFFSET__)<<(((((__HANDLE__)->Instance->CFGR) & (ADC_CFGR_RES & 0xFFFFFFF3UL))>> 2UL )*2UL))  \
+        )
+#endif /* ADC_VER_V5_3 */
+
+#if defined(ADC_VER_V5_V90)
+#define ADC3_OFFSET_SHIFT_RESOLUTION(__HANDLE__, __OFFSET__) \
+        ((__OFFSET__) << ((((__HANDLE__)->Instance->CFGR & ADC3_CFGR_RES) >> 3UL) * 2UL))
+
+#endif /* ADC_VER_V5_V90 */
+
+/**
+  * @brief Shift the AWD1 threshold in function of the selected ADC resolution.
+  * @note  Thresholds have to be left-aligned on bit 15, the LSB (right bits) are set to 0.
+  *        If resolution 16 bits, no shift.
+  *        If resolution 14 bits, shift of 2 ranks on the left.
+  *        If resolution 12 bits, shift of 4 ranks on the left.
+  *        If resolution 10 bits, shift of 6 ranks on the left.
+  *        If resolution 8 bits, shift of 8 ranks on the left.
+  *        therefore, shift = (16 - resolution) = 16 - (16- (((RES[2:0]) >> 2)*2))
+  * @param __HANDLE__: ADC handle
+  * @param __THRESHOLD__: Value to be shifted
+  * @retval None
+  */
+#if defined(ADC_VER_V5_3)
+#if defined(ADC_VER_V5_V90)
+#define ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__)                                           \
+        (  ((__HANDLE__)->Instance == ADC3)                                                                       \
+             ?((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & ADC3_CFGR_RES)>> 3UL)*2UL))                     \
+               :                                                                                                   \
+              ((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES_2) == 0UL)                                          \
+               ?((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                    \
+                :                                                                                                   \
+                ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & (ADC_CFGR_RES & 0xFFFFFFF3UL))>> 2UL )*2UL))  \
+        )
+#else
+#define ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__)                                             \
+        (                                                                                                         \
+           ((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES_2) == 0UL)                                             \
+            ? ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                    \
+              :                                                                                                   \
+              ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & (ADC_CFGR_RES & 0xFFFFFFF3UL))>> 2UL )*2UL))  \
+        )
+#endif
+
+#else
+#define ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__)                                             \
+        (((DBGMCU->IDCODE & 0xF0000000UL) == 0x10000000UL)                                                        \
+         ? ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                       \
+            :                                                                                                     \
+           ((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES_2) == 0UL)                                             \
+            ? ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                    \
+              :                                                                                                   \
+              ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & (ADC_CFGR_RES & 0xFFFFFFF3UL))>> 2UL )*2UL))  \
+        )
+#endif /* ADC_VER_V5_3 */
+
+/**
+  * @brief Shift the AWD2 and AWD3 threshold in function of the selected ADC resolution.
+  * @note  Thresholds have to be left-aligned on bit 15, the LSB (right bits) are set to 0.
+  *        If resolution 16 bits, no shift.
+  *        If resolution 14 bits, shift of 2 ranks on the left.
+  *        If resolution 12 bits, shift of 4 ranks on the left.
+  *        If resolution 10 bits, shift of 6 ranks on the left.
+  *        If resolution 8 bits, shift of 8 ranks on the left.
+  *        therefore, shift = (16 - resolution) = 16 - (16- (((RES[2:0]) >> 2)*2))
+  * @param __HANDLE__: ADC handle
+  * @param __THRESHOLD__: Value to be shifted
+  * @retval None
+  */
+#if defined(ADC_VER_V5_3) || defined(ADC_VER_V5_V90)
+#define ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__)                                           \
+        (                                                                                                           \
+            ((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES_2) == 0UL)                                              \
+              ? ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                    \
+                :                                                                                                   \
+                ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & (ADC_CFGR_RES & 0xFFFFFFF3UL))>> 2UL )*2UL))  \
+        )
+#else
+#define ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(__HANDLE__, __THRESHOLD__)                                              \
+        (((DBGMCU->IDCODE & 0xF0000000UL) == 0x10000000UL)                                                          \
+          ? ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                        \
+            :                                                                                                       \
+            ((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES_2) == 0UL)                                              \
+              ? ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & ADC_CFGR_RES)>> 2UL)*2UL))                    \
+                :                                                                                                   \
+                ((__THRESHOLD__)<<(((((__HANDLE__)->Instance->CFGR) & (ADC_CFGR_RES & 0xFFFFFFF3UL))>> 2UL )*2UL))  \
+        )
+#endif /* ADC_VER_V5_3 */
+/**
+  * @brief Clear Common Control Register.
+  * @param __HANDLE__ ADC handle.
+  * @retval None
+  */
+/**
+  * @brief Report common register to ADC1 and ADC2
+  * @param __HANDLE__: ADC handle
+  * @retval Common control register
+  */
+#define ADC12_COMMON_REGISTER(__HANDLE__)   (ADC12_COMMON)
+#if defined (ADC3)
+/**
+  * @brief Report common register to ADC3
+  * @param __HANDLE__: ADC handle
+  * @retval Common control register
+  */
+#define ADC3_COMMON_REGISTER(__HANDLE__)   (ADC3_COMMON)
+#endif
+/**
+  * @brief Report Master Instance
+  * @param __HANDLE__: ADC handle
+  * @note return same instance if ADC of input handle is independent ADC
+  * @retval Master Instance
+  */
+#if defined (ADC3)
+#define ADC_MASTER_REGISTER(__HANDLE__)                                          \
+  ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC3)) \
+    )?                                                                           \
+     ((__HANDLE__)->Instance)                                                    \
+     :                                                                           \
+     (ADC1)                                                                      \
+  )
+#else
+#define ADC_MASTER_REGISTER(__HANDLE__) ( (ADC1))
+#endif
+
+/**
+  * @brief Check whether or not dual regular conversions are enabled
+  * @param __HANDLE__: ADC handle
+  * @retval SET (dual regular conversions are enabled) or RESET (ADC is independent or no dual regular conversions are enabled)
+  */
+#define ADC_IS_DUAL_REGULAR_CONVERSION_ENABLE(__HANDLE__)                        \
+  ( ( ((((__HANDLE__)->Instance) == ADC1) || (((__HANDLE__)->Instance) == ADC2)) \
+    )?                                                                           \
+     ( ((ADC12_COMMON->CCR & ADC_CCR_DUAL) != ADC_MODE_INDEPENDENT)     &&       \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) != ADC_DUALMODE_INJECSIMULT) &&       \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) != ADC_DUALMODE_ALTERTRIG) )          \
+     :                                                                           \
+     RESET                                                                       \
+  )
+
+/**
+  * @brief Verification of condition for ADC start conversion: ADC must be in non-MultiMode or MultiMode with handle of ADC master
+  * @param __HANDLE__: ADC handle
+  * @retval SET (non-MultiMode or Master handle) or RESET (handle of Slave ADC in MultiMode)
+  */
+#define ADC12_NONMULTIMODE_OR_MULTIMODEMASTER(__HANDLE__)                      \
+  ( ( ((__HANDLE__)->Instance == ADC1) || ((__HANDLE__)->Instance == ADC2)     \
+    )?                                                                         \
+     SET                                                                       \
+     :                                                                         \
+     ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == RESET)                             \
+  )
+#if defined (ADC3)
+/**
+  * @brief Verification of condition for ADC start conversion: ADC must be in non-MultiMode or MultiMode with handle of ADC master
+  * @param __HANDLE__: ADC handle
+  * @retval SET (non-MultiMode or Master handle) or RESET (handle of Slave ADC in MultiMode)
+  */
+#define ADC3_NONMULTIMODE_OR_MULTIMODEMASTER(__HANDLE__)                        \
+  ( ( ((__HANDLE__)->Instance == ADC3)                                          \
+    )?                                                                          \
+     SET                                                                        \
+     :                                                                          \
+     ((ADC3_COMMON->CCR & ADC_CCR_DUAL) == RESET)                              \
+  )
+#endif
+/**
+  * @brief Ensure ADC Instance is Independent or Master, or is not Slave ADC with dual regular conversions enabled
+  * @param __HANDLE__: ADC handle
+  * @retval SET (Independent or Master, or Slave without dual regular conversions enabled) or RESET (Slave ADC with dual regular conversions enabled)
+  */
+#if defined (ADC3)
+#define ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(__HANDLE__)            \
+  ( ( ((__HANDLE__)->Instance == ADC1) || ((__HANDLE__)->Instance == ADC3)  \
+    )?                                                                      \
+     SET                                                                    \
+     :                                                                      \
+     ( ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_MODE_INDEPENDENT)     ||  \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_INJECSIMULT) ||  \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_ALTERTRIG) ))
+#else
+#define ADC_INDEPENDENT_OR_NONMULTIMODEREGULAR_SLAVE(__HANDLE__)            \
+  ( ( ((__HANDLE__)->Instance == ADC1)                                      \
+    )?                                                                      \
+     SET                                                                    \
+     :                                                                      \
+     ( ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_MODE_INDEPENDENT)     ||  \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_INJECSIMULT) ||  \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_ALTERTRIG) ))
+#endif
+
+/**
+  * @brief Ensure ADC Instance is Independent or Master, or is not Slave ADC with dual injected conversions enabled
+  * @param __HANDLE__: ADC handle
+  * @retval SET (non-MultiMode or Master, or Slave without dual injected conversions enabled) or RESET (Slave ADC with dual injected conversions enabled)
+  */
+#if defined (ADC3)
+#define ADC_INDEPENDENT_OR_NONMULTIMODEINJECTED_SLAVE(__HANDLE__)          \
+  ( ( ((__HANDLE__)->Instance == ADC1) || ((__HANDLE__)->Instance == ADC3) \
+    )?                                                                     \
+     SET                                                                   \
+     :                                                                     \
+     ( ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_MODE_INDEPENDENT)    ||  \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_REGSIMULT)  ||  \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_INTERL) ))
+#else
+#define ADC_INDEPENDENT_OR_NONMULTIMODEINJECTED_SLAVE(__HANDLE__)          \
+  ( ( ((__HANDLE__)->Instance == ADC1)                                     \
+    )?                                                                     \
+     SET                                                                   \
+     :                                                                     \
+     ( ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_MODE_INDEPENDENT)    ||  \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_REGSIMULT)  ||  \
+       ((ADC12_COMMON->CCR & ADC_CCR_DUAL) == ADC_DUALMODE_INTERL) ))
+#endif
+
+#define ADC_CLEAR_COMMON_CONTROL_REGISTER(__HANDLE__) CLEAR_BIT(__LL_ADC_COMMON_INSTANCE((__HANDLE__)->Instance)->CCR, ADC_CCR_CKMODE    | \
+                                                                                                      ADC_CCR_PRESC     | \
+                                                                                                      ADC_CCR_VBATEN    | \
+                                                                                                      ADC_CCR_TSEN      | \
+                                                                                                      ADC_CCR_VREFEN    | \
+                                                                                                      ADC_CCR_DAMDF     | \
+                                                                                                      ADC_CCR_DELAY     | \
+                                                                                                      ADC_CCR_DUAL  )
+
+/**
+  * @brief Set handle instance of the ADC slave associated to the ADC master.
+  * @param __HANDLE_MASTER__ ADC master handle.
+  * @param __HANDLE_SLAVE__ ADC slave handle.
+  * @note if __HANDLE_MASTER__ is the handle of a slave ADC (ADC2) or an independent ADC, __HANDLE_SLAVE__ instance is set to NULL.
+  * @retval None
+  */
+#define ADC_MULTI_SLAVE(__HANDLE_MASTER__, __HANDLE_SLAVE__)             \
+  ( (((__HANDLE_MASTER__)->Instance == ADC1)) ? ((__HANDLE_SLAVE__)->Instance = ADC2) : ((__HANDLE_SLAVE__)->Instance = NULL) )
+
+
+/**
+  * @brief Verify the ADC instance connected to the temperature sensor.
+  * @param __HANDLE__ ADC handle.
+  * @retval SET (ADC instance is valid) or RESET (ADC instance is invalid)
+  */
+#if defined(ADC3)
+#define ADC_TEMPERATURE_SENSOR_INSTANCE(__HANDLE__)  (((__HANDLE__)->Instance) == ADC3)
+#else
+#define ADC_TEMPERATURE_SENSOR_INSTANCE(__HANDLE__)  (((__HANDLE__)->Instance) == ADC2)
+#endif
+
+/**
+  * @brief Verify the ADC instance connected to the battery voltage VBAT.
+  * @param __HANDLE__ ADC handle.
+  * @retval SET (ADC instance is valid) or RESET (ADC instance is invalid)
+  */
+#if defined(ADC3)
+#define ADC_BATTERY_VOLTAGE_INSTANCE(__HANDLE__)  (((__HANDLE__)->Instance) == ADC3)
+#else
+#define ADC_BATTERY_VOLTAGE_INSTANCE(__HANDLE__)  (((__HANDLE__)->Instance) == ADC2)
+#endif
+
+/**
+  * @brief Verify the ADC instance connected to the internal voltage reference VREFINT.
+  * @param __HANDLE__ ADC handle.
+  * @retval SET (ADC instance is valid) or RESET (ADC instance is invalid)
+  */
+#if defined(ADC3)
+#define ADC_VREFINT_INSTANCE(__HANDLE__)  (((__HANDLE__)->Instance) == ADC3)
+#else
+#define ADC_VREFINT_INSTANCE(__HANDLE__)  (((__HANDLE__)->Instance) == ADC2)
+#endif
+
+/**
+  * @brief Verify the length of scheduled injected conversions group.
+  * @param __LENGTH__ number of programmed conversions.
+  * @retval SET (__LENGTH__ is within the maximum number of possible programmable injected conversions) or RESET (__LENGTH__ is null or too large)
+  */
+#define IS_ADC_INJECTED_NB_CONV(__LENGTH__) (((__LENGTH__) >= (1U)) && ((__LENGTH__) <= (4U)))
+
+/**
+  * @brief Calibration factor size verification (11 bits maximum).
+  * @param __CALIBRATION_FACTOR__ Calibration factor value.
+  * @retval SET (__CALIBRATION_FACTOR__ is within the authorized size) or RESET (__CALIBRATION_FACTOR__ is too large)
+  */
+#define IS_ADC_CALFACT(__CALIBRATION_FACTOR__) ((__CALIBRATION_FACTOR__) <= (0x7FFU))
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief Calibration factor size verification (7 bits maximum on ADC3).
+  * @param __CALIBRATION_FACTOR__ Calibration factor value.
+  * @retval SET (__CALIBRATION_FACTOR__ is within the authorized size) or RESET (__CALIBRATION_FACTOR__ is too large)
+  */
+#define IS_ADC_CALFACT_ADC3(__CALIBRATION_FACTOR__) ((__CALIBRATION_FACTOR__) <= (0x7FU))
+#endif
+
+/**
+  * @brief Verify the ADC channel setting.
+  * @param __CHANNEL__ programmed ADC channel.
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC_CHANNEL(__CHANNEL__) (((__CHANNEL__) == ADC_CHANNEL_0)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_1)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_2)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_3)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_4)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_5)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_6)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_7)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_8)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_9)           || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_10)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_11)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_12)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_13)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_14)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_15)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_16)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_17)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_18)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_19)          || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_TEMPSENSOR)  || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_VBAT)        || \
+                                     ((__CHANNEL__) == ADC_CHANNEL_DAC1CH1_ADC2)|| \
+                                     ((__CHANNEL__) == ADC_CHANNEL_DAC1CH2_ADC2)|| \
+                                     ((__CHANNEL__) == ADC_CHANNEL_VREFINT)       )
+
+/**
+  * @brief Verify the ADC channel setting in differential mode for ADC1.
+  * @param __CHANNEL__: programmed ADC channel.
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC1_DIFF_CHANNEL(__CHANNEL__) (((__CHANNEL__) == ADC_CHANNEL_1)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_2)      ||\
+                                           ((__CHANNEL__) == ADC_CHANNEL_3)      ||\
+                                           ((__CHANNEL__) == ADC_CHANNEL_4)      ||\
+                                           ((__CHANNEL__) == ADC_CHANNEL_5)      ||\
+                                           ((__CHANNEL__) == ADC_CHANNEL_10)     ||\
+                                           ((__CHANNEL__) == ADC_CHANNEL_11)     ||\
+                                           ((__CHANNEL__) == ADC_CHANNEL_12)     ||\
+                                           ((__CHANNEL__) == ADC_CHANNEL_16)     ||\
+                                           ((__CHANNEL__) == ADC_CHANNEL_18)      )
+
+/**
+  * @brief Verify the ADC channel setting in differential mode for ADC2.
+  * @param __CHANNEL__: programmed ADC channel.
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC2_DIFF_CHANNEL(__CHANNEL__) (((__CHANNEL__) == ADC_CHANNEL_1)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_2)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_3)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_4)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_5)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_10)     || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_11)     || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_12)     || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_18)      )
+
+/**
+  * @brief Verify the ADC channel setting in differential mode for ADC3.
+  * @param __CHANNEL__: programmed ADC channel.
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC3_DIFF_CHANNEL(__CHANNEL__) (((__CHANNEL__) == ADC_CHANNEL_1)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_2)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_3)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_4)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_5)      || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_10)     || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_11)     || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_13)     || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_14)     || \
+                                           ((__CHANNEL__) == ADC_CHANNEL_15)       )
+
+/**
+  * @brief Helper macro to determine the selected channel corresponding
+  *        negative input for ADC1.
+  * @param __CHANNEL__: programmed ADC channel.
+  * @retval return the negative input channels corresponding to the selected channel.
+  */
+#define ADC_CHANNEL_DIFF_NEG_INPUT_ADC1(__CHANNEL__) (((__CHANNEL__) == ADC_CHANNEL_1)  ? ADC_CHANNEL_0  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_2)  ? ADC_CHANNEL_6  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_3)  ? ADC_CHANNEL_7  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_4)  ? ADC_CHANNEL_8  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_5)  ? ADC_CHANNEL_9  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_10) ? ADC_CHANNEL_11 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_11) ? ADC_CHANNEL_12 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_12) ? ADC_CHANNEL_13 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_16) ? ADC_CHANNEL_17 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_18) ? ADC_CHANNEL_19 : 0UL)
+
+/**
+  * @brief Helper macro to determine the selected channel corresponding
+  *        negative input for ADC2.
+  * @param __CHANNEL__: programmed ADC channel.
+  * @retval return the negative input channels corresponding to the selected channel.
+  */
+#define ADC_CHANNEL_DIFF_NEG_INPUT_ADC2(__CHANNEL__) (((__CHANNEL__) == ADC_CHANNEL_1)  ? ADC_CHANNEL_0  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_2)  ? ADC_CHANNEL_6  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_3)  ? ADC_CHANNEL_7  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_4)  ? ADC_CHANNEL_8  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_5)  ? ADC_CHANNEL_9  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_10) ? ADC_CHANNEL_11 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_11) ? ADC_CHANNEL_12 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_12) ? ADC_CHANNEL_13 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_18) ? ADC_CHANNEL_19 : 0UL)
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief Helper macro to determine the selected channel corresponding
+  *        negative input for ADC3.
+  * @param __CHANNEL__: programmed ADC channel.
+  * @retval return the negative input channels corresponding to the selected channel.
+  */
+#define ADC_CHANNEL_DIFF_NEG_INPUT_ADC3(__CHANNEL__) (((__CHANNEL__) == ADC_CHANNEL_1)  ? ADC_CHANNEL_0  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_2)  ? ADC_CHANNEL_6  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_3)  ? ADC_CHANNEL_7  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_4)  ? ADC_CHANNEL_8  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_5)  ? ADC_CHANNEL_9  : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_10) ? ADC_CHANNEL_11 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_11) ? ADC_CHANNEL_12 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_13) ? ADC_CHANNEL_14 : \
+                                                      ((__CHANNEL__) == ADC_CHANNEL_14) ? ADC_CHANNEL_15 : 0UL)
+#endif /* ADC_VER_V5_V90 */
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief  Helper macro to determine the selected channel corresponding
+  *         negative input on the ADC instance selected.
+  * @param __HANDLE__ ADC handle.
+  * @param __CHANNEL__ This parameter can be one of the following values:
+  * @retval return the negative input channels corresponding to the selected channel.
+  */
+#define ADC_CHANNEL_DIFF_NEG_INPUT(__HANDLE__, __CHANNEL__) ((((__HANDLE__)->Instance) == ADC1) ? ADC_CHANNEL_DIFF_NEG_INPUT_ADC1(__CHANNEL__) : \
+                                                             (((__HANDLE__)->Instance) == ADC2) ? ADC_CHANNEL_DIFF_NEG_INPUT_ADC2(__CHANNEL__) : \
+                                                             (((__HANDLE__)->Instance) == ADC3) ? ADC_CHANNEL_DIFF_NEG_INPUT_ADC3(__CHANNEL__) : 0UL)
+#else
+/**
+  * @brief  Helper macro to determine the selected channel corresponding
+  *         negative input on the ADC instance selected.
+  * @param __HANDLE__ ADC handle.
+  * @param __CHANNEL__ This parameter can be one of the following values:
+  * @retval return the negative input channels corresponding to the selected channel.
+  */
+#define ADC_CHANNEL_DIFF_NEG_INPUT(__HANDLE__, __CHANNEL__) ((((__HANDLE__)->Instance) == ADC1) ? ADC_CHANNEL_DIFF_NEG_INPUT_ADC1(__CHANNEL__) : \
+                                                             (((__HANDLE__)->Instance) == ADC2) ? ADC_CHANNEL_DIFF_NEG_INPUT_ADC2(__CHANNEL__) : 0UL)
+#endif /* ADC_VER_V5_V90 */
+
+/**
+  * @brief Verify the ADC single-ended input or differential mode setting.
+  * @param __SING_DIFF__ programmed channel setting.
+  * @retval SET (__SING_DIFF__ is valid) or RESET (__SING_DIFF__ is invalid)
+  */
+#define IS_ADC_SINGLE_DIFFERENTIAL(__SING_DIFF__) (((__SING_DIFF__) == ADC_SINGLE_ENDED)      || \
+                                                   ((__SING_DIFF__) == ADC_DIFFERENTIAL_ENDED)  )
+
+/**
+  * @brief Verify the ADC offset management setting.
+  * @param __OFFSET_NUMBER__ ADC offset management.
+  * @retval SET (__OFFSET_NUMBER__ is valid) or RESET (__OFFSET_NUMBER__ is invalid)
+  */
+#define IS_ADC_OFFSET_NUMBER(__OFFSET_NUMBER__) (((__OFFSET_NUMBER__) == ADC_OFFSET_NONE) || \
+                                                 ((__OFFSET_NUMBER__) == ADC_OFFSET_1)    || \
+                                                 ((__OFFSET_NUMBER__) == ADC_OFFSET_2)    || \
+                                                 ((__OFFSET_NUMBER__) == ADC_OFFSET_3)    || \
+                                                 ((__OFFSET_NUMBER__) == ADC_OFFSET_4)      )
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief Verify the ADC offset sign setting.
+  * @param __OFFSET_SIGN__ ADC offset sign.
+  * @retval SET (__OFFSET_SIGN__ is valid) or RESET (__OFFSET_SIGN__ is invalid)
+  */
+#define IS_ADC3_OFFSET_SIGN(__OFFSET_SIGN__)     (((__OFFSET_SIGN__) == ADC3_OFFSET_SIGN_NEGATIVE) || \
+                                                  ((__OFFSET_SIGN__) == ADC3_OFFSET_SIGN_POSITIVE)    )
+#endif  /* ADC_VER_V5_V90 */
+/**
+  * @brief Verify the ADC injected channel setting.
+  * @param __CHANNEL__ programmed ADC injected channel.
+  * @retval SET (__CHANNEL__ is valid) or RESET (__CHANNEL__ is invalid)
+  */
+#define IS_ADC_INJECTED_RANK(__CHANNEL__) (((__CHANNEL__) == ADC_INJECTED_RANK_1) || \
+                                           ((__CHANNEL__) == ADC_INJECTED_RANK_2) || \
+                                           ((__CHANNEL__) == ADC_INJECTED_RANK_3) || \
+                                           ((__CHANNEL__) == ADC_INJECTED_RANK_4)   )
+
+/**
+  * @brief Verify the ADC injected conversions external trigger.
+  * @param __INJTRIG__ programmed ADC injected conversions external trigger.
+  * @retval SET (__INJTRIG__ is a valid value) or RESET (__INJTRIG__ is invalid)
+  */
+#if defined (HRTIM1)
+#define IS_ADC_EXTTRIGINJEC(__INJTRIG__) (((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T2_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T2_CC1)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T4_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_EXT_IT15)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_TRGO2)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_TRGO2)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC3)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC1)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T6_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T15_TRGO)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_HR1_ADCTRG2) || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_HR1_ADCTRG4) || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_LPTIM1_OUT)  || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_LPTIM2_OUT)  || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_LPTIM3_OUT)  || \
+                                                                                          \
+                                           ((__INJTRIG__) == ADC_SOFTWARE_START)                   )
+#else
+#define IS_ADC_EXTTRIGINJEC(__INJTRIG__) (((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T2_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T2_CC1)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T4_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_EXT_IT15)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_CC4)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T1_TRGO2)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T8_TRGO2)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC3)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T3_CC1)      || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T6_TRGO)     || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_T15_TRGO)    || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_LPTIM1_OUT)  || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_LPTIM2_OUT)  || \
+                                          ((__INJTRIG__) == ADC_EXTERNALTRIGINJEC_LPTIM3_OUT)  || \
+                                                                                          \
+                                           ((__INJTRIG__) == ADC_SOFTWARE_START)                   )
+#endif /* HRTIM */
+/**
+  * @brief Verify the ADC edge trigger setting for injected group.
+  * @param __EDGE__ programmed ADC edge trigger setting.
+  * @retval SET (__EDGE__ is a valid value) or RESET (__EDGE__ is invalid)
+  */
+#define IS_ADC_EXTTRIGINJEC_EDGE(__EDGE__) (((__EDGE__) == ADC_EXTERNALTRIGINJECCONV_EDGE_NONE)        || \
+                                           ((__EDGE__) == ADC_EXTERNALTRIGINJECCONV_EDGE_RISING)       || \
+                                           ((__EDGE__) == ADC_EXTERNALTRIGINJECCONV_EDGE_FALLING)      || \
+                                           ((__EDGE__) == ADC_EXTERNALTRIGINJECCONV_EDGE_RISINGFALLING) )
+
+/**
+  * @brief Verify the ADC multimode setting.
+  * @param __MODE__ programmed ADC multimode setting.
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */
+#define IS_ADC_MULTIMODE(__MODE__) (((__MODE__) == ADC_MODE_INDEPENDENT)          || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT_INJECSIMULT) || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT_ALTERTRIG)   || \
+                               ((__MODE__) == ADC_DUALMODE_REGINTERL_INJECSIMULT) || \
+                               ((__MODE__) == ADC_DUALMODE_INJECSIMULT)           || \
+                               ((__MODE__) == ADC_DUALMODE_REGSIMULT)             || \
+                               ((__MODE__) == ADC_DUALMODE_INTERL)                || \
+                               ((__MODE__) == ADC_DUALMODE_ALTERTRIG)               )
+
+/**
+  * @brief Verify the ADC dual data mode setting.
+  * @param MODE: programmed ADC dual mode setting.
+  * @retval SET (MODE is valid) or RESET (MODE is invalid)
+  */
+#define IS_ADC_DUAL_DATA_MODE(MODE) (((MODE) == ADC_DUALMODEDATAFORMAT_DISABLED)   || \
+                                     ((MODE) == ADC_DUALMODEDATAFORMAT_32_10_BITS) || \
+                                     ((MODE) == ADC_DUALMODEDATAFORMAT_8_BITS)     )
+
+/**
+  * @brief Verify the ADC multimode delay setting.
+  * @param __DELAY__ programmed ADC multimode delay setting.
+  * @retval SET (__DELAY__ is a valid value) or RESET (__DELAY__ is invalid)
+  */
+#define IS_ADC_SAMPLING_DELAY(__DELAY__) (((__DELAY__) == ADC_TWOSAMPLINGDELAY_1CYCLE)   || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_2CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_3CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_4CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_5CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_6CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_7CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_8CYCLES)  || \
+                                          ((__DELAY__) == ADC_TWOSAMPLINGDELAY_9CYCLES)    )
+
+/**
+  * @brief Verify the ADC analog watchdog setting.
+  * @param __WATCHDOG__ programmed ADC analog watchdog setting.
+  * @retval SET (__WATCHDOG__ is valid) or RESET (__WATCHDOG__ is invalid)
+  */
+#define IS_ADC_ANALOG_WATCHDOG_NUMBER(__WATCHDOG__) (((__WATCHDOG__) == ADC_ANALOGWATCHDOG_1) || \
+                                                     ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_2) || \
+                                                     ((__WATCHDOG__) == ADC_ANALOGWATCHDOG_3)   )
+
+/**
+  * @brief Verify the ADC analog watchdog mode setting.
+  * @param __WATCHDOG_MODE__ programmed ADC analog watchdog mode setting.
+  * @retval SET (__WATCHDOG_MODE__ is valid) or RESET (__WATCHDOG_MODE__ is invalid)
+  */
+#define IS_ADC_ANALOG_WATCHDOG_MODE(__WATCHDOG_MODE__) (((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_NONE)             || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_SINGLE_REG)       || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_SINGLE_INJEC)     || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC)  || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_ALL_REG)          || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_ALL_INJEC)        || \
+                                                        ((__WATCHDOG_MODE__) == ADC_ANALOGWATCHDOG_ALL_REGINJEC)       )
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief Verify the ADC analog watchdog filtering setting.
+  * @param __FILTERING_MODE__ programmed ADC analog watchdog mode setting.
+  * @retval SET (__FILTERING_MODE__ is valid) or RESET (__FILTERING_MODE__ is invalid)
+  */
+#define IS_ADC_ANALOG_WATCHDOG_FILTERING_MODE_ADC3(__FILTERING_MODE__)  (((__FILTERING_MODE__) == ADC3_AWD_FILTERING_NONE)            || \
+                                                                         ((__FILTERING_MODE__) == ADC3_AWD_FILTERING_2SAMPLES)        || \
+                                                                         ((__FILTERING_MODE__) == ADC3_AWD_FILTERING_3SAMPLES)        || \
+                                                                         ((__FILTERING_MODE__) == ADC3_AWD_FILTERING_4SAMPLES)        || \
+                                                                         ((__FILTERING_MODE__) == ADC3_AWD_FILTERING_5SAMPLES)        || \
+                                                                         ((__FILTERING_MODE__) == ADC3_AWD_FILTERING_6SAMPLES)        || \
+                                                                         ((__FILTERING_MODE__) == ADC3_AWD_FILTERING_7SAMPLES)        || \
+                                                                         ((__FILTERING_MODE__) == ADC3_AWD_FILTERING_8SAMPLES)           )
+
+#endif /* ADC_VER_V5_V90 */
+
+/**
+  * @brief Verify the ADC conversion (regular or injected or both).
+  * @param __CONVERSION__ ADC conversion group.
+  * @retval SET (__CONVERSION__ is valid) or RESET (__CONVERSION__ is invalid)
+  */
+#define IS_ADC_CONVERSION_GROUP(__CONVERSION__) (((__CONVERSION__) == ADC_REGULAR_GROUP)     || \
+                                             ((__CONVERSION__) == ADC_INJECTED_GROUP)        || \
+                                             ((__CONVERSION__) == ADC_REGULAR_INJECTED_GROUP)  )
+
+/**
+  * @brief Verify the ADC event type.
+  * @param __EVENT__ ADC event.
+  * @retval SET (__EVENT__ is valid) or RESET (__EVENT__ is invalid)
+  */
+#define IS_ADC_EVENT_TYPE(__EVENT__) (((__EVENT__) == ADC_EOSMP_EVENT) || \
+                                     ((__EVENT__) == ADC_AWD_EVENT)    || \
+                                     ((__EVENT__) == ADC_AWD2_EVENT)   || \
+                                     ((__EVENT__) == ADC_AWD3_EVENT)   || \
+                                     ((__EVENT__) == ADC_OVR_EVENT)    || \
+                                     ((__EVENT__) == ADC_JQOVF_EVENT)  )
+
+/**
+  * @brief Verify the ADC oversampling ratio.
+  * @param RATIO: programmed ADC oversampling ratio.
+  * @retval SET (RATIO is a valid value) or RESET (RATIO is invalid)
+  */
+#define IS_ADC_OVERSAMPLING_RATIO(RATIO)  (((RATIO) >= 1UL) && ((RATIO) <= 1024UL))
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief Verify the ADC3 oversampling ratio.
+  * @param __RATIO__ programmed ADC oversampling ratio.
+  * @retval SET (__RATIO__ is a valid value) or RESET (__RATIO__ is invalid)
+  */
+#define IS_ADC_OVERSAMPLING_RATIO_ADC3(__RATIO__)    (((__RATIO__) == ADC3_OVERSAMPLING_RATIO_2   ) || \
+                                                      ((__RATIO__) == ADC3_OVERSAMPLING_RATIO_4   ) || \
+                                                      ((__RATIO__) == ADC3_OVERSAMPLING_RATIO_8   ) || \
+                                                      ((__RATIO__) == ADC3_OVERSAMPLING_RATIO_16  ) || \
+                                                      ((__RATIO__) == ADC3_OVERSAMPLING_RATIO_32  ) || \
+                                                      ((__RATIO__) == ADC3_OVERSAMPLING_RATIO_64  ) || \
+                                                      ((__RATIO__) == ADC3_OVERSAMPLING_RATIO_128 ) || \
+                                                      ((__RATIO__) == ADC3_OVERSAMPLING_RATIO_256 ))
+#endif  /* ADC_VER_V5_V90 */
+
+/**
+  * @brief Verify the ADC oversampling shift.
+  * @param __SHIFT__ programmed ADC oversampling shift.
+  * @retval SET (__SHIFT__ is a valid value) or RESET (__SHIFT__ is invalid)
+  */
+#define IS_ADC_RIGHT_BIT_SHIFT(__SHIFT__)        (((__SHIFT__) == ADC_RIGHTBITSHIFT_NONE) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_1   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_2   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_3   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_4   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_5   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_6   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_7   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_8   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_9   ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_10  ) || \
+                                                  ((__SHIFT__) == ADC_RIGHTBITSHIFT_11  ))
+
+/**
+  * @brief Verify the ADC oversampling triggered mode.
+  * @param __MODE__ programmed ADC oversampling triggered mode.
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */
+#define IS_ADC_TRIGGERED_OVERSAMPLING_MODE(__MODE__) (((__MODE__) == ADC_TRIGGEREDMODE_SINGLE_TRIGGER) || \
+                                                      ((__MODE__) == ADC_TRIGGEREDMODE_MULTI_TRIGGER) )
+
+/**
+  * @brief Verify the ADC oversampling regular conversion resumed or continued mode.
+  * @param __MODE__ programmed ADC oversampling regular conversion resumed or continued mode.
+  * @retval SET (__MODE__ is valid) or RESET (__MODE__ is invalid)
+  */
+#define IS_ADC_REGOVERSAMPLING_MODE(__MODE__) (((__MODE__) == ADC_REGOVERSAMPLING_CONTINUED_MODE) || \
+                                               ((__MODE__) == ADC_REGOVERSAMPLING_RESUMED_MODE) )
+
+/**
+  * @brief Verify the DFSDM mode configuration.
+  * @param __HANDLE__ ADC handle.
+  * @note When DMSDFM configuration is not supported, the macro systematically reports SET. For
+  *      this reason, the input parameter is the ADC handle and not the configuration parameter
+  *      directly.
+  * @retval SET (DFSDM mode configuration is valid) or RESET (DFSDM mode configuration is invalid)
+  */
+#if defined(DFSDM1_Channel0)
+#define IS_ADC_DFSDMCFG_MODE(__HANDLE__) (((__HANDLE__)->Init.DFSDMConfig == ADC_DFSDM_MODE_DISABLE) || \
+                                          ((__HANDLE__)->Init.DFSDMConfig == ADC_DFSDM_MODE_ENABLE) )
+#else
+#define IS_ADC_DFSDMCFG_MODE(__HANDLE__) (SET)
+#endif
+
+/**
+  * @brief Return the DFSDM configuration mode.
+  * @param __HANDLE__ ADC handle.
+  * @note When DMSDFM configuration is not supported, the macro systematically reports 0x0 (i.e disabled).
+  *       For this reason, the input parameter is the ADC handle and not the configuration parameter
+  *       directly.
+  * @retval DFSDM configuration mode
+  */
+#if defined(DFSDM1_Channel0)
+#define ADC_CFGR_DFSDM(__HANDLE__) ((__HANDLE__)->Init.DFSDMConfig)
+#else
+#define ADC_CFGR_DFSDM(__HANDLE__) (0x0UL)
+#endif
+
+/**
+  * @}
+  */
+
+
+/* Exported functions --------------------------------------------------------*/
+/** @addtogroup ADCEx_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup ADCEx_Exported_Functions_Group1
+  * @{
+  */
+/* IO operation functions *****************************************************/
+
+/* ADC calibration */
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc, uint32_t CalibrationMode, uint32_t SingleDiff);
+uint32_t                HAL_ADCEx_Calibration_GetValue(const ADC_HandleTypeDef *hadc, uint32_t SingleDiff);
+HAL_StatusTypeDef       HAL_ADCEx_LinearCalibration_GetValue(ADC_HandleTypeDef *hadc, uint32_t *LinearCalib_Buffer);
+HAL_StatusTypeDef       HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t SingleDiff, uint32_t CalibrationFactor);
+HAL_StatusTypeDef       HAL_ADCEx_LinearCalibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t *LinearCalib_Buffer);
+HAL_StatusTypeDef       HAL_ADCEx_LinearCalibration_FactorLoad(ADC_HandleTypeDef *hadc);
+
+
+/* Blocking mode: Polling */
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStart(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStop(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef *hadc, uint32_t Timeout);
+
+/* Non-blocking mode: Interruption */
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef *hadc);
+
+/* ADC multimode */
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeStart_DMA(ADC_HandleTypeDef *hadc, const uint32_t *pData, uint32_t Length);
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeStop_DMA(ADC_HandleTypeDef *hadc);
+uint32_t                HAL_ADCEx_MultiModeGetValue(const ADC_HandleTypeDef *hadc);
+
+/* ADC retrieve conversion value intended to be used with polling or interruption */
+uint32_t                HAL_ADCEx_InjectedGetValue(const ADC_HandleTypeDef *hadc, uint32_t InjectedRank);
+
+/* ADC IRQHandler and Callbacks used in non-blocking modes (Interruption) */
+void                    HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADCEx_InjectedQueueOverflowCallback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef *hadc);
+void                    HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef *hadc);
+
+/* ADC group regular conversions stop */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_IT(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_DMA(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef HAL_ADCEx_RegularMultiModeStop_DMA(ADC_HandleTypeDef *hadc);
+
+/**
+  * @}
+  */
+
+/** @addtogroup ADCEx_Exported_Functions_Group2
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef       HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef *hadc, ADC_InjectionConfTypeDef *sConfigInjected);
+HAL_StatusTypeDef       HAL_ADCEx_MultiModeConfigChannel(ADC_HandleTypeDef *hadc, ADC_MultiModeTypeDef *multimode);
+HAL_StatusTypeDef       HAL_ADCEx_EnableInjectedQueue(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADCEx_DisableInjectedQueue(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef *hadc);
+HAL_StatusTypeDef       HAL_ADCEx_EnterADCDeepPowerDownMode(ADC_HandleTypeDef *hadc);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32H7xx_HAL_ADC_EX_H */
+
+

--- a/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_adc.h
+++ b/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_adc.h
@@ -1,0 +1,8412 @@
+/**
+  ******************************************************************************
+  * @file    stm32h7xx_ll_adc.h
+  * @author  MCD Application Team
+  * @brief   Header file of ADC LL module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32H7xx_LL_ADC_H
+#define STM32H7xx_LL_ADC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32h7xx.h"
+
+/** @addtogroup STM32H7xx_LL_Driver
+  * @{
+  */
+
+#if defined (ADC1) || defined (ADC2) || defined (ADC3)
+
+/** @defgroup ADC_LL ADC
+  * @{
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup ADC_LL_Private_Constants ADC Private Constants
+  * @{
+  */
+
+/* Internal mask for ADC calibration:                                         */
+/* Internal register offset for ADC calibration factors configuration */
+
+/* To select into literals LL_ADC_CALIB_OFFSET, LL_ADC_CALIB_LINEARITY, ...   */
+/* the relevant bits for:                                                     */
+/* (concatenation of multiple bits used in different registers)               */
+/* - ADC calibration configuration: configuration before calibration start    */
+/* - ADC calibration factors: register offset                                 */
+#define ADC_CALIB_FACTOR_OFFSET_REGOFFSET    (0x00000000UL) /* Register CALFACT defined as reference register */
+#define ADC_CALIB_FACTOR_LINEARITY_REGOFFSET (0x00000001UL) /* Register CALFACT2 offset vs register CALFACT */
+#define ADC_CALIB_FACTOR_REGOFFSET_MASK      (ADC_CALIB_FACTOR_OFFSET_REGOFFSET | ADC_CALIB_FACTOR_LINEARITY_REGOFFSET)
+#define ADC_CALIB_MODE_MASK                  (ADC_CR_ADCALLIN)
+#define ADC_CALIB_MODE_BINARY_MASK           (ADC_CALIB_FACTOR_REGOFFSET_MASK) /* Mask to get binary value of calibration mode: 0 for offset, 1 for linearity */
+
+
+/* Internal mask for ADC group regular sequencer:                             */
+/* To select into literal LL_ADC_REG_RANK_x the relevant bits for:            */
+/* - sequencer register offset                                                */
+/* - sequencer rank bits position into the selected register                  */
+
+/* Internal register offset for ADC group regular sequencer configuration */
+/* (offset placed into a spare area of literal definition) */
+#define ADC_SQR1_REGOFFSET                 (0x00000000UL)
+#define ADC_SQR2_REGOFFSET                 (0x00000100UL)
+#define ADC_SQR3_REGOFFSET                 (0x00000200UL)
+#define ADC_SQR4_REGOFFSET                 (0x00000300UL)
+
+#define ADC_REG_SQRX_REGOFFSET_MASK        (ADC_SQR1_REGOFFSET | ADC_SQR2_REGOFFSET | ADC_SQR3_REGOFFSET | ADC_SQR4_REGOFFSET)
+#define ADC_SQRX_REGOFFSET_POS             (8UL) /* Position of bits ADC_SQRx_REGOFFSET in ADC_REG_SQRX_REGOFFSET_MASK */
+#define ADC_REG_RANK_ID_SQRX_MASK          (ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0)
+
+/* Definition of ADC group regular sequencer bits information to be inserted  */
+/* into ADC group regular sequencer ranks literals definition.                */
+#define ADC_REG_RANK_1_SQRX_BITOFFSET_POS  ( 6UL) /* Value equivalent to bitfield "ADC_SQR1_SQ1" position in register */
+#define ADC_REG_RANK_2_SQRX_BITOFFSET_POS  (12UL) /* Value equivalent to bitfield "ADC_SQR1_SQ2" position in register */
+#define ADC_REG_RANK_3_SQRX_BITOFFSET_POS  (18UL) /* Value equivalent to bitfield "ADC_SQR1_SQ3" position in register */
+#define ADC_REG_RANK_4_SQRX_BITOFFSET_POS  (24UL) /* Value equivalent to bitfield "ADC_SQR1_SQ4" position in register */
+#define ADC_REG_RANK_5_SQRX_BITOFFSET_POS  ( 0UL) /* Value equivalent to bitfield "ADC_SQR2_SQ5" position in register */
+#define ADC_REG_RANK_6_SQRX_BITOFFSET_POS  ( 6UL) /* Value equivalent to bitfield "ADC_SQR2_SQ6" position in register */
+#define ADC_REG_RANK_7_SQRX_BITOFFSET_POS  (12UL) /* Value equivalent to bitfield "ADC_SQR2_SQ7" position in register */
+#define ADC_REG_RANK_8_SQRX_BITOFFSET_POS  (18UL) /* Value equivalent to bitfield "ADC_SQR2_SQ8" position in register */
+#define ADC_REG_RANK_9_SQRX_BITOFFSET_POS  (24UL) /* Value equivalent to bitfield "ADC_SQR2_SQ9" position in register */
+#define ADC_REG_RANK_10_SQRX_BITOFFSET_POS ( 0UL) /* Value equivalent to bitfield "ADC_SQR3_SQ10" position in register */
+#define ADC_REG_RANK_11_SQRX_BITOFFSET_POS ( 6UL) /* Value equivalent to bitfield "ADC_SQR3_SQ11" position in register */
+#define ADC_REG_RANK_12_SQRX_BITOFFSET_POS (12UL) /* Value equivalent to bitfield "ADC_SQR3_SQ12" position in register */
+#define ADC_REG_RANK_13_SQRX_BITOFFSET_POS (18UL) /* Value equivalent to bitfield "ADC_SQR3_SQ13" position in register */
+#define ADC_REG_RANK_14_SQRX_BITOFFSET_POS (24UL) /* Value equivalent to bitfield "ADC_SQR3_SQ14" position in register */
+#define ADC_REG_RANK_15_SQRX_BITOFFSET_POS ( 0UL) /* Value equivalent to bitfield "ADC_SQR4_SQ15" position in register */
+#define ADC_REG_RANK_16_SQRX_BITOFFSET_POS ( 6UL) /* Value equivalent to bitfield "ADC_SQR4_SQ16" position in register */
+
+
+
+/* Internal mask for ADC group injected sequencer:                            */
+/* To select into literal LL_ADC_INJ_RANK_x the relevant bits for:            */
+/* - data register offset                                                     */
+/* - sequencer rank bits position into the selected register                  */
+
+/* Internal register offset for ADC group injected data register */
+/* (offset placed into a spare area of literal definition) */
+#define ADC_JDR1_REGOFFSET                 (0x00000000UL)
+#define ADC_JDR2_REGOFFSET                 (0x00000100UL)
+#define ADC_JDR3_REGOFFSET                 (0x00000200UL)
+#define ADC_JDR4_REGOFFSET                 (0x00000300UL)
+
+#define ADC_INJ_JDRX_REGOFFSET_MASK        (ADC_JDR1_REGOFFSET | ADC_JDR2_REGOFFSET | ADC_JDR3_REGOFFSET | ADC_JDR4_REGOFFSET)
+#define ADC_INJ_RANK_ID_JSQR_MASK          (ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0)
+#define ADC_JDRX_REGOFFSET_POS             (8UL) /* Position of bits ADC_JDRx_REGOFFSET in ADC_INJ_JDRX_REGOFFSET_MASK */
+
+/* Definition of ADC group injected sequencer bits information to be inserted */
+/* into ADC group injected sequencer ranks literals definition.               */
+#define ADC_INJ_RANK_1_JSQR_BITOFFSET_POS  (ADC_JSQR_JSQ1_Pos)
+#define ADC_INJ_RANK_2_JSQR_BITOFFSET_POS  (ADC_JSQR_JSQ2_Pos)
+#define ADC_INJ_RANK_3_JSQR_BITOFFSET_POS  (ADC_JSQR_JSQ3_Pos)
+#define ADC_INJ_RANK_4_JSQR_BITOFFSET_POS  (ADC_JSQR_JSQ4_Pos)
+
+
+
+/* Internal mask for ADC group regular trigger:                               */
+/* To select into literal LL_ADC_REG_TRIG_x the relevant bits for:            */
+/* - regular trigger source                                                   */
+/* - regular trigger edge                                                     */
+#define ADC_REG_TRIG_EXT_EDGE_DEFAULT       (ADC_CFGR_EXTEN_0) /* Trigger edge set to rising edge (default setting for compatibility with some ADC on other STM32 families having this setting set by HW default value) */
+
+/* Mask containing trigger source masks for each of possible                  */
+/* trigger edge selection duplicated with shifts [0; 4; 8; 12]                */
+/* corresponding to {SW start; ext trigger; ext trigger; ext trigger}.        */
+#define ADC_REG_TRIG_SOURCE_MASK            (((LL_ADC_REG_TRIG_SOFTWARE & ADC_CFGR_EXTSEL) << (4U * 0UL)) | \
+                                             ((ADC_CFGR_EXTSEL)                            << (4U * 1UL)) | \
+                                             ((ADC_CFGR_EXTSEL)                            << (4U * 2UL)) | \
+                                             ((ADC_CFGR_EXTSEL)                            << (4U * 3UL))  )
+
+/* Mask containing trigger edge masks for each of possible                    */
+/* trigger edge selection duplicated with shifts [0; 4; 8; 12]                */
+/* corresponding to {SW start; ext trigger; ext trigger; ext trigger}.        */
+#define ADC_REG_TRIG_EDGE_MASK              (((LL_ADC_REG_TRIG_SOFTWARE & ADC_CFGR_EXTEN) << (4U * 0UL)) | \
+                                             ((ADC_REG_TRIG_EXT_EDGE_DEFAULT)             << (4U * 1UL)) | \
+                                             ((ADC_REG_TRIG_EXT_EDGE_DEFAULT)             << (4U * 2UL)) | \
+                                             ((ADC_REG_TRIG_EXT_EDGE_DEFAULT)             << (4U * 3UL))  )
+
+/* Definition of ADC group regular trigger bits information.                  */
+#define ADC_REG_TRIG_EXTSEL_BITOFFSET_POS  ( 6UL) /* Value equivalent to bitfield "ADC_CFGR_EXTSEL" position in register */
+#define ADC_REG_TRIG_EXTEN_BITOFFSET_POS   (10UL) /* Value equivalent to bitfield "ADC_CFGR_EXTEN" position in register */
+
+
+
+/* Internal mask for ADC group injected trigger:                              */
+/* To select into literal LL_ADC_INJ_TRIG_x the relevant bits for:            */
+/* - injected trigger source                                                  */
+/* - injected trigger edge                                                    */
+#define ADC_INJ_TRIG_EXT_EDGE_DEFAULT      (ADC_JSQR_JEXTEN_0) /* Trigger edge set to rising edge (default setting for compatibility with some ADC on other STM32 families having this setting set by HW default value) */
+
+/* Mask containing trigger source masks for each of possible                  */
+/* trigger edge selection duplicated with shifts [0; 4; 8; 12]                */
+/* corresponding to {SW start; ext trigger; ext trigger; ext trigger}.        */
+#define ADC_INJ_TRIG_SOURCE_MASK            (((LL_ADC_INJ_TRIG_SOFTWARE & ADC_JSQR_JEXTSEL) << (4U * 0UL)) | \
+                                            ((ADC_JSQR_JEXTSEL)                             << (4U * 1UL)) | \
+                                            ((ADC_JSQR_JEXTSEL)                             << (4U * 2UL)) | \
+                                            ((ADC_JSQR_JEXTSEL)                             << (4U * 3UL))  )
+
+/* Mask containing trigger edge masks for each of possible                    */
+/* trigger edge selection duplicated with shifts [0; 4; 8; 12]                */
+/* corresponding to {SW start; ext trigger; ext trigger; ext trigger}.        */
+#define ADC_INJ_TRIG_EDGE_MASK              (((LL_ADC_INJ_TRIG_SOFTWARE & ADC_JSQR_JEXTEN) << (4U * 0UL)) | \
+                                             ((ADC_INJ_TRIG_EXT_EDGE_DEFAULT)              << (4U * 1UL)) | \
+                                             ((ADC_INJ_TRIG_EXT_EDGE_DEFAULT)              << (4U * 2UL)) | \
+                                             ((ADC_INJ_TRIG_EXT_EDGE_DEFAULT)              << (4U * 3UL))  )
+
+/* Definition of ADC group injected trigger bits information.                 */
+#define ADC_INJ_TRIG_EXTSEL_BITOFFSET_POS  ( 2UL) /* Value equivalent to bitfield "ADC_JSQR_JEXTSEL" position in register */
+#define ADC_INJ_TRIG_EXTEN_BITOFFSET_POS   ( 6UL) /* Value equivalent to bitfield "ADC_JSQR_JEXTEN" position in register */
+
+
+
+
+
+
+/* Internal mask for ADC channel:                                             */
+/* To select into literal LL_ADC_CHANNEL_x the relevant bits for:             */
+/* - channel identifier defined by number                                     */
+/* - channel identifier defined by bitfield                                   */
+/* - channel differentiation between external channels (connected to          */
+/*   GPIO pins) and internal channels (connected to internal paths)           */
+/* - channel sampling time defined by SMPRx register offset                   */
+/*   and SMPx bits positions into SMPRx register                              */
+#define ADC_CHANNEL_ID_NUMBER_MASK         (ADC_CFGR_AWD1CH)
+#define ADC_CHANNEL_ID_BITFIELD_MASK       (ADC_AWD2CR_AWD2CH)
+#define ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS (26UL)/* Value equivalent to bitfield "ADC_CHANNEL_ID_NUMBER_MASK" position in register */
+#define ADC_CHANNEL_ID_MASK                (ADC_CHANNEL_ID_NUMBER_MASK | ADC_CHANNEL_ID_BITFIELD_MASK | ADC_CHANNEL_ID_INTERNAL_CH_MASK)
+/* Equivalent mask of ADC_CHANNEL_NUMBER_MASK aligned on register LSB (bit 0) */
+#define ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0 (ADC_SQR2_SQ5) /* Equivalent to shift: (ADC_CHANNEL_NUMBER_MASK >> [Position of bitfield "ADC_CHANNEL_NUMBER_MASK" in register]) */
+
+/* Channel differentiation between external and internal channels */
+#define ADC_CHANNEL_ID_INTERNAL_CH         (0x80000000UL) /* Marker of internal channel */
+#define ADC_CHANNEL_ID_INTERNAL_CH_MASK    (ADC_CHANNEL_ID_INTERNAL_CH)
+
+/* Internal register offset for ADC channel sampling time configuration */
+/* (offset placed into a spare area of literal definition) */
+#define ADC_SMPR1_REGOFFSET                (0x00000000UL)
+#define ADC_SMPR2_REGOFFSET                (0x02000000UL)
+#define ADC_CHANNEL_SMPRX_REGOFFSET_MASK   (ADC_SMPR1_REGOFFSET | ADC_SMPR2_REGOFFSET)
+#define ADC_SMPRX_REGOFFSET_POS            (25UL) /* Position of bits ADC_SMPRx_REGOFFSET in ADC_CHANNEL_SMPRX_REGOFFSET_MASK */
+
+#define ADC_CHANNEL_SMPx_BITOFFSET_MASK    (0x01F00000UL)
+#define ADC_CHANNEL_SMPx_BITOFFSET_POS     (20UL)           /* Value equivalent to bitfield "ADC_CHANNEL_SMPx_BITOFFSET_MASK" position in register */
+
+/* Definition of channels ID number information to be inserted into           */
+/* channels literals definition.                                              */
+#define ADC_CHANNEL_0_NUMBER               (0x00000000UL)
+#define ADC_CHANNEL_1_NUMBER               (                                                                                ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_2_NUMBER               (                                                            ADC_CFGR_AWD1CH_1                    )
+#define ADC_CHANNEL_3_NUMBER               (                                                            ADC_CFGR_AWD1CH_1 | ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_4_NUMBER               (                                        ADC_CFGR_AWD1CH_2                                        )
+#define ADC_CHANNEL_5_NUMBER               (                                        ADC_CFGR_AWD1CH_2                     | ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_6_NUMBER               (                                        ADC_CFGR_AWD1CH_2 | ADC_CFGR_AWD1CH_1                    )
+#define ADC_CHANNEL_7_NUMBER               (                                        ADC_CFGR_AWD1CH_2 | ADC_CFGR_AWD1CH_1 | ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_8_NUMBER               (                    ADC_CFGR_AWD1CH_3                                                            )
+#define ADC_CHANNEL_9_NUMBER               (                    ADC_CFGR_AWD1CH_3                                         | ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_10_NUMBER              (                    ADC_CFGR_AWD1CH_3                     | ADC_CFGR_AWD1CH_1                    )
+#define ADC_CHANNEL_11_NUMBER              (                    ADC_CFGR_AWD1CH_3                     | ADC_CFGR_AWD1CH_1 | ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_12_NUMBER              (                    ADC_CFGR_AWD1CH_3 | ADC_CFGR_AWD1CH_2                                        )
+#define ADC_CHANNEL_13_NUMBER              (                    ADC_CFGR_AWD1CH_3 | ADC_CFGR_AWD1CH_2                     | ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_14_NUMBER              (                    ADC_CFGR_AWD1CH_3 | ADC_CFGR_AWD1CH_2 | ADC_CFGR_AWD1CH_1                    )
+#define ADC_CHANNEL_15_NUMBER              (                    ADC_CFGR_AWD1CH_3 | ADC_CFGR_AWD1CH_2 | ADC_CFGR_AWD1CH_1 | ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_16_NUMBER              (ADC_CFGR_AWD1CH_4                                                                                )
+#define ADC_CHANNEL_17_NUMBER              (ADC_CFGR_AWD1CH_4                                                             | ADC_CFGR_AWD1CH_0)
+#define ADC_CHANNEL_18_NUMBER              (ADC_CFGR_AWD1CH_4                                         | ADC_CFGR_AWD1CH_1                    )
+#define ADC_CHANNEL_19_NUMBER              (ADC_CFGR_AWD1CH_4                                         | ADC_CFGR_AWD1CH_1 | ADC_CFGR_AWD1CH_0)
+
+/* Definition of channels ID bitfield information to be inserted into         */
+/* channels literals definition.                                              */
+#define ADC_CHANNEL_0_BITFIELD             (ADC_AWD2CR_AWD2CH_0)
+#define ADC_CHANNEL_1_BITFIELD             (ADC_AWD2CR_AWD2CH_1)
+#define ADC_CHANNEL_2_BITFIELD             (ADC_AWD2CR_AWD2CH_2)
+#define ADC_CHANNEL_3_BITFIELD             (ADC_AWD2CR_AWD2CH_3)
+#define ADC_CHANNEL_4_BITFIELD             (ADC_AWD2CR_AWD2CH_4)
+#define ADC_CHANNEL_5_BITFIELD             (ADC_AWD2CR_AWD2CH_5)
+#define ADC_CHANNEL_6_BITFIELD             (ADC_AWD2CR_AWD2CH_6)
+#define ADC_CHANNEL_7_BITFIELD             (ADC_AWD2CR_AWD2CH_7)
+#define ADC_CHANNEL_8_BITFIELD             (ADC_AWD2CR_AWD2CH_8)
+#define ADC_CHANNEL_9_BITFIELD             (ADC_AWD2CR_AWD2CH_9)
+#define ADC_CHANNEL_10_BITFIELD            (ADC_AWD2CR_AWD2CH_10)
+#define ADC_CHANNEL_11_BITFIELD            (ADC_AWD2CR_AWD2CH_11)
+#define ADC_CHANNEL_12_BITFIELD            (ADC_AWD2CR_AWD2CH_12)
+#define ADC_CHANNEL_13_BITFIELD            (ADC_AWD2CR_AWD2CH_13)
+#define ADC_CHANNEL_14_BITFIELD            (ADC_AWD2CR_AWD2CH_14)
+#define ADC_CHANNEL_15_BITFIELD            (ADC_AWD2CR_AWD2CH_15)
+#define ADC_CHANNEL_16_BITFIELD            (ADC_AWD2CR_AWD2CH_16)
+#define ADC_CHANNEL_17_BITFIELD            (ADC_AWD2CR_AWD2CH_17)
+#define ADC_CHANNEL_18_BITFIELD            (ADC_AWD2CR_AWD2CH_18)
+#define ADC_CHANNEL_19_BITFIELD            (ADC_AWD2CR_AWD2CH_19)
+
+/* Definition of channels sampling time information to be inserted into       */
+/* channels literals definition.                                              */
+#define ADC_CHANNEL_0_SMP                  (ADC_SMPR1_REGOFFSET | (( 0UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP0" position in register */
+#define ADC_CHANNEL_1_SMP                  (ADC_SMPR1_REGOFFSET | (( 3UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP1" position in register */
+#define ADC_CHANNEL_2_SMP                  (ADC_SMPR1_REGOFFSET | (( 6UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP2" position in register */
+#define ADC_CHANNEL_3_SMP                  (ADC_SMPR1_REGOFFSET | (( 9UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP3" position in register */
+#define ADC_CHANNEL_4_SMP                  (ADC_SMPR1_REGOFFSET | ((12UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP4" position in register */
+#define ADC_CHANNEL_5_SMP                  (ADC_SMPR1_REGOFFSET | ((15UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP5" position in register */
+#define ADC_CHANNEL_6_SMP                  (ADC_SMPR1_REGOFFSET | ((18UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP6" position in register */
+#define ADC_CHANNEL_7_SMP                  (ADC_SMPR1_REGOFFSET | ((21UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP7" position in register */
+#define ADC_CHANNEL_8_SMP                  (ADC_SMPR1_REGOFFSET | ((24UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP8" position in register */
+#define ADC_CHANNEL_9_SMP                  (ADC_SMPR1_REGOFFSET | ((27UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR1_SMP9" position in register */
+#define ADC_CHANNEL_10_SMP                 (ADC_SMPR2_REGOFFSET | (( 0UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP10" position in register */
+#define ADC_CHANNEL_11_SMP                 (ADC_SMPR2_REGOFFSET | (( 3UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP11" position in register */
+#define ADC_CHANNEL_12_SMP                 (ADC_SMPR2_REGOFFSET | (( 6UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP12" position in register */
+#define ADC_CHANNEL_13_SMP                 (ADC_SMPR2_REGOFFSET | (( 9UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP13" position in register */
+#define ADC_CHANNEL_14_SMP                 (ADC_SMPR2_REGOFFSET | ((12UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP14" position in register */
+#define ADC_CHANNEL_15_SMP                 (ADC_SMPR2_REGOFFSET | ((15UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP15" position in register */
+#define ADC_CHANNEL_16_SMP                 (ADC_SMPR2_REGOFFSET | ((18UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP16" position in register */
+#define ADC_CHANNEL_17_SMP                 (ADC_SMPR2_REGOFFSET | ((21UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP17" position in register */
+#define ADC_CHANNEL_18_SMP                 (ADC_SMPR2_REGOFFSET | ((24UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP18" position in register */
+#define ADC_CHANNEL_19_SMP                 (ADC_SMPR2_REGOFFSET | ((27UL) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to bitfield "ADC_SMPR2_SMP19" position in register */
+
+
+/* Internal mask for ADC mode single or differential ended:                   */
+/* To select into literals LL_ADC_SINGLE_ENDED or LL_ADC_SINGLE_DIFFERENTIAL  */
+/* the relevant bits for:                                                     */
+/* (concatenation of multiple bits used in different registers)               */
+/* - ADC calibration: calibration start, calibration factor get or set        */
+/* - ADC channels: set each ADC channel ending mode                           */
+#define ADC_SINGLEDIFF_CALIB_START_MASK    (ADC_CR_ADCALDIF)
+#define ADC_SINGLEDIFF_CALIB_FACTOR_MASK   (ADC_CALFACT_CALFACT_D | ADC_CALFACT_CALFACT_S)
+#define ADC_SINGLEDIFF_CHANNEL_MASK        (ADC_CHANNEL_ID_BITFIELD_MASK) /* Equivalent to ADC_DIFSEL_DIFSEL */
+#define ADC_SINGLEDIFF_CHANNEL_SHIFT_MASK  (ADC_CALFACT_CALFACT_S_4 | ADC_CALFACT_CALFACT_S_3) /* Bits chosen to perform of shift when single mode is selected, shift value out of channels bits range. */
+#define ADC_SINGLEDIFF_CALIB_F_BIT_D_MASK   (0x00010000UL)                           /* Selection of 1 bit to discriminate differential mode: mask of bit */
+#define ADC_SINGLEDIFF_CALIB_F_BIT_D_POS    (16UL)                                   /* Selection of 1 bit to discriminate differential mode: position of bit */
+#define ADC_SINGLEDIFF_CALIB_F_BIT_D_SHIFT4 (ADC_SINGLEDIFF_CALIB_F_BIT_D_POS - 4UL) /* Shift of bit ADC_SINGLEDIFF_CALIB_F_BIT_D to position to perform a shift of 4 ranks */
+
+/* Internal mask for ADC analog watchdog:                                     */
+/* To select into literals LL_ADC_AWD_CHANNELx_xxx the relevant bits for:     */
+/* (concatenation of multiple bits used in different analog watchdogs,        */
+/* (feature of several watchdogs not available on all STM32 families)).       */
+/* - analog watchdog 1: monitored channel defined by number,                  */
+/*   selection of ADC group (ADC groups regular and-or injected).             */
+/* - analog watchdog 2 and 3: monitored channel defined by bitfield, no       */
+/*   selection on groups.                                                     */
+
+/* Internal register offset for ADC analog watchdog channel configuration */
+#define ADC_AWD_CR1_REGOFFSET              (0x00000000UL)
+#define ADC_AWD_CR2_REGOFFSET              (0x00100000UL)
+#define ADC_AWD_CR3_REGOFFSET              (0x00200000UL)
+
+/* Register offset gap between AWD1 and AWD2-AWD3 configuration registers */
+/* (Set separately as ADC_AWD_CRX_REGOFFSET to spare 32 bits space */
+#define ADC_AWD_CR12_REGOFFSETGAP_MASK     (ADC_AWD2CR_AWD2CH_0)
+#define ADC_AWD_CR12_REGOFFSETGAP_VAL      (0x00000024UL)
+
+#define ADC_AWD_CRX_REGOFFSET_MASK         (ADC_AWD_CR1_REGOFFSET | ADC_AWD_CR2_REGOFFSET | ADC_AWD_CR3_REGOFFSET)
+
+#define ADC_AWD_CR1_CHANNEL_MASK           (ADC_CFGR_AWD1CH | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL)
+#define ADC_AWD_CR23_CHANNEL_MASK          (ADC_AWD2CR_AWD2CH)
+#define ADC_AWD_CR_ALL_CHANNEL_MASK        (ADC_AWD_CR1_CHANNEL_MASK | ADC_AWD_CR23_CHANNEL_MASK)
+
+#define ADC_AWD_CRX_REGOFFSET_POS          (20UL) /* Position of bits ADC_AWD_CRx_REGOFFSET in ADC_AWD_CRX_REGOFFSET_MASK */
+
+/* Internal register offset for ADC analog watchdog threshold configuration */
+#define ADC_AWD_TR1_REGOFFSET              (ADC_AWD_CR1_REGOFFSET)
+#define ADC_AWD_TR2_REGOFFSET              (ADC_AWD_CR2_REGOFFSET)
+#define ADC_AWD_TR3_REGOFFSET              (ADC_AWD_CR3_REGOFFSET)
+#define ADC_AWD_TRX_REGOFFSET_MASK         (ADC_AWD_TR1_REGOFFSET | ADC_AWD_TR2_REGOFFSET | ADC_AWD_TR3_REGOFFSET)
+#define ADC_AWD_TRX_REGOFFSET_POS          (ADC_AWD_CRX_REGOFFSET_POS)     /* Position of bits ADC_TRx_REGOFFSET in ADC_AWD_TRX_REGOFFSET_MASK */
+#if defined(ADC_VER_V5_V90)
+#define ADC_AWD_TRX_BIT_HIGH_MASK          (0x00010000UL)                   /* Selection of 1 bit to discriminate threshold high: mask of bit */
+#define ADC_AWD_TRX_BIT_HIGH_POS           (16UL)                           /* Selection of 1 bit to discriminate threshold high: position of bit */
+#define ADC_AWD_TRX_BIT_HIGH_SHIFT4        (ADC_AWD_TRX_BIT_HIGH_POS - 4UL) /* Shift of bit ADC_AWD_TRX_BIT_HIGH to position to perform a shift of 4 ranks */
+#endif  /* ADC_VER_V5_V90 */
+
+/* Register offset gap between AWD1 and AWD2-AWD3 thresholds registers */
+/* (Set separately as ADC_AWD_TRX_REGOFFSET to spare 32 bits space */
+#define ADC_AWD_TR12_REGOFFSETGAP_MASK     (ADC_AWD2CR_AWD2CH_0)
+#define ADC_AWD_TR12_REGOFFSETGAP_VAL      (0x00000022UL)
+
+/* Legacy literals */
+#define LL_ADC_AWD1_TR                      LL_ADC_AWD1
+#define LL_ADC_AWD2_TR                      LL_ADC_AWD2
+#define LL_ADC_AWD3_TR                      LL_ADC_AWD3
+
+/* Internal mask for ADC offset:                                              */
+/* Internal register offset for ADC offset number configuration */
+#define ADC_OFR1_REGOFFSET                 (0x00000000UL)
+#define ADC_OFR2_REGOFFSET                 (0x00000001UL)
+#define ADC_OFR3_REGOFFSET                 (0x00000002UL)
+#define ADC_OFR4_REGOFFSET                 (0x00000003UL)
+#define ADC_OFRx_REGOFFSET_MASK            (ADC_OFR1_REGOFFSET | ADC_OFR2_REGOFFSET | ADC_OFR3_REGOFFSET | ADC_OFR4_REGOFFSET)
+
+
+/* ADC registers bits positions */
+#define ADC_CFGR_RES_BITOFFSET_POS         (ADC_CFGR_RES_Pos)
+#define ADC_CFGR_AWD1SGL_BITOFFSET_POS     (ADC_CFGR_AWD1SGL_Pos)
+#define ADC_CFGR_AWD1EN_BITOFFSET_POS      (ADC_CFGR_AWD1EN_Pos)
+#define ADC_CFGR_JAWD1EN_BITOFFSET_POS     (ADC_CFGR_JAWD1EN_Pos)
+#if defined(ADC_VER_V5_V90)
+#define ADC_CFGR_RES_BITOFFSET_POS_ADC3    (ADC3_CFGR_RES_Pos)
+#endif /* ADC_VER_V5_V90 */
+
+
+/* ADC registers bits groups */
+#define ADC_CR_BITS_PROPERTY_RS            (ADC_CR_ADCAL | ADC_CR_JADSTP | ADC_CR_ADSTP | ADC_CR_JADSTART | ADC_CR_ADSTART | ADC_CR_ADDIS | ADC_CR_ADEN) /* ADC register CR bits with HW property "rs": Software can read as well as set this bit. Writing '0' has no effect on the bit value. */
+
+
+/* ADC internal channels related definitions */
+/* Internal voltage reference VrefInt */
+#if defined(ADC_VER_V5_3)
+#define VREFINT_CAL_ADDR                   ((uint16_t*) (0x8fff810UL))  /* Internal voltage reference, address of parameter VREFINT_CAL: VrefInt ADC raw data acquired at temperature 30 DegC (tolerance: +-5 DegC), Vref+ = 3.3 V (tolerance: +-10 mV). */
+                                                                        /* Address related to STM32H7A3 */
+#else /* ADC_VER_V5_90 || ADC_VER_V5_X */
+#define VREFINT_CAL_ADDR                   ((uint16_t*) (0x1FF1E860UL)) /* Internal voltage reference, address of parameter VREFINT_CAL: VrefInt ADC raw data acquired at temperature 30 DegC (tolerance: +-5 DegC), Vref+ = 3.3 V (tolerance: +-10 mV). */
+#endif /* ADC_VER_V5_3 */
+#define VREFINT_CAL_VREF                   (3300UL)                     /* Analog voltage reference (Vref+) value with which temperature sensor has been calibrated in production (tolerance: +-10 mV) (unit: mV). */
+/* Temperature sensor */
+#if defined(ADC_VER_V5_3)
+#define TEMPSENSOR_CAL1_ADDR               ((uint16_t*) (0x8fff814UL))  /* Internal temperature sensor, address of parameter TS_CAL1: On STM32H7, temperature sensor ADC raw data acquired at temperature  30 DegC (tolerance: +-5 DegC), Vref+ = 3.3 V (tolerance: +-10 mV). */
+#define TEMPSENSOR_CAL2_ADDR               ((uint16_t*) (0x8fff818UL))  /* Internal temperature sensor, address of parameter TS_CAL2: On STM32H7, temperature sensor ADC raw data acquired at temperature 110 DegC (tolerance: +-5 DegC), Vref+ = 3.3 V (tolerance: +-10 mV). */
+                                                                        /* Addresses related to STM32H7A3 */
+#else /* ADC_VER_V5_90 || ADC_VER_V5_X */
+#define TEMPSENSOR_CAL1_ADDR               ((uint16_t*) (0x1FF1E820UL)) /* Internal temperature sensor, address of parameter TS_CAL1: On STM32H7, temperature sensor ADC raw data acquired at temperature  30 DegC (tolerance: +-5 DegC), Vref+ = 3.3 V (tolerance: +-10 mV). */
+#define TEMPSENSOR_CAL2_ADDR               ((uint16_t*) (0x1FF1E840UL)) /* Internal temperature sensor, address of parameter TS_CAL2: On STM32H7, temperature sensor ADC raw data acquired at temperature 110 DegC (tolerance: +-5 DegC), Vref+ = 3.3 V (tolerance: +-10 mV). */
+#endif /* ADC_VER_V5_3 */
+
+#define TEMPSENSOR_CAL1_TEMP               (30L)                        /* Internal temperature sensor, temperature at which temperature sensor has been calibrated in production for data into TEMPSENSOR_CAL1_ADDR (tolerance: +-5 DegC) (unit: DegC). */
+#if defined (STM32H742xx) || defined (STM32H743xx) || defined (STM32H753xx) || defined (STM32H750xx)
+#define TEMPSENSOR_CAL2_TEMP               ((((DBGMCU->IDCODE) >> 16) <= ((uint32_t)0x1003)) ? 110L : 130L)            /* Internal temperature sensor , 
+                                           temperature at which temperature sensor has been calibrated in production for data into TEMPSENSOR_CAL2_ADDR
+                                            110 °C for revision Y and 130 °C for revision V (tolerance: +-5 DegC) (unit: DegC). */
+#else
+#define TEMPSENSOR_CAL2_TEMP               (130L)                       /* Internal temperature sensor, temperature at which temperature sensor has been
+                                           calibrated in production for data into TEMPSENSOR_CAL2_ADDR (tolerance: +-5 DegC) (unit: DegC). */
+#endif /* defined (STM32H742xx) || defined (STM32H743xx) || defined (STM32H753xx) */
+#define TEMPSENSOR_CAL_VREFANALOG          (3300UL)                     /* Analog voltage reference (Vref+) voltage with which temperature sensor has been calibrated in production (+-10 mV) (unit: mV). */
+
+/* Registers addresses with ADC linearity calibration content (programmed during device production, specific to each device) */
+#define ADC_LINEAR_CALIB_REG_1_ADDR ((uint32_t*) (0x1FF1EC00UL))
+#define ADC_LINEAR_CALIB_REG_2_ADDR ((uint32_t*) (0x1FF1EC04UL))
+#define ADC_LINEAR_CALIB_REG_3_ADDR ((uint32_t*) (0x1FF1EC08UL))
+#define ADC_LINEAR_CALIB_REG_4_ADDR ((uint32_t*) (0x1FF1EC0CUL))
+#define ADC_LINEAR_CALIB_REG_5_ADDR ((uint32_t*) (0x1FF1EC10UL))
+#define ADC_LINEAR_CALIB_REG_6_ADDR ((uint32_t*) (0x1FF1EC14UL))
+#define ADC_LINEAR_CALIB_REG_COUNT  (6UL)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_Alias_definition  ADC Alias definition
+  * @{
+  */
+#define LL_ADC_SetChannelPreSelection  LL_ADC_SetChannelPreselection    /* Alias of LL_ADC_SetChannelPreselection for backward compatibility. */
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+/** @defgroup ADC_LL_Private_Macros ADC Private Macros
+  * @{
+  */
+
+/**
+  * @brief  Driver macro reserved for internal use: set a pointer to
+  *         a register from a register basis from which an offset
+  *         is applied.
+  * @param  __REG__ Register basis from which the offset is applied.
+  * @param  __REG_OFFFSET__ Offset to be applied (unit: number of registers).
+  * @retval Pointer to register address
+  */
+#define __ADC_PTR_REG_OFFSET(__REG__, __REG_OFFFSET__)                         \
+ ((__IO uint32_t *)((uint32_t) ((uint32_t)(&(__REG__)) + ((__REG_OFFFSET__) << 2UL))))
+
+/**
+  * @}
+  */
+
+
+/* Exported types ------------------------------------------------------------*/
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup ADC_LL_ES_INIT ADC Exported Init structure
+  * @{
+  */
+
+/**
+  * @brief  Structure definition of some features of ADC common parameters
+  *         and multimode
+  *         (all ADC instances belonging to the same ADC common instance).
+  * @note   The setting of these parameters by function @ref LL_ADC_CommonInit()
+  *         is conditioned to ADC instances state (all ADC instances
+  *         sharing the same ADC common instance):
+  *         All ADC instances sharing the same ADC common instance must be
+  *         disabled.
+  */
+typedef struct
+{
+  uint32_t CommonClock;                 /*!< Set parameter common to several ADC: Clock source and prescaler.
+                                             This parameter can be a value of @ref ADC_LL_EC_COMMON_CLOCK_SOURCE
+                                             @note On this STM32 series, if ADC group injected is used, some
+                                                   clock ratio constraints between ADC clock and AHB clock
+                                                   must be respected. Refer to reference manual.
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_SetCommonClock(). */
+
+  uint32_t Multimode;                   /*!< Set ADC multimode configuration to operate in independent mode or multimode (for devices with several ADC instances).
+                                             This parameter can be a value of @ref ADC_LL_EC_MULTI_MODE
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_SetMultimode(). */
+
+  uint32_t MultiDMATransfer;            /*!< Set ADC dual ADC mode DMA transfer data format: Each DMA, 32 down to 10-bits or 8-bits resolution.
+                                             This parameter can be a value of @ref ADC_LL_EC_MULTI_DMA_TRANSFER
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_SetMultiDMATransfer(). */
+
+  uint32_t MultiTwoSamplingDelay;       /*!< Set ADC multimode delay between 2 sampling phases.
+                                             This parameter can be a value of @ref ADC_LL_EC_MULTI_TWOSMP_DELAY
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_SetMultiTwoSamplingDelay(). */
+
+} LL_ADC_CommonInitTypeDef;
+
+/**
+  * @brief  Structure definition of some features of ADC instance.
+  * @note   These parameters have an impact on ADC scope: ADC instance.
+  *         Affects both group regular and group injected (availability
+  *         of ADC group injected depends on STM32 families).
+  *         Refer to corresponding unitary functions into
+  *         @ref ADC_LL_EF_Configuration_ADC_Instance .
+  * @note   The setting of these parameters by function @ref LL_ADC_Init()
+  *         is conditioned to ADC state:
+  *         ADC instance must be disabled.
+  *         This condition is applied to all ADC features, for efficiency
+  *         and compatibility over all STM32 families. However, the different
+  *         features can be set under different ADC state conditions
+  *         (setting possible with ADC enabled without conversion on going,
+  *         ADC enabled with conversion on going, ...)
+  *         Each feature can be updated afterwards with a unitary function
+  *         and potentially with ADC in a different state than disabled,
+  *         refer to description of each function for setting
+  *         conditioned to ADC state.
+  */
+typedef struct
+{
+  uint32_t Resolution;                  /*!< Set ADC resolution.
+                                             This parameter can be a value of @ref ADC_LL_EC_RESOLUTION
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_SetResolution(). */
+
+  uint32_t LeftBitShift;                /*!< Configures the left shifting applied to the final result with or without oversampling.
+                                             This parameter can be a value of @ref ADC_LL_EC_LEFT_BIT_SHIFT. */
+
+  uint32_t LowPowerMode;                /*!< Set ADC low power mode.
+                                             This parameter can be a value of @ref ADC_LL_EC_LP_MODE
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_SetLowPowerMode(). */
+
+} LL_ADC_InitTypeDef;
+
+/**
+  * @brief  Structure definition of some features of ADC group regular.
+  * @note   These parameters have an impact on ADC scope: ADC group regular.
+  *         Refer to corresponding unitary functions into
+  *         @ref ADC_LL_EF_Configuration_ADC_Group_Regular
+  *         (functions with prefix "REG").
+  * @note   The setting of these parameters by function @ref LL_ADC_REG_Init()
+  *         is conditioned to ADC state:
+  *         ADC instance must be disabled.
+  *         This condition is applied to all ADC features, for efficiency
+  *         and compatibility over all STM32 families. However, the different
+  *         features can be set under different ADC state conditions
+  *         (setting possible with ADC enabled without conversion on going,
+  *         ADC enabled with conversion on going, ...)
+  *         Each feature can be updated afterwards with a unitary function
+  *         and potentially with ADC in a different state than disabled,
+  *         refer to description of each function for setting
+  *         conditioned to ADC state.
+  */
+typedef struct
+{
+  uint32_t TriggerSource;               /*!< Set ADC group regular conversion trigger source: internal (SW start) or from external peripheral (timer event, external interrupt line).
+                                             This parameter can be a value of @ref ADC_LL_EC_REG_TRIGGER_SOURCE
+                                             @note On this STM32 series, setting trigger source to external trigger also set trigger polarity to rising edge
+                                                   (default setting for compatibility with some ADC on other STM32 families having this setting set by HW default value).
+                                                   In case of need to modify trigger edge, use function @ref LL_ADC_REG_SetTriggerEdge().
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_REG_SetTriggerSource(). */
+
+  uint32_t SequencerLength;             /*!< Set ADC group regular sequencer length.
+                                             This parameter can be a value of @ref ADC_LL_EC_REG_SEQ_SCAN_LENGTH
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_REG_SetSequencerLength(). */
+
+  uint32_t SequencerDiscont;            /*!< Set ADC group regular sequencer discontinuous mode: sequence subdivided and scan conversions interrupted every selected number of ranks.
+                                             This parameter can be a value of @ref ADC_LL_EC_REG_SEQ_DISCONT_MODE
+                                             @note This parameter has an effect only if group regular sequencer is enabled
+                                                   (scan length of 2 ranks or more).
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_REG_SetSequencerDiscont(). */
+
+  uint32_t ContinuousMode;              /*!< Set ADC continuous conversion mode on ADC group regular, whether ADC conversions are performed in single mode (one conversion per trigger) or in continuous mode (after the first trigger, following conversions launched successively automatically).
+                                             This parameter can be a value of @ref ADC_LL_EC_REG_CONTINUOUS_MODE
+                                             Note: It is not possible to enable both ADC group regular continuous mode and discontinuous mode.
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_REG_SetContinuousMode(). */
+
+  uint32_t DataTransferMode;            /*!< Set ADC group regular conversion data transfer mode: no transfer, transfer by DMA (Limited/Unlimited) or DFSDM.
+                                             This parameter can be a value of @ref ADC_LL_EC_REG_DATA_TRANSFER_MODE
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_REG_SetDataTransferMode(). */
+
+  uint32_t Overrun;                     /*!< Set ADC group regular behavior in case of overrun:
+                                             data preserved or overwritten.
+                                             This parameter can be a value of @ref ADC_LL_EC_REG_OVR_DATA_BEHAVIOR
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_REG_SetOverrun(). */
+
+} LL_ADC_REG_InitTypeDef;
+
+/**
+  * @brief  Structure definition of some features of ADC group injected.
+  * @note   These parameters have an impact on ADC scope: ADC group injected.
+  *         Refer to corresponding unitary functions into
+  *         @ref ADC_LL_EF_Configuration_ADC_Group_Regular
+  *         (functions with prefix "INJ").
+  * @note   The setting of these parameters by function @ref LL_ADC_INJ_Init()
+  *         is conditioned to ADC state:
+  *         ADC instance must be disabled.
+  *         This condition is applied to all ADC features, for efficiency
+  *         and compatibility over all STM32 families. However, the different
+  *         features can be set under different ADC state conditions
+  *         (setting possible with ADC enabled without conversion on going,
+  *         ADC enabled with conversion on going, ...)
+  *         Each feature can be updated afterwards with a unitary function
+  *         and potentially with ADC in a different state than disabled,
+  *         refer to description of each function for setting
+  *         conditioned to ADC state.
+  */
+typedef struct
+{
+  uint32_t TriggerSource;               /*!< Set ADC group injected conversion trigger source: internal (SW start) or from external peripheral (timer event, external interrupt line).
+                                             This parameter can be a value of @ref ADC_LL_EC_INJ_TRIGGER_SOURCE
+                                             @note On this STM32 series, setting trigger source to external trigger also set trigger polarity to rising edge
+                                                   (default setting for compatibility with some ADC on other STM32 families having this setting set by HW default value).
+                                                   In case of need to modify trigger edge, use function @ref LL_ADC_INJ_SetTriggerEdge().
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_INJ_SetTriggerSource(). */
+
+  uint32_t SequencerLength;             /*!< Set ADC group injected sequencer length.
+                                             This parameter can be a value of @ref ADC_LL_EC_INJ_SEQ_SCAN_LENGTH
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_INJ_SetSequencerLength(). */
+
+  uint32_t SequencerDiscont;            /*!< Set ADC group injected sequencer discontinuous mode: sequence subdivided and scan conversions interrupted every selected number of ranks.
+                                             This parameter can be a value of @ref ADC_LL_EC_INJ_SEQ_DISCONT_MODE
+                                             @note This parameter has an effect only if group injected sequencer is enabled
+                                                   (scan length of 2 ranks or more).
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_INJ_SetSequencerDiscont(). */
+
+  uint32_t TrigAuto;                    /*!< Set ADC group injected conversion trigger: independent or from ADC group regular.
+                                             This parameter can be a value of @ref ADC_LL_EC_INJ_TRIG_AUTO
+                                             Note: This parameter must be set to set to independent trigger if injected trigger source is set to an external trigger.
+
+                                             This feature can be modified afterwards using unitary function @ref LL_ADC_INJ_SetTrigAuto(). */
+
+} LL_ADC_INJ_InitTypeDef;
+
+/**
+  * @}
+  */
+#endif /* USE_FULL_LL_DRIVER */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup ADC_LL_Exported_Constants ADC Exported Constants
+  * @{
+  */
+
+/** @defgroup ADC_LL_EC_FLAG ADC flags
+  * @brief    Flags defines which can be used with LL_ADC_ReadReg function
+  * @{
+  */
+#define LL_ADC_FLAG_ADRDY                  ADC_ISR_ADRDY      /*!< ADC flag ADC instance ready */
+#define LL_ADC_FLAG_EOC                    ADC_ISR_EOC        /*!< ADC flag ADC group regular end of unitary conversion */
+#define LL_ADC_FLAG_EOS                    ADC_ISR_EOS        /*!< ADC flag ADC group regular end of sequence conversions */
+#define LL_ADC_FLAG_OVR                    ADC_ISR_OVR        /*!< ADC flag ADC group regular overrun */
+#define LL_ADC_FLAG_EOSMP                  ADC_ISR_EOSMP      /*!< ADC flag ADC group regular end of sampling phase */
+#define LL_ADC_FLAG_JEOC                   ADC_ISR_JEOC       /*!< ADC flag ADC group injected end of unitary conversion */
+#define LL_ADC_FLAG_JEOS                   ADC_ISR_JEOS       /*!< ADC flag ADC group injected end of sequence conversions */
+#define LL_ADC_FLAG_JQOVF                  ADC_ISR_JQOVF      /*!< ADC flag ADC group injected contexts queue overflow */
+#define LL_ADC_FLAG_AWD1                   ADC_ISR_AWD1       /*!< ADC flag ADC analog watchdog 1 */
+#define LL_ADC_FLAG_AWD2                   ADC_ISR_AWD2       /*!< ADC flag ADC analog watchdog 2 */
+#define LL_ADC_FLAG_AWD3                   ADC_ISR_AWD3       /*!< ADC flag ADC analog watchdog 3 */
+#define LL_ADC_FLAG_LDORDY                 ADC_ISR_LDORDY     /*!< ADC flag ADC LDO output voltage ready bit */
+#define LL_ADC_FLAG_ADRDY_MST              ADC_CSR_ADRDY_MST  /*!< ADC flag ADC multimode master instance ready */
+#define LL_ADC_FLAG_ADRDY_SLV              ADC_CSR_ADRDY_SLV  /*!< ADC flag ADC multimode slave instance ready */
+#define LL_ADC_FLAG_EOC_MST                ADC_CSR_EOC_MST    /*!< ADC flag ADC multimode master group regular end of unitary conversion */
+#define LL_ADC_FLAG_EOC_SLV                ADC_CSR_EOC_SLV    /*!< ADC flag ADC multimode slave group regular end of unitary conversion */
+#define LL_ADC_FLAG_EOS_MST                ADC_CSR_EOS_MST    /*!< ADC flag ADC multimode master group regular end of sequence conversions */
+#define LL_ADC_FLAG_EOS_SLV                ADC_CSR_EOS_SLV    /*!< ADC flag ADC multimode slave group regular end of sequence conversions */
+#define LL_ADC_FLAG_OVR_MST                ADC_CSR_OVR_MST    /*!< ADC flag ADC multimode master group regular overrun */
+#define LL_ADC_FLAG_OVR_SLV                ADC_CSR_OVR_SLV    /*!< ADC flag ADC multimode slave group regular overrun */
+#define LL_ADC_FLAG_EOSMP_MST              ADC_CSR_EOSMP_MST  /*!< ADC flag ADC multimode master group regular end of sampling phase */
+#define LL_ADC_FLAG_EOSMP_SLV              ADC_CSR_EOSMP_SLV  /*!< ADC flag ADC multimode slave group regular end of sampling phase */
+#define LL_ADC_FLAG_JEOC_MST               ADC_CSR_JEOC_MST   /*!< ADC flag ADC multimode master group injected end of unitary conversion */
+#define LL_ADC_FLAG_JEOC_SLV               ADC_CSR_JEOC_SLV   /*!< ADC flag ADC multimode slave group injected end of unitary conversion */
+#define LL_ADC_FLAG_JEOS_MST               ADC_CSR_JEOS_MST   /*!< ADC flag ADC multimode master group injected end of sequence conversions */
+#define LL_ADC_FLAG_JEOS_SLV               ADC_CSR_JEOS_SLV   /*!< ADC flag ADC multimode slave group injected end of sequence conversions */
+#define LL_ADC_FLAG_JQOVF_MST              ADC_CSR_JQOVF_MST  /*!< ADC flag ADC multimode master group injected contexts queue overflow */
+#define LL_ADC_FLAG_JQOVF_SLV              ADC_CSR_JQOVF_SLV  /*!< ADC flag ADC multimode slave group injected contexts queue overflow */
+#define LL_ADC_FLAG_AWD1_MST               ADC_CSR_AWD1_MST   /*!< ADC flag ADC multimode master analog watchdog 1 of the ADC master */
+#define LL_ADC_FLAG_AWD1_SLV               ADC_CSR_AWD1_SLV   /*!< ADC flag ADC multimode slave analog watchdog 1 of the ADC slave */
+#define LL_ADC_FLAG_AWD2_MST               ADC_CSR_AWD2_MST   /*!< ADC flag ADC multimode master analog watchdog 2 of the ADC master */
+#define LL_ADC_FLAG_AWD2_SLV               ADC_CSR_AWD2_SLV   /*!< ADC flag ADC multimode slave analog watchdog 2 of the ADC slave */
+#define LL_ADC_FLAG_AWD3_MST               ADC_CSR_AWD3_MST   /*!< ADC flag ADC multimode master analog watchdog 3 of the ADC master */
+#define LL_ADC_FLAG_AWD3_SLV               ADC_CSR_AWD3_SLV   /*!< ADC flag ADC multimode slave analog watchdog 3 of the ADC slave */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_IT ADC interruptions for configuration (interruption enable or disable)
+  * @brief    IT defines which can be used with LL_ADC_ReadReg and  LL_ADC_WriteReg functions
+  * @{
+  */
+#define LL_ADC_IT_ADRDY                    ADC_IER_ADRDYIE    /*!< ADC interruption ADC instance ready */
+#define LL_ADC_IT_EOC                      ADC_IER_EOCIE      /*!< ADC interruption ADC group regular end of unitary conversion */
+#define LL_ADC_IT_EOS                      ADC_IER_EOSIE      /*!< ADC interruption ADC group regular end of sequence conversions */
+#define LL_ADC_IT_OVR                      ADC_IER_OVRIE      /*!< ADC interruption ADC group regular overrun */
+#define LL_ADC_IT_EOSMP                    ADC_IER_EOSMPIE    /*!< ADC interruption ADC group regular end of sampling phase */
+#define LL_ADC_IT_JEOC                     ADC_IER_JEOCIE     /*!< ADC interruption ADC group injected end of unitary conversion */
+#define LL_ADC_IT_JEOS                     ADC_IER_JEOSIE     /*!< ADC interruption ADC group injected end of sequence conversions */
+#define LL_ADC_IT_JQOVF                    ADC_IER_JQOVFIE    /*!< ADC interruption ADC group injected contexts queue overflow */
+#define LL_ADC_IT_AWD1                     ADC_IER_AWD1IE     /*!< ADC interruption ADC analog watchdog 1 */
+#define LL_ADC_IT_AWD2                     ADC_IER_AWD2IE     /*!< ADC interruption ADC analog watchdog 2 */
+#define LL_ADC_IT_AWD3                     ADC_IER_AWD3IE     /*!< ADC interruption ADC analog watchdog 3 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_REGISTERS  ADC registers compliant with specific purpose
+  * @{
+  */
+/* List of ADC registers intended to be used (most commonly) with             */
+/* DMA transfer.                                                              */
+/* Refer to function @ref LL_ADC_DMA_GetRegAddr().                            */
+#define LL_ADC_DMA_REG_REGULAR_DATA          (0x00000000UL) /* ADC group regular conversion data register (corresponding to register DR) to be used with ADC configured in independent mode. Without DMA transfer, register accessed by LL function @ref LL_ADC_REG_ReadConversionData32() and other functions @ref LL_ADC_REG_ReadConversionDatax() */
+#define LL_ADC_DMA_REG_REGULAR_DATA_MULTI    (0x00000001UL) /* ADC group regular conversion data register (corresponding to register CDR) to be used with ADC configured in multimode (available on STM32 devices with several ADC instances). Without DMA transfer, register accessed by LL function @ref LL_ADC_REG_ReadMultiConversionData32() */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_COMMON_CLOCK_SOURCE  ADC common - Clock source
+  * @{
+  */
+#define LL_ADC_CLOCK_SYNC_PCLK_DIV1        (ADC_CCR_CKMODE_0)                                    /*!< ADC synchronous clock derived from AHB clock without prescaler */
+#define LL_ADC_CLOCK_SYNC_PCLK_DIV2        (ADC_CCR_CKMODE_1                   )                 /*!< ADC synchronous clock derived from AHB clock with prescaler division by 2 */
+#define LL_ADC_CLOCK_SYNC_PCLK_DIV4        (ADC_CCR_CKMODE_1 | ADC_CCR_CKMODE_0)                 /*!< ADC synchronous clock derived from AHB clock with prescaler division by 4 */
+#define LL_ADC_CLOCK_ASYNC_DIV1            (0x00000000UL)                                        /*!< ADC asynchronous clock without prescaler */
+#define LL_ADC_CLOCK_ASYNC_DIV2            (ADC_CCR_PRESC_0)                                     /*!< ADC asynchronous clock with prescaler division by 2   */
+#define LL_ADC_CLOCK_ASYNC_DIV4            (ADC_CCR_PRESC_1                  )                   /*!< ADC asynchronous clock with prescaler division by 4   */
+#define LL_ADC_CLOCK_ASYNC_DIV6            (ADC_CCR_PRESC_1 | ADC_CCR_PRESC_0)                   /*!< ADC asynchronous clock with prescaler division by 6   */
+#define LL_ADC_CLOCK_ASYNC_DIV8            (ADC_CCR_PRESC_2                                    ) /*!< ADC asynchronous clock with prescaler division by 8   */
+#define LL_ADC_CLOCK_ASYNC_DIV10           (ADC_CCR_PRESC_2                   | ADC_CCR_PRESC_0) /*!< ADC asynchronous clock with prescaler division by 10  */
+#define LL_ADC_CLOCK_ASYNC_DIV12           (ADC_CCR_PRESC_2 | ADC_CCR_PRESC_1                  ) /*!< ADC asynchronous clock with prescaler division by 12  */
+#define LL_ADC_CLOCK_ASYNC_DIV16           (ADC_CCR_PRESC_2 | ADC_CCR_PRESC_1 | ADC_CCR_PRESC_0) /*!< ADC asynchronous clock with prescaler division by 16  */
+#define LL_ADC_CLOCK_ASYNC_DIV32           (ADC_CCR_PRESC_3)                                     /*!< ADC asynchronous clock with prescaler division by 32  */
+#define LL_ADC_CLOCK_ASYNC_DIV64           (ADC_CCR_PRESC_3 | ADC_CCR_PRESC_0)                   /*!< ADC asynchronous clock with prescaler division by 64  */
+#define LL_ADC_CLOCK_ASYNC_DIV128          (ADC_CCR_PRESC_3 | ADC_CCR_PRESC_1)                   /*!< ADC asynchronous clock with prescaler division by 128 */
+#define LL_ADC_CLOCK_ASYNC_DIV256          (ADC_CCR_PRESC_3 | ADC_CCR_PRESC_1 | ADC_CCR_PRESC_0) /*!< ADC asynchronous clock with prescaler division by 256 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_COMMON_PATH_INTERNAL  ADC common - Measurement path to internal channels
+  * @{
+  */
+/* Note: Other measurement paths to internal channels may be available        */
+/*       (connections to other peripherals).                                  */
+/*       If they are not listed below, they do not require any specific       */
+/*       path enable. In this case, Access to measurement path is done        */
+/*       only by selecting the corresponding ADC internal channel.            */
+#define LL_ADC_PATH_INTERNAL_NONE          (0x00000000UL)         /*!< ADC measurement paths all disabled */
+#define LL_ADC_PATH_INTERNAL_VREFINT       (ADC_CCR_VREFEN)       /*!< ADC measurement path to internal channel VrefInt */
+#define LL_ADC_PATH_INTERNAL_TEMPSENSOR    (ADC_CCR_TSEN)         /*!< ADC measurement path to internal channel temperature sensor */
+#define LL_ADC_PATH_INTERNAL_VBAT          (ADC_CCR_VBATEN)       /*!< ADC measurement path to internal channel Vbat */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_BOOST_MODE ADC instance - Boost mode
+  * @{
+  */
+#define LL_ADC_BOOST_MODE_6MHZ25   (0x00000000UL)                                            /*!< Boost mode is configured for frequency <= 6.25Mhz           */
+#define LL_ADC_BOOST_MODE_12MHZ5   (                                        ADC_CR_BOOST_0)  /*!< Boost mode is configured for 6.25Mhz < frequency <= 12.5Mhz */
+#define LL_ADC_BOOST_MODE_20MHZ    (                       ADC_CR_BOOST_1                 )  /*!< Boost mode is configured for 12.5Mhz < frequency <= 20Mhz   */
+#define LL_ADC_BOOST_MODE_25MHZ    ((ADC_CR_BOOST_0 <<2) | ADC_CR_BOOST_1                 )  /*!< Boost mode is configured for 20Mhz   < frequency <= 25Mhz   */
+#define LL_ADC_BOOST_MODE_50MHZ    ((ADC_CR_BOOST_0 <<2) | ADC_CR_BOOST_1 | ADC_CR_BOOST_0)  /*!< Boost mode is configured for frequency > 25Mhz              */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_CALIBRATION_OFFSET_LINEARITY  ADC instance - Calibration mode for offset and linearity
+  * @{
+  */
+#define LL_ADC_CALIB_OFFSET                (ADC_CALIB_FACTOR_OFFSET_REGOFFSET)                      /*!< Calibration of ADC offset. Duration of calibration of offset duration: 1280 ADC clock cycles. For devices with differential mode available: Calibration of offset is specific to each of single-ended and differential modes. */
+#define LL_ADC_CALIB_LINEARITY             (ADC_CALIB_FACTOR_LINEARITY_REGOFFSET)                   /*!< Calibration of ADC linearity. Duration of calibration of linearity: 15104 ADC clock cycles. For devices with differential mode available: Calibration of linearity is common to both single-ended and differential modes. */
+#define LL_ADC_CALIB_OFFSET_LINEARITY      (ADC_CALIB_FACTOR_LINEARITY_REGOFFSET | ADC_CR_ADCALLIN) /*!< Calibration of ADC offset and linearity. Duration of calibration of offset and linearity: 16384 ADC clock cycles. For devices with differential mode available: Calibration of offset is specific to each of single-ended and differential modes, calibration of linearity is common to both single-ended and differential modes. */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_CALIBRATION_LINEARITY_WORD  ADC instance - Calibration linearity words
+  * @{
+  */
+#define LL_ADC_CALIB_LINEARITY_WORD1       (ADC_CR_LINCALRDYW1)    /*!< ADC calibration linearity word 1 */
+#define LL_ADC_CALIB_LINEARITY_WORD2       (ADC_CR_LINCALRDYW2)    /*!< ADC calibration linearity word 2 */
+#define LL_ADC_CALIB_LINEARITY_WORD3       (ADC_CR_LINCALRDYW3)    /*!< ADC calibration linearity word 3 */
+#define LL_ADC_CALIB_LINEARITY_WORD4       (ADC_CR_LINCALRDYW4)    /*!< ADC calibration linearity word 4 */
+#define LL_ADC_CALIB_LINEARITY_WORD5       (ADC_CR_LINCALRDYW5)    /*!< ADC calibration linearity word 5 */
+#define LL_ADC_CALIB_LINEARITY_WORD6       (ADC_CR_LINCALRDYW6)    /*!< ADC calibration linearity word 6 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_RESOLUTION  ADC instance - Resolution
+  * @{
+  */
+#define LL_ADC_RESOLUTION_16B              (0x00000000UL)                                      /*!< ADC resolution 16 bits */
+#define LL_ADC_RESOLUTION_14B              (                                  ADC_CFGR_RES_0)  /*!< ADC resolution 12 bits */
+#define LL_ADC_RESOLUTION_12B              (                 ADC_CFGR_RES_1                 )  /*!< ADC resolution 12 bits */
+#define LL_ADC_RESOLUTION_10B              (                 ADC_CFGR_RES_1 | ADC_CFGR_RES_0)  /*!< ADC resolution 10 bits */
+
+#if defined (ADC_VER_V5_X)
+#define LL_ADC_RESOLUTION_14B_OPT          (ADC_CFGR_RES_2 |                  ADC_CFGR_RES_0)  /*!< ADC resolution 14 bits optimized for power consumption, available on for devices revision V only */
+#define LL_ADC_RESOLUTION_12B_OPT          (ADC_CFGR_RES_2 | ADC_CFGR_RES_1                 )  /*!< ADC resolution 12 bits optimized for power consumption, available on for devices revision V only */
+#endif
+
+#if defined (ADC_VER_V5_3) || defined(ADC_VER_V5_V90)
+#define LL_ADC_RESOLUTION_8B               (ADC_CFGR_RES_2|ADC_CFGR_RES_1 | ADC_CFGR_RES_0) /*!< ADC resolution  8 bits */
+#else
+#define LL_ADC_RESOLUTION_8B               (ADC_CFGR_RES_2                                ) /*!< ADC resolution  8 bits */
+                                                                                            /*!< The resolution setting is managed internally in the driver:
+                                                                                                    "LL_ADC_RESOLUTION_8B" definition: keep using the "100b" value (corresponding to STM32H74x/5x rev Y).
+                                                                                                    Rev.V value "111b" is handled through functions "LL_ADC_SetResolution/LL_ADC_GetResolution"  with a dedicated check on DBGMCU IDCODE register */
+#endif
+#if defined(ADC_VER_V5_V90)
+#define LL_ADC_RESOLUTION_6B               (ADC3_CFGR_RES_1 | ADC3_CFGR_RES_0)   /*!< ADC resolution  6 bits. Value available for ADC3 on STM32H72xx/3xx devices only*/
+#endif  /* ADC_VER_V5_V90 */
+/**
+  * @}
+  */
+
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_LL_EC_DATA_ALIGN  ADC instance - Data alignment
+  * @{
+  */
+#define LL_ADC_DATA_ALIGN_RIGHT            (0x00000000UL)         /*!< ADC conversion data alignment: right aligned (alignment on data register LSB bit 0)*/
+#define LL_ADC_DATA_ALIGN_LEFT             (ADC3_CFGR_ALIGN)       /*!< ADC conversion data alignment: left aligned (alignment on data register MSB bit 15)*/
+/**
+  * @}
+  */
+
+#endif  /* ADC_VER_V5_V90 */
+
+/** @defgroup ADC_LL_EC_LEFT_BIT_SHIFT   ADC left Shift
+  * @{
+  */
+#define LL_ADC_LEFT_BIT_SHIFT_NONE  (0x00000000UL)                                                                       /*!< ADC no bit shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_1     (ADC_CFGR2_LSHIFT_0)                                                                 /*!< ADC 1 bit shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_2     (ADC_CFGR2_LSHIFT_1)                                                                 /*!< ADC 2 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_3     (ADC_CFGR2_LSHIFT_1 | ADC_CFGR2_LSHIFT_0)                                            /*!< ADC 3 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_4     (ADC_CFGR2_LSHIFT_2)                                                                 /*!< ADC 4 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_5     (ADC_CFGR2_LSHIFT_2 | ADC_CFGR2_LSHIFT_0)                                            /*!< ADC 5 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_6     (ADC_CFGR2_LSHIFT_2 | ADC_CFGR2_LSHIFT_1)                                            /*!< ADC 6 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_7     (ADC_CFGR2_LSHIFT_2 | ADC_CFGR2_LSHIFT_1 | ADC_CFGR2_LSHIFT_0)                       /*!< ADC 7 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_8     (ADC_CFGR2_LSHIFT_3)                                                                 /*!< ADC 8 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_9     (ADC_CFGR2_LSHIFT_3 | ADC_CFGR2_LSHIFT_0)                                            /*!< ADC 9 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_10    (ADC_CFGR2_LSHIFT_3 | ADC_CFGR2_LSHIFT_1)                                            /*!< ADC 10 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_11    (ADC_CFGR2_LSHIFT_3 | ADC_CFGR2_LSHIFT_1 | ADC_CFGR2_LSHIFT_0)                       /*!< ADC 11 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_12    (ADC_CFGR2_LSHIFT_3 | ADC_CFGR2_LSHIFT_2)                                            /*!< ADC 12 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_13    (ADC_CFGR2_LSHIFT_3 | ADC_CFGR2_LSHIFT_2 | ADC_CFGR2_LSHIFT_0)                       /*!< ADC 13 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_14    (ADC_CFGR2_LSHIFT_3 | ADC_CFGR2_LSHIFT_2 | ADC_CFGR2_LSHIFT_1)                       /*!< ADC 14 bits shift left applied on the final ADC conversion data */
+#define LL_ADC_LEFT_BIT_SHIFT_15    (ADC_CFGR2_LSHIFT_3 | ADC_CFGR2_LSHIFT_2 | ADC_CFGR2_LSHIFT_1 | ADC_CFGR2_LSHIFT_0)  /*!< ADC 15 bits shift left applied on the final ADC conversion data */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_LP_MODE  ADC instance - Low power mode
+  * @{
+  */
+#define LL_ADC_LP_MODE_NONE                (0x00000000UL)                      /*!< No ADC low power mode activated */
+#define LL_ADC_LP_AUTOWAIT                 (ADC_CFGR_AUTDLY)                   /*!< ADC low power mode auto delay: Dynamic low power mode, ADC conversions are performed only when necessary (when previous ADC conversion data is read). See description with function @ref LL_ADC_SetLowPowerMode(). */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_OFFSET_NB  ADC instance - Offset number
+  * @{
+  */
+#define LL_ADC_OFFSET_1                    ADC_OFR1_REGOFFSET /*!< ADC offset number 1: ADC channel and offset level to which the offset programmed will be applied (independently of channel mapped on ADC group regular or group injected) */
+#define LL_ADC_OFFSET_2                    ADC_OFR2_REGOFFSET /*!< ADC offset number 2: ADC channel and offset level to which the offset programmed will be applied (independently of channel mapped on ADC group regular or group injected) */
+#define LL_ADC_OFFSET_3                    ADC_OFR3_REGOFFSET /*!< ADC offset number 3: ADC channel and offset level to which the offset programmed will be applied (independently of channel mapped on ADC group regular or group injected) */
+#define LL_ADC_OFFSET_4                    ADC_OFR4_REGOFFSET /*!< ADC offset number 4: ADC channel and offset level to which the offset programmed will be applied (independently of channel mapped on ADC group regular or group injected) */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_OFFSET_SIGNED_SATURATION ADC instance - Offset signed saturation mode
+  * @{
+  */
+#define LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE   (0x00000000UL)   /*!< ADC offset signed saturation is disabled (among ADC selected offset number 1, 2, 3 or 4) */
+#define LL_ADC_OFFSET_SIGNED_SATURATION_ENABLE    (ADC_OFR1_SSATE) /*!< ADC offset signed saturation is enabled (among ADC selected offset number 1, 2, 3 or 4) */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_OFFSET_RSHIFT ADC instance - Offset right shift
+  * @{
+  */
+#define LL_ADC_OFFSET_RSHIFT_DISABLE   (0x00000000UL)      /*!< ADC offset right shift is disabled (among ADC selected offset number 1, 2, 3 or 4) */
+#define LL_ADC_OFFSET_RSHIFT_ENABLE    (ADC_CFGR2_RSHIFT1) /*!< ADC offset right shift is enabled (among ADC selected offset number 1, 2, 3 or 4) */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_LL_EC_OFFSET_SATURATION ADC instance - Offset saturation mode
+  * @{
+  */
+#define LL_ADC_OFFSET_SATURATION_DISABLE   (0x00000000UL)           /*!< ADC offset saturation is disabled (among ADC selected offset number 1, 2, 3 or 4). On devices STM32H72xx and STM32H73xx */
+#define LL_ADC_OFFSET_SATURATION_ENABLE    (ADC3_OFR1_SATEN)        /*!< ADC offset saturation is enabled (among ADC selected offset number 1, 2, 3 or 4). On devices STM32H72xx and STM32H73xx */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_OFFSET_STATE ADC instance - Offset state
+  * @{
+  */
+#define LL_ADC_OFFSET_DISABLE              (0x00000000UL)         /*!< ADC offset disabled (among ADC selected offset number 1, 2, 3 or 4) */
+#define LL_ADC_OFFSET_ENABLE               (ADC3_OFR1_OFFSET1_EN)  /*!< ADC offset enabled (among ADC selected offset number 1, 2, 3 or 4) */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_LL_EC_OFFSET_SIGN ADC instance - Offset sign
+  * @{
+  */
+#define LL_ADC_OFFSET_SIGN_NEGATIVE        (0x00000000UL)        /*!< ADC offset is negative (among ADC selected offset number 1, 2, 3 or 4). On devices STM32H72xx and STM32H73xx */
+#define LL_ADC_OFFSET_SIGN_POSITIVE        (ADC3_OFR1_OFFSETPOS) /*!< ADC offset is positive (among ADC selected offset number 1, 2, 3 or 4). On devices STM32H72xx and STM32H73xx */
+/**
+  * @}
+  */
+#endif /* ADC_VER_V5_V90 */
+
+#endif /* ADC_VER_V5_V90 */
+
+/** @defgroup ADC_LL_EC_GROUPS  ADC instance - Groups
+  * @{
+  */
+#define LL_ADC_GROUP_REGULAR               (0x00000001UL) /*!< ADC group regular (available on all STM32 devices) */
+#define LL_ADC_GROUP_INJECTED              (0x00000002UL) /*!< ADC group injected (not available on all STM32 devices)*/
+#define LL_ADC_GROUP_REGULAR_INJECTED      (0x00000003UL) /*!< ADC both groups regular and injected */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_CHANNEL  ADC instance - Channel number
+  * @{
+  */
+#define LL_ADC_CHANNEL_0                   (ADC_CHANNEL_0_NUMBER  | ADC_CHANNEL_0_SMP  | ADC_CHANNEL_0_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN0  */
+#define LL_ADC_CHANNEL_1                   (ADC_CHANNEL_1_NUMBER  | ADC_CHANNEL_1_SMP  | ADC_CHANNEL_1_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN1  */
+#define LL_ADC_CHANNEL_2                   (ADC_CHANNEL_2_NUMBER  | ADC_CHANNEL_2_SMP  | ADC_CHANNEL_2_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN2  */
+#define LL_ADC_CHANNEL_3                   (ADC_CHANNEL_3_NUMBER  | ADC_CHANNEL_3_SMP  | ADC_CHANNEL_3_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN3  */
+#define LL_ADC_CHANNEL_4                   (ADC_CHANNEL_4_NUMBER  | ADC_CHANNEL_4_SMP  | ADC_CHANNEL_4_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN4  */
+#define LL_ADC_CHANNEL_5                   (ADC_CHANNEL_5_NUMBER  | ADC_CHANNEL_5_SMP  | ADC_CHANNEL_5_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN5  */
+#define LL_ADC_CHANNEL_6                   (ADC_CHANNEL_6_NUMBER  | ADC_CHANNEL_6_SMP  | ADC_CHANNEL_6_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN6  */
+#define LL_ADC_CHANNEL_7                   (ADC_CHANNEL_7_NUMBER  | ADC_CHANNEL_7_SMP  | ADC_CHANNEL_7_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN7  */
+#define LL_ADC_CHANNEL_8                   (ADC_CHANNEL_8_NUMBER  | ADC_CHANNEL_8_SMP  | ADC_CHANNEL_8_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN8  */
+#define LL_ADC_CHANNEL_9                   (ADC_CHANNEL_9_NUMBER  | ADC_CHANNEL_9_SMP  | ADC_CHANNEL_9_BITFIELD ) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN9  */
+#define LL_ADC_CHANNEL_10                  (ADC_CHANNEL_10_NUMBER | ADC_CHANNEL_10_SMP | ADC_CHANNEL_10_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN10 */
+#define LL_ADC_CHANNEL_11                  (ADC_CHANNEL_11_NUMBER | ADC_CHANNEL_11_SMP | ADC_CHANNEL_11_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN11 */
+#define LL_ADC_CHANNEL_12                  (ADC_CHANNEL_12_NUMBER | ADC_CHANNEL_12_SMP | ADC_CHANNEL_12_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN12 */
+#define LL_ADC_CHANNEL_13                  (ADC_CHANNEL_13_NUMBER | ADC_CHANNEL_13_SMP | ADC_CHANNEL_13_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN13 */
+#define LL_ADC_CHANNEL_14                  (ADC_CHANNEL_14_NUMBER | ADC_CHANNEL_14_SMP | ADC_CHANNEL_14_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN14 */
+#define LL_ADC_CHANNEL_15                  (ADC_CHANNEL_15_NUMBER | ADC_CHANNEL_15_SMP | ADC_CHANNEL_15_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN15 */
+#define LL_ADC_CHANNEL_16                  (ADC_CHANNEL_16_NUMBER | ADC_CHANNEL_16_SMP | ADC_CHANNEL_16_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN16 */
+#define LL_ADC_CHANNEL_17                  (ADC_CHANNEL_17_NUMBER | ADC_CHANNEL_17_SMP | ADC_CHANNEL_17_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN17 */
+#define LL_ADC_CHANNEL_18                  (ADC_CHANNEL_18_NUMBER | ADC_CHANNEL_18_SMP | ADC_CHANNEL_18_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN18 */
+#define LL_ADC_CHANNEL_19                  (ADC_CHANNEL_19_NUMBER | ADC_CHANNEL_19_SMP | ADC_CHANNEL_19_BITFIELD) /*!< ADC external channel (channel connected to GPIO pin) ADCx_IN19 */
+#if defined(ADC3)
+#if defined(ADC_VER_V5_V90)
+#define LL_ADC_CHANNEL_VREFINT             (LL_ADC_CHANNEL_18 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to VrefInt: Internal voltage reference. On STM32H7, ADC channel available only on ADC instance: ADC3. */
+#define LL_ADC_CHANNEL_TEMPSENSOR          (LL_ADC_CHANNEL_17 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to Temperature sensor. On STM32H7, ADC channel available only on ADC instance: ADC3. */
+#define LL_ADC_CHANNEL_VBAT                (LL_ADC_CHANNEL_16 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to Vbat/3: Vbat voltage through a divider ladder of factor 1/4 to have Vbat always below Vdda. On STM32H7, ADC channel available only on ADC instance: ADC3. */
+#else
+#define LL_ADC_CHANNEL_VREFINT             (LL_ADC_CHANNEL_19 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to VrefInt: Internal voltage reference. On STM32H7, ADC channel available only on ADC instance: ADC3. */
+#define LL_ADC_CHANNEL_TEMPSENSOR          (LL_ADC_CHANNEL_18 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to Temperature sensor. On STM32H7, ADC channel available only on ADC instance: ADC3. */
+#define LL_ADC_CHANNEL_VBAT                (LL_ADC_CHANNEL_17 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to Vbat/3: Vbat voltage through a divider ladder of factor 1/4 to have Vbat always below Vdda. On STM32H7, ADC channel available only on ADC instance: ADC3. */
+#endif /* ADC_VER_V5_V90 */
+#else
+/*!< Specific define for STM32H7A3xx and STM32HB3xx varieties of STM32H7XXX */
+#define LL_ADC_CHANNEL_VREFINT             (LL_ADC_CHANNEL_19 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to VrefInt: Internal voltage reference. On STM32H7, ADC channel available only on ADC instance: ADC2. */
+#define LL_ADC_CHANNEL_TEMPSENSOR          (LL_ADC_CHANNEL_18 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to Temperature sensor. On STM32H7, ADC channel available only on ADC instance: ADC2. */
+#define LL_ADC_CHANNEL_VBAT                (LL_ADC_CHANNEL_14 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to Vbat/3: Vbat voltage through a divider ladder of factor 1/4 to have Vbat always below Vdda. On STM32H7, ADC channel available only on ADC instance: ADC2. */
+#endif
+#define LL_ADC_CHANNEL_DAC1CH1_ADC2        (LL_ADC_CHANNEL_16 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to DAC1 channel 1, channel specific to ADC2 */
+#define LL_ADC_CHANNEL_DAC1CH2_ADC2        (LL_ADC_CHANNEL_17 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to DAC1 channel 2, channel specific to ADC2 */
+#if defined(DAC2)
+/*!< Specific define for STM32H7A3xx and STM32HB3xx varieties of STM32H7XXX */
+#define LL_ADC_CHANNEL_DAC2CH1_ADC2        (LL_ADC_CHANNEL_15 | ADC_CHANNEL_ID_INTERNAL_CH) /*!< ADC internal channel connected to DAC2 channel 1, channel specific to ADC2 */
+#endif
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_REG_TRIGGER_SOURCE  ADC group regular - Trigger source
+  * @{
+  */
+#define LL_ADC_REG_TRIG_SOFTWARE          (0x00000000UL)                                                                                                    /*!< ADC group regular conversion trigger internal: SW start. */
+#define LL_ADC_REG_TRIG_EXT_TIM1_CH1      (ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                                                   /*!< ADC group regular conversion trigger from external peripheral: TIM1 channel 1 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM1_CH2      (ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                               /*!< ADC group regular conversion trigger from external peripheral: TIM1 channel 2 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM1_CH3      (ADC_CFGR_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                               /*!< ADC group regular conversion trigger from external peripheral: TIM1 channel 3 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM2_CH2      (ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: TIM2 channel 2 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM3_TRGO     (ADC_CFGR_EXTSEL_2 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                               /*!< ADC group regular conversion trigger from external peripheral: TIM3 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM4_CH4      (ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: TIM4 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_EXTI_LINE11   (ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: external interrupt line 11 event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM8_TRGO     (ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: TIM8 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM8_TRGO2    (ADC_CFGR_EXTSEL_3 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                               /*!< ADC group regular conversion trigger from external peripheral: TIM8 TRGO2 event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM1_TRGO     (ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: TIM1 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM1_TRGO2    (ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: TIM1 TRGO2 event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM2_TRGO     (ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: TIM2 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM4_TRGO     (ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: TIM4 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM6_TRGO     (ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: TIM6 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM15_TRGO    (ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: TIM15 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_TIM3_CH4      (ADC_CFGR_EXTSEL_3 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)   /*!< ADC group regular conversion trigger from external peripheral: TIM3 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_HRTIM_TRG1    (ADC_CFGR_EXTSEL_4 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                               /*!< ADC group regular conversion trigger from external peripheral: HRTIM TRG1 event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_HRTIM_TRG3    (ADC_CFGR_EXTSEL_4 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: HRTIM TRG2 event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_LPTIM1_OUT    (ADC_CFGR_EXTSEL_4 | ADC_CFGR_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: LPTIM1 OUT event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_LPTIM2_OUT    (ADC_CFGR_EXTSEL_4 | ADC_CFGR_EXTSEL_1 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: LPTIM2 OUT event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_LPTIM3_OUT    (ADC_CFGR_EXTSEL_4 | ADC_CFGR_EXTSEL_2 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                           /*!< ADC group regular conversion trigger from external peripheral: LPTIM3 event OUT. Trigger edge set to rising edge (default setting). */
+#if defined (TIM23)
+#define LL_ADC_REG_TRIG_EXT_TIM23_TRGO    (ADC_CFGR_EXTSEL_4 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: TIM23 TRGO event. Trigger edge set to rising edge (default setting). */
+#endif /* TIM23 */
+#if defined (TIM24)
+#define LL_ADC_REG_TRIG_EXT_TIM24_TRGO    (ADC_CFGR_EXTSEL_4 | ADC_CFGR_EXTSEL_2 | ADC_CFGR_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: TIM24 TRGO event. Trigger edge set to rising edge (default setting). */
+#endif /* TIM24 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_REG_TRIGGER_EDGE  ADC group regular - Trigger edge
+  * @{
+  */
+#define LL_ADC_REG_TRIG_EXT_RISING         (                   ADC_CFGR_EXTEN_0)   /*!< ADC group regular conversion trigger polarity set to rising edge */
+#define LL_ADC_REG_TRIG_EXT_FALLING        (ADC_CFGR_EXTEN_1                   )   /*!< ADC group regular conversion trigger polarity set to falling edge */
+#define LL_ADC_REG_TRIG_EXT_RISINGFALLING  (ADC_CFGR_EXTEN_1 | ADC_CFGR_EXTEN_0)   /*!< ADC group regular conversion trigger polarity set to both rising and falling edges */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+ /** @defgroup ADC_LL_EC_REG_SAMPLING_MODE  ADC group regular - Sampling mode
+  * @{
+  */
+#define LL_ADC_REG_SAMPLING_MODE_NORMAL               (0x00000000UL)        /*!< ADC conversions sampling phase duration is defined using  @ref ADC_LL_EC_CHANNEL_SAMPLINGTIME. On devices STM32H72xx and STM32H73xx */
+#define LL_ADC_REG_SAMPLING_MODE_BULB                 (ADC3_CFGR2_BULB)     /*!< ADC conversions sampling phase starts immediately after end of conversion, and stops upon trigger event.
+                                                                                 Note: First conversion is using minimal sampling time (see @ref ADC_LL_EC_CHANNEL_SAMPLINGTIME). On devices STM32H72xx and STM32H73xx */
+#define LL_ADC_REG_SAMPLING_MODE_TRIGGER_CONTROLED    (ADC3_CFGR2_SMPTRIG)  /*!< ADC conversions sampling phase is controlled by trigger events:
+                                                                                 Trigger rising edge  = start sampling
+                                                                                 Trigger falling edge = stop sampling and start conversion. On devices STM32H72xx and STM32H73xx */
+/**
+  * @}
+  */
+#endif /* ADC_VER_V5_V90 */
+
+/** @defgroup ADC_LL_EC_REG_CONTINUOUS_MODE  ADC group regular - Continuous mode
+* @{
+*/
+#define LL_ADC_REG_CONV_SINGLE             (0x00000000UL)          /*!< ADC conversions are performed in single mode: one conversion per trigger */
+#define LL_ADC_REG_CONV_CONTINUOUS         (ADC_CFGR_CONT)         /*!< ADC conversions are performed in continuous mode: after the first trigger, following conversions launched successively automatically */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_REG_DATA_TRANSFER_MODE  ADC group regular - Data transfer mode of ADC conversion data
+  * @{
+  */
+#define LL_ADC_REG_DR_TRANSFER             (0x00000000UL)                        /*!< ADC conversions are transferred to DR rigister */
+#define LL_ADC_REG_DMA_TRANSFER_LIMITED    (                   ADC_CFGR_DMNGT_0) /*!< ADC conversion data are transferred by DMA, in limited mode (one shot mode): DMA transfer requests are stopped when number of DMA data transfers (number of ADC conversions) is reached. This ADC mode is intended to be used with DMA mode non-circular. */
+#define LL_ADC_REG_DMA_TRANSFER_UNLIMITED  (ADC_CFGR_DMNGT_1 | ADC_CFGR_DMNGT_0) /*!< ADC conversion data are transferred by DMA, in unlimited mode: DMA transfer requests are unlimited, whatever number of DMA data transferred (number of ADC conversions). This ADC mode is intended to be used with DMA mode circular. */
+#define LL_ADC_REG_DFSDM_TRANSFER          (ADC_CFGR_DMNGT_1                   ) /*!< ADC conversion data are transferred to DFSDM */
+/**
+  * @}
+  */
+
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_LL_EC_REG_DMA_TRANSFER  ADC group regular - DMA transfer of ADC conversion data
+  * @{
+  */
+
+#define LL_ADC3_REG_DMA_TRANSFER_NONE       (0x00000000UL)                        /*!< ADC conversions are not transferred by DMA. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC3_REG_DMA_TRANSFER_LIMITED    (                  ADC3_CFGR_DMAEN)    /*!< ADC conversion data are transferred by DMA, in limited mode (one shot mode): DMA transfer requests are stopped when number of DMA data transfers (number of ADC conversions) is reached. This ADC mode is intended to be used with DMA mode non-circular. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC3_REG_DMA_TRANSFER_UNLIMITED  (ADC3_CFGR_DMACFG | ADC3_CFGR_DMAEN)    /*!< ADC conversion data are transferred by DMA, in unlimited mode: DMA transfer requests are unlimited, whatever number of DMA data transferred (number of ADC conversions). This ADC mode is intended to be used with DMA mode circular. On ADC3 of devices STM32H72xx and STM32H73xx*/
+/**
+  * @}
+  */
+#endif /* ADC_VER_V5_V90 */
+
+/** @defgroup ADC_LL_EC_REG_OVR_DATA_BEHAVIOR  ADC group regular - Overrun behavior on conversion data
+* @{
+*/
+#define LL_ADC_REG_OVR_DATA_PRESERVED      (0x00000000UL)         /*!< ADC group regular behavior in case of overrun: data preserved */
+#define LL_ADC_REG_OVR_DATA_OVERWRITTEN    (ADC_CFGR_OVRMOD)      /*!< ADC group regular behavior in case of overrun: data overwritten */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_REG_SEQ_SCAN_LENGTH  ADC group regular - Sequencer scan length
+  * @{
+  */
+#define LL_ADC_REG_SEQ_SCAN_DISABLE        (0x00000000UL)                                              /*!< ADC group regular sequencer disable (equivalent to sequencer of 1 rank: ADC conversion on only 1 channel) */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_2RANKS  (                                             ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 2 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_3RANKS  (                              ADC_SQR1_L_1               ) /*!< ADC group regular sequencer enable with 3 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_4RANKS  (                              ADC_SQR1_L_1 | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 4 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_5RANKS  (               ADC_SQR1_L_2                              ) /*!< ADC group regular sequencer enable with 5 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_6RANKS  (               ADC_SQR1_L_2                | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 6 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_7RANKS  (               ADC_SQR1_L_2 | ADC_SQR1_L_1               ) /*!< ADC group regular sequencer enable with 7 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_8RANKS  (               ADC_SQR1_L_2 | ADC_SQR1_L_1 | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 8 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_9RANKS  (ADC_SQR1_L_3                                             ) /*!< ADC group regular sequencer enable with 9 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_10RANKS (ADC_SQR1_L_3                               | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 10 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_11RANKS (ADC_SQR1_L_3                | ADC_SQR1_L_1               ) /*!< ADC group regular sequencer enable with 11 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_12RANKS (ADC_SQR1_L_3                | ADC_SQR1_L_1 | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 12 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_13RANKS (ADC_SQR1_L_3 | ADC_SQR1_L_2                              ) /*!< ADC group regular sequencer enable with 13 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_14RANKS (ADC_SQR1_L_3 | ADC_SQR1_L_2                | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 14 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_15RANKS (ADC_SQR1_L_3 | ADC_SQR1_L_2 | ADC_SQR1_L_1               ) /*!< ADC group regular sequencer enable with 15 ranks in the sequence */
+#define LL_ADC_REG_SEQ_SCAN_ENABLE_16RANKS (ADC_SQR1_L_3 | ADC_SQR1_L_2 | ADC_SQR1_L_1 | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 16 ranks in the sequence */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_REG_SEQ_DISCONT_MODE  ADC group regular - Sequencer discontinuous mode
+  * @{
+  */
+#define LL_ADC_REG_SEQ_DISCONT_DISABLE     (0x00000000UL)                                                               /*!< ADC group regular sequencer discontinuous mode disable */
+#define LL_ADC_REG_SEQ_DISCONT_1RANK       (                                                               ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every rank */
+#define LL_ADC_REG_SEQ_DISCONT_2RANKS      (                                          ADC_CFGR_DISCNUM_0 | ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enabled with sequence interruption every 2 ranks */
+#define LL_ADC_REG_SEQ_DISCONT_3RANKS      (                     ADC_CFGR_DISCNUM_1                      | ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every 3 ranks */
+#define LL_ADC_REG_SEQ_DISCONT_4RANKS      (                     ADC_CFGR_DISCNUM_1 | ADC_CFGR_DISCNUM_0 | ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every 4 ranks */
+#define LL_ADC_REG_SEQ_DISCONT_5RANKS      (ADC_CFGR_DISCNUM_2                                           | ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every 5 ranks */
+#define LL_ADC_REG_SEQ_DISCONT_6RANKS      (ADC_CFGR_DISCNUM_2                      | ADC_CFGR_DISCNUM_0 | ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every 6 ranks */
+#define LL_ADC_REG_SEQ_DISCONT_7RANKS      (ADC_CFGR_DISCNUM_2 | ADC_CFGR_DISCNUM_1                      | ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every 7 ranks */
+#define LL_ADC_REG_SEQ_DISCONT_8RANKS      (ADC_CFGR_DISCNUM_2 | ADC_CFGR_DISCNUM_1 | ADC_CFGR_DISCNUM_0 | ADC_CFGR_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every 8 ranks */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_REG_SEQ_RANKS  ADC group regular - Sequencer ranks
+  * @{
+  */
+#define LL_ADC_REG_RANK_1                  (ADC_SQR1_REGOFFSET | ADC_REG_RANK_1_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 1 */
+#define LL_ADC_REG_RANK_2                  (ADC_SQR1_REGOFFSET | ADC_REG_RANK_2_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 2 */
+#define LL_ADC_REG_RANK_3                  (ADC_SQR1_REGOFFSET | ADC_REG_RANK_3_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 3 */
+#define LL_ADC_REG_RANK_4                  (ADC_SQR1_REGOFFSET | ADC_REG_RANK_4_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 4 */
+#define LL_ADC_REG_RANK_5                  (ADC_SQR2_REGOFFSET | ADC_REG_RANK_5_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 5 */
+#define LL_ADC_REG_RANK_6                  (ADC_SQR2_REGOFFSET | ADC_REG_RANK_6_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 6 */
+#define LL_ADC_REG_RANK_7                  (ADC_SQR2_REGOFFSET | ADC_REG_RANK_7_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 7 */
+#define LL_ADC_REG_RANK_8                  (ADC_SQR2_REGOFFSET | ADC_REG_RANK_8_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 8 */
+#define LL_ADC_REG_RANK_9                  (ADC_SQR2_REGOFFSET | ADC_REG_RANK_9_SQRX_BITOFFSET_POS)  /*!< ADC group regular sequencer rank 9 */
+#define LL_ADC_REG_RANK_10                 (ADC_SQR3_REGOFFSET | ADC_REG_RANK_10_SQRX_BITOFFSET_POS) /*!< ADC group regular sequencer rank 10 */
+#define LL_ADC_REG_RANK_11                 (ADC_SQR3_REGOFFSET | ADC_REG_RANK_11_SQRX_BITOFFSET_POS) /*!< ADC group regular sequencer rank 11 */
+#define LL_ADC_REG_RANK_12                 (ADC_SQR3_REGOFFSET | ADC_REG_RANK_12_SQRX_BITOFFSET_POS) /*!< ADC group regular sequencer rank 12 */
+#define LL_ADC_REG_RANK_13                 (ADC_SQR3_REGOFFSET | ADC_REG_RANK_13_SQRX_BITOFFSET_POS) /*!< ADC group regular sequencer rank 13 */
+#define LL_ADC_REG_RANK_14                 (ADC_SQR3_REGOFFSET | ADC_REG_RANK_14_SQRX_BITOFFSET_POS) /*!< ADC group regular sequencer rank 14 */
+#define LL_ADC_REG_RANK_15                 (ADC_SQR4_REGOFFSET | ADC_REG_RANK_15_SQRX_BITOFFSET_POS) /*!< ADC group regular sequencer rank 15 */
+#define LL_ADC_REG_RANK_16                 (ADC_SQR4_REGOFFSET | ADC_REG_RANK_16_SQRX_BITOFFSET_POS) /*!< ADC group regular sequencer rank 16 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_INJ_TRIGGER_SOURCE  ADC group injected - Trigger source
+  * @{
+  */
+#define LL_ADC_INJ_TRIG_SOFTWARE           (0x00000000UL)                                                                                                         /*!< ADC group injected conversion trigger internal: SW start. */
+#define LL_ADC_INJ_TRIG_EXT_TIM1_TRGO      (ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                                        /*!< ADC group injected conversion trigger from external peripheral: TIM1 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM1_CH4       (ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                   /*!< ADC group injected conversion trigger from external peripheral: TIM1 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM2_TRGO      (ADC_JSQR_JEXTSEL_1 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                   /*!< ADC group injected conversion trigger from external peripheral: TIM2 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM2_CH1       (ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                              /*!< ADC group injected conversion trigger from external peripheral: TIM2 channel 1 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM3_CH4       (ADC_JSQR_JEXTSEL_2 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                   /*!< ADC group injected conversion trigger from external peripheral: TIM3 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM4_TRGO      (ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                              /*!< ADC group injected conversion trigger from external peripheral: TIM4 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_EXTI_LINE15    (ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                              /*!< ADC group injected conversion trigger from external peripheral: external interrupt line 15. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM8_CH4       (ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                         /*!< ADC group injected conversion trigger from external peripheral: TIM8 channel 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM1_TRGO2     (ADC_JSQR_JEXTSEL_3 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                   /*!< ADC group injected conversion trigger from external peripheral: TIM1 TRGO2 event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM8_TRGO      (ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                              /*!< ADC group injected conversion trigger from external peripheral: TIM8 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM8_TRGO2     (ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                              /*!< ADC group injected conversion trigger from external peripheral: TIM8 TRGO2 event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM3_CH3       (ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                         /*!< ADC group injected conversion trigger from external peripheral: TIM3 channel 3 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM3_TRGO      (ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                            /*!< ADC group injected conversion trigger from external peripheral: TIM3 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM3_CH1       (ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                         /*!< ADC group injected conversion trigger from external peripheral: TIM3 channel 1 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM6_TRGO      (ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                         /*!< ADC group injected conversion trigger from external peripheral: TIM6 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM15_TRGO     (ADC_JSQR_JEXTSEL_3 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)    /*!< ADC group injected conversion trigger from external peripheral: TIM15 TRGO event. Trigger edge set to rising edge (default setting). */
+#if defined(HRTIM1)
+#define LL_ADC_INJ_TRIG_EXT_HRTIM_TRG2     (ADC_JSQR_JEXTSEL_4 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                                                   /*!< ADC group injected conversion trigger from external peripheral: HRTIM1 TRG2 event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_HRTIM_TRG4     (ADC_JSQR_JEXTSEL_4 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                              /*!< ADC group injected conversion trigger from external peripheral: HRTIM1 TRG4 event. Trigger edge set to rising edge (default setting). */
+#endif /* HRTIM1 */
+#define LL_ADC_INJ_TRIG_EXT_LPTIM1_OUT     (ADC_JSQR_JEXTSEL_4 | ADC_JSQR_JEXTSEL_1 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                              /*!< ADC group injected conversion trigger from external peripheral: LPTIM1 OUT event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_LPTIM2_OUT     (ADC_JSQR_JEXTSEL_4 | ADC_JSQR_JEXTSEL_1 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                         /*!< ADC group injected conversion trigger from external peripheral: LPTIM2 OUT event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_LPTIM3_OUT     (ADC_JSQR_JEXTSEL_4 | ADC_JSQR_JEXTSEL_2 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                              /*!< ADC group injected conversion trigger from external peripheral: LPTIM3 OUT event. 4 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM23_TRGO     (ADC_JSQR_JEXTSEL_4 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: TIM23 TRGO event. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_TIM24_TRGO     (ADC_JSQR_JEXTSEL_4 | ADC_JSQR_JEXTSEL_2 | ADC_JSQR_JEXTSEL_1 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                       /*!< ADC group regular conversion trigger from external peripheral: TIM24 TRGO event. Trigger edge set to rising edge (default setting). */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_INJ_TRIGGER_EDGE  ADC group injected - Trigger edge
+  * @{
+  */
+#define LL_ADC_INJ_TRIG_EXT_RISING         (                    ADC_JSQR_JEXTEN_0) /*!< ADC group injected conversion trigger polarity set to rising edge */
+#define LL_ADC_INJ_TRIG_EXT_FALLING        (ADC_JSQR_JEXTEN_1                    ) /*!< ADC group injected conversion trigger polarity set to falling edge */
+#define LL_ADC_INJ_TRIG_EXT_RISINGFALLING  (ADC_JSQR_JEXTEN_1 | ADC_JSQR_JEXTEN_0) /*!< ADC group injected conversion trigger polarity set to both rising and falling edges */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_INJ_TRIG_AUTO  ADC group injected - Automatic trigger mode
+* @{
+*/
+#define LL_ADC_INJ_TRIG_INDEPENDENT        (0x00000000UL)         /*!< ADC group injected conversion trigger independent. Setting mandatory if ADC group injected injected trigger source is set to an external trigger. */
+#define LL_ADC_INJ_TRIG_FROM_GRP_REGULAR   (ADC_CFGR_JAUTO)       /*!< ADC group injected conversion trigger from ADC group regular. Setting compliant only with group injected trigger source set to SW start, without any further action on  ADC group injected conversion start or stop: in this case, ADC group injected is controlled only from ADC group regular. */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_INJ_CONTEXT_QUEUE  ADC group injected - Context queue mode
+  * @{
+  */
+#define LL_ADC_INJ_QUEUE_2CONTEXTS_LAST_ACTIVE (0x00000000UL)         /* Group injected sequence context queue is enabled and can contain up to 2 contexts. When all contexts have been processed, the queue maintains the last context active perpetually. */
+#define LL_ADC_INJ_QUEUE_2CONTEXTS_END_EMPTY   (ADC_CFGR_JQM)         /* Group injected sequence context queue is enabled and can contain up to 2 contexts. When all contexts have been processed, the queue is empty and injected group triggers are disabled. */
+#define LL_ADC_INJ_QUEUE_DISABLE               (ADC_CFGR_JQDIS)       /* Group injected sequence context queue is disabled: only 1 sequence can be configured and is active perpetually. */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_INJ_SEQ_SCAN_LENGTH  ADC group injected - Sequencer scan length
+  * @{
+  */
+#define LL_ADC_INJ_SEQ_SCAN_DISABLE        (0x00000000UL)                  /*!< ADC group injected sequencer disable (equivalent to sequencer of 1 rank: ADC conversion on only 1 channel) */
+#define LL_ADC_INJ_SEQ_SCAN_ENABLE_2RANKS  (                ADC_JSQR_JL_0) /*!< ADC group injected sequencer enable with 2 ranks in the sequence */
+#define LL_ADC_INJ_SEQ_SCAN_ENABLE_3RANKS  (ADC_JSQR_JL_1                ) /*!< ADC group injected sequencer enable with 3 ranks in the sequence */
+#define LL_ADC_INJ_SEQ_SCAN_ENABLE_4RANKS  (ADC_JSQR_JL_1 | ADC_JSQR_JL_0) /*!< ADC group injected sequencer enable with 4 ranks in the sequence */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_INJ_SEQ_DISCONT_MODE  ADC group injected - Sequencer discontinuous mode
+  * @{
+  */
+#define LL_ADC_INJ_SEQ_DISCONT_DISABLE     (0x00000000UL)         /*!< ADC group injected sequencer discontinuous mode disable */
+#define LL_ADC_INJ_SEQ_DISCONT_1RANK       (ADC_CFGR_JDISCEN)     /*!< ADC group injected sequencer discontinuous mode enable with sequence interruption every rank */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_INJ_SEQ_RANKS  ADC group injected - Sequencer ranks
+  * @{
+  */
+#define LL_ADC_INJ_RANK_1                  (ADC_JDR1_REGOFFSET | ADC_INJ_RANK_1_JSQR_BITOFFSET_POS) /*!< ADC group injected sequencer rank 1 */
+#define LL_ADC_INJ_RANK_2                  (ADC_JDR2_REGOFFSET | ADC_INJ_RANK_2_JSQR_BITOFFSET_POS) /*!< ADC group injected sequencer rank 2 */
+#define LL_ADC_INJ_RANK_3                  (ADC_JDR3_REGOFFSET | ADC_INJ_RANK_3_JSQR_BITOFFSET_POS) /*!< ADC group injected sequencer rank 3 */
+#define LL_ADC_INJ_RANK_4                  (ADC_JDR4_REGOFFSET | ADC_INJ_RANK_4_JSQR_BITOFFSET_POS) /*!< ADC group injected sequencer rank 4 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_CHANNEL_SAMPLINGTIME  Channel - Sampling time
+  * @{
+  */
+#define LL_ADC_SAMPLINGTIME_1CYCLE_5       (0x00000000UL)                                              /*!< Sampling time 1.5 ADC clock cycles */
+#define LL_ADC_SAMPLINGTIME_2CYCLES_5      (                                        ADC_SMPR2_SMP10_0) /*!< Sampling time 2.5 ADC clock cycles */
+#define LL_ADC_SAMPLINGTIME_8CYCLES_5      (                    ADC_SMPR2_SMP10_1                    ) /*!< Sampling time 8.5 ADC clock cycles */
+#define LL_ADC_SAMPLINGTIME_16CYCLES_5     (                    ADC_SMPR2_SMP10_1 | ADC_SMPR2_SMP10_0) /*!< Sampling time 16.5 ADC clock cycles */
+#define LL_ADC_SAMPLINGTIME_32CYCLES_5     (ADC_SMPR2_SMP10_2                                        ) /*!< Sampling time 32.5 ADC clock cycles */
+#define LL_ADC_SAMPLINGTIME_64CYCLES_5     (ADC_SMPR2_SMP10_2                     | ADC_SMPR2_SMP10_0) /*!< Sampling time 64.5 ADC clock cycles */
+#define LL_ADC_SAMPLINGTIME_387CYCLES_5    (ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_1                    ) /*!< Sampling time 387.5 ADC clock cycles */
+#define LL_ADC_SAMPLINGTIME_810CYCLES_5    (ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_1 | ADC_SMPR2_SMP10_0) /*!< Sampling time 810.5 ADC clock cycles */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_LL_EC_CHANNEL_SAMPLINGTIME  Channel - Sampling time
+  * @{
+  */
+#define LL_ADC_SAMPLINGTIME_ADC3_2CYCLES_5      (0x00000000UL)                                              /*!< Sampling time 2.5 ADC clock cycles. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_SAMPLINGTIME_ADC3_6CYCLES_5      (                                        ADC_SMPR2_SMP10_0) /*!< Sampling time 6.5 ADC clock cycles. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_SAMPLINGTIME_ADC3_12CYCLES_5     (                    ADC_SMPR2_SMP10_1                    ) /*!< Sampling time 12.5 ADC clock cycles. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_SAMPLINGTIME_ADC3_24CYCLES_5     (                    ADC_SMPR2_SMP10_1 | ADC_SMPR2_SMP10_0) /*!< Sampling time 24.5 ADC clock cycles. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_SAMPLINGTIME_ADC3_47CYCLES_5     (ADC_SMPR2_SMP10_2                                        ) /*!< Sampling time 47.5 ADC clock cycles. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_SAMPLINGTIME_ADC3_92CYCLES_5     (ADC_SMPR2_SMP10_2                     | ADC_SMPR2_SMP10_0) /*!< Sampling time 92.5 ADC clock cycles. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_SAMPLINGTIME_ADC3_247CYCLES_5    (ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_1                    ) /*!< Sampling time 247.5 ADC clock cycles. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_SAMPLINGTIME_ADC3_640CYCLES_5    (ADC_SMPR2_SMP10_2 | ADC_SMPR2_SMP10_1 | ADC_SMPR2_SMP10_0) /*!< Sampling time 640.5 ADC clock cycles. On ADC3 of devices STM32H72xx and STM32H73xx */
+/**
+  * @}
+  */
+#endif  /* ADC_VER_V5_V90 */
+
+/** @defgroup ADC_LL_EC_CHANNEL_SINGLE_DIFF_ENDING  Channel - Single or differential ending
+  * @{
+  */
+#define LL_ADC_SINGLE_ENDED                (                  ADC_CALFACT_CALFACT_S)         /*!< ADC channel ending set to single ended (literal also used to set calibration mode) */
+#define LL_ADC_DIFFERENTIAL_ENDED          (ADC_CR_ADCALDIF | ADC_CALFACT_CALFACT_D)         /*!< ADC channel ending set to differential (literal also used to set calibration mode) */
+#define LL_ADC_BOTH_SINGLE_DIFF_ENDED      (LL_ADC_SINGLE_ENDED | LL_ADC_DIFFERENTIAL_ENDED) /*!< ADC channel ending set to both single ended and differential (literal used only to set calibration factors) */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_AWD_NUMBER Analog watchdog - Analog watchdog number
+  * @{
+  */
+#define LL_ADC_AWD1                        (ADC_AWD_CR1_CHANNEL_MASK  | ADC_AWD_CR1_REGOFFSET) /*!< ADC analog watchdog number 1 */
+#define LL_ADC_AWD2                        (ADC_AWD_CR23_CHANNEL_MASK | ADC_AWD_CR2_REGOFFSET) /*!< ADC analog watchdog number 2 */
+#define LL_ADC_AWD3                        (ADC_AWD_CR23_CHANNEL_MASK | ADC_AWD_CR3_REGOFFSET) /*!< ADC analog watchdog number 3 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_AWD_CHANNELS  Analog watchdog - Monitored channels
+  * @{
+  */
+#define LL_ADC_AWD_DISABLE                 (0x00000000UL)                                                                                      /*!< ADC analog watchdog monitoring disabled */
+#define LL_ADC_AWD_ALL_CHANNELS_REG        (ADC_AWD_CR23_CHANNEL_MASK                                    | ADC_CFGR_AWD1EN                   ) /*!< ADC analog watchdog monitoring of all channels, converted by group regular only */
+#define LL_ADC_AWD_ALL_CHANNELS_INJ        (ADC_AWD_CR23_CHANNEL_MASK                 | ADC_CFGR_JAWD1EN                                     ) /*!< ADC analog watchdog monitoring of all channels, converted by group injected only */
+#define LL_ADC_AWD_ALL_CHANNELS_REG_INJ    (ADC_AWD_CR23_CHANNEL_MASK                 | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN                   ) /*!< ADC analog watchdog monitoring of all channels, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_0_REG           ((LL_ADC_CHANNEL_0  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN0, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_0_INJ           ((LL_ADC_CHANNEL_0  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN0, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_0_REG_INJ       ((LL_ADC_CHANNEL_0  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN0, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_1_REG           ((LL_ADC_CHANNEL_1  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN1, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_1_INJ           ((LL_ADC_CHANNEL_1  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN1, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_1_REG_INJ       ((LL_ADC_CHANNEL_1  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN1, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_2_REG           ((LL_ADC_CHANNEL_2  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN2, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_2_INJ           ((LL_ADC_CHANNEL_2  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN2, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_2_REG_INJ       ((LL_ADC_CHANNEL_2  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN2, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_3_REG           ((LL_ADC_CHANNEL_3  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN3, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_3_INJ           ((LL_ADC_CHANNEL_3  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN3, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_3_REG_INJ       ((LL_ADC_CHANNEL_3  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN3, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_4_REG           ((LL_ADC_CHANNEL_4  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN4, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_4_INJ           ((LL_ADC_CHANNEL_4  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN4, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_4_REG_INJ       ((LL_ADC_CHANNEL_4  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN4, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_5_REG           ((LL_ADC_CHANNEL_5  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN5, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_5_INJ           ((LL_ADC_CHANNEL_5  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN5, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_5_REG_INJ       ((LL_ADC_CHANNEL_5  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN5, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_6_REG           ((LL_ADC_CHANNEL_6  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN6, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_6_INJ           ((LL_ADC_CHANNEL_6  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN6, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_6_REG_INJ       ((LL_ADC_CHANNEL_6  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN6, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_7_REG           ((LL_ADC_CHANNEL_7  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN7, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_7_INJ           ((LL_ADC_CHANNEL_7  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN7, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_7_REG_INJ       ((LL_ADC_CHANNEL_7  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN7, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_8_REG           ((LL_ADC_CHANNEL_8  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN8, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_8_INJ           ((LL_ADC_CHANNEL_8  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN8, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_8_REG_INJ       ((LL_ADC_CHANNEL_8  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN8, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_9_REG           ((LL_ADC_CHANNEL_9  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN9, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_9_INJ           ((LL_ADC_CHANNEL_9  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN9, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_9_REG_INJ       ((LL_ADC_CHANNEL_9  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN9, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_10_REG          ((LL_ADC_CHANNEL_10 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN10, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_10_INJ          ((LL_ADC_CHANNEL_10 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN10, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_10_REG_INJ      ((LL_ADC_CHANNEL_10 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN10, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_11_REG          ((LL_ADC_CHANNEL_11 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN11, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_11_INJ          ((LL_ADC_CHANNEL_11 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN11, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_11_REG_INJ      ((LL_ADC_CHANNEL_11 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN11, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_12_REG          ((LL_ADC_CHANNEL_12 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN12, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_12_INJ          ((LL_ADC_CHANNEL_12 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN12, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_12_REG_INJ      ((LL_ADC_CHANNEL_12 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN12, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_13_REG          ((LL_ADC_CHANNEL_13 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN13, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_13_INJ          ((LL_ADC_CHANNEL_13 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN13, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_13_REG_INJ      ((LL_ADC_CHANNEL_13 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN13, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_14_REG          ((LL_ADC_CHANNEL_14 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN14, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_14_INJ          ((LL_ADC_CHANNEL_14 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN14, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_14_REG_INJ      ((LL_ADC_CHANNEL_14 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN14, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_15_REG          ((LL_ADC_CHANNEL_15 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN15, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_15_INJ          ((LL_ADC_CHANNEL_15 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN15, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_15_REG_INJ      ((LL_ADC_CHANNEL_15 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN15, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_16_REG          ((LL_ADC_CHANNEL_16 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN16, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_16_INJ          ((LL_ADC_CHANNEL_16 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN16, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_16_REG_INJ      ((LL_ADC_CHANNEL_16 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN16, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_17_REG          ((LL_ADC_CHANNEL_17 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN17, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_17_INJ          ((LL_ADC_CHANNEL_17 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN17, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_17_REG_INJ      ((LL_ADC_CHANNEL_17 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN17, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_18_REG          ((LL_ADC_CHANNEL_18 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN18, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_18_INJ          ((LL_ADC_CHANNEL_18 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN18, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_18_REG_INJ      ((LL_ADC_CHANNEL_18 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN18, converted by either group regular or injected */
+#define LL_ADC_AWD_CHANNEL_19_REG          ((LL_ADC_CHANNEL_19 & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN19, converted by group regular only */
+#define LL_ADC_AWD_CHANNEL_19_INJ          ((LL_ADC_CHANNEL_19 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN19, converted by group injected only */
+#define LL_ADC_AWD_CHANNEL_19_REG_INJ      ((LL_ADC_CHANNEL_19 & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC external channel (channel connected to GPIO pin) ADCx_IN19, converted by either group regular or injected */
+#define LL_ADC_AWD_CH_VREFINT_REG          ((LL_ADC_CHANNEL_VREFINT       & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to VrefInt: Internal voltage reference, converted by group regular only */
+#define LL_ADC_AWD_CH_VREFINT_INJ          ((LL_ADC_CHANNEL_VREFINT       & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to VrefInt: Internal voltage reference, converted by group injected only */
+#define LL_ADC_AWD_CH_VREFINT_REG_INJ      ((LL_ADC_CHANNEL_VREFINT       & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to VrefInt: Internal voltage reference, converted by either group regular or injected */
+#define LL_ADC_AWD_CH_TEMPSENSOR_REG       ((LL_ADC_CHANNEL_TEMPSENSOR    & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to Temperature sensor, converted by group regular only */
+#define LL_ADC_AWD_CH_TEMPSENSOR_INJ       ((LL_ADC_CHANNEL_TEMPSENSOR    & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to Temperature sensor, converted by group injected only */
+#define LL_ADC_AWD_CH_TEMPSENSOR_REG_INJ   ((LL_ADC_CHANNEL_TEMPSENSOR    & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to Temperature sensor, converted by either group regular or injected */
+#define LL_ADC_AWD_CH_VBAT_REG             ((LL_ADC_CHANNEL_VBAT          & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to Vbat/4: Vbat voltage through a divider ladder of factor 1/4 to have Vbat always below Vdda, converted by group regular only */
+#define LL_ADC_AWD_CH_VBAT_INJ             ((LL_ADC_CHANNEL_VBAT          & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to Vbat/4: Vbat voltage through a divider ladder of factor 1/4 to have Vbat always below Vdda, converted by group injected only */
+#define LL_ADC_AWD_CH_VBAT_REG_INJ         ((LL_ADC_CHANNEL_VBAT          & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to Vbat/4: Vbat voltage through a divider ladder of factor 1/4 to have Vbat always below Vdda */
+#define LL_ADC_AWD_CH_DAC1CH1_ADC2_REG     ((LL_ADC_CHANNEL_DAC1CH1_ADC2  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to DAC1 channel 1, channel specific to ADC2, converted by group regular only */
+#define LL_ADC_AWD_CH_DAC1CH1_ADC2_INJ     ((LL_ADC_CHANNEL_DAC1CH1_ADC2  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to DAC1 channel 1, channel specific to ADC2, converted by group injected only */
+#define LL_ADC_AWD_CH_DAC1CH1_ADC2_REG_INJ ((LL_ADC_CHANNEL_DAC1CH1_ADC2  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to DAC1 channel 1, channel specific to ADC2, converted by either group regular or injected */
+#define LL_ADC_AWD_CH_DAC1CH2_ADC2_REG     ((LL_ADC_CHANNEL_DAC1CH2_ADC2  & ADC_CHANNEL_ID_MASK)                    | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to DAC1 channel 1, channel specific to ADC2, converted by group regular only */
+#define LL_ADC_AWD_CH_DAC1CH2_ADC2_INJ     ((LL_ADC_CHANNEL_DAC1CH2_ADC2  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN                   | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to DAC1 channel 1, channel specific to ADC2, converted by group injected only */
+#define LL_ADC_AWD_CH_DAC1CH2_ADC2_REG_INJ ((LL_ADC_CHANNEL_DAC1CH2_ADC2  & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL) /*!< ADC analog watchdog monitoring of ADC internal channel connected to DAC1 channel 1, channel specific to ADC2, converted by either group regular or injected */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_AWD_THRESHOLDS  Analog watchdog - Thresholds
+  * @{
+  */
+#define LL_ADC_AWD_THRESHOLD_HIGH          (0x1UL)                     /*!< ADC analog watchdog threshold high */
+#define LL_ADC_AWD_THRESHOLD_LOW           (0x0UL)                     /*!< ADC analog watchdog threshold low */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_LL_EC_AWD_FILTERING_CONFIG  Analog watchdog - filtering config
+  * @{
+  */
+#define LL_ADC_AWD_FILTERING_NONE          (0x00000000UL)                                                   /*!< ADC analog watchdog no filtering, one out-of-window sample is needed to raise flag or interrupt. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_AWD_FILTERING_2SAMPLES      (                                          ADC3_TR1_AWDFILT_0)   /*!< ADC analog watchdog 2 consecutives out-of-window samples are needed to raise flag or interrupt. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_AWD_FILTERING_3SAMPLES      (                     ADC3_TR1_AWDFILT_1                     )   /*!< ADC analog watchdog 3 consecutives out-of-window samples are needed to raise flag or interrupt. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_AWD_FILTERING_4SAMPLES      (                     ADC3_TR1_AWDFILT_1 | ADC3_TR1_AWDFILT_0)   /*!< ADC analog watchdog 4 consecutives out-of-window samples are needed to raise flag or interrupt. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_AWD_FILTERING_5SAMPLES      (ADC3_TR1_AWDFILT_2                                          )   /*!< ADC analog watchdog 5 consecutives out-of-window samples are needed to raise flag or interrupt. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_AWD_FILTERING_6SAMPLES      (ADC3_TR1_AWDFILT_2 |                      ADC3_TR1_AWDFILT_0)   /*!< ADC analog watchdog 6 consecutives out-of-window samples are needed to raise flag or interrupt. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_AWD_FILTERING_7SAMPLES      (ADC3_TR1_AWDFILT_2 | ADC3_TR1_AWDFILT_1                     )   /*!< ADC analog watchdog 7 consecutives out-of-window samples are needed to raise flag or interrupt. On ADC3 of devices STM32H72xx and STM32H73xx */
+#define LL_ADC_AWD_FILTERING_8SAMPLES      (ADC3_TR1_AWDFILT_2 | ADC3_TR1_AWDFILT_1 | ADC3_TR1_AWDFILT_0)   /*!< ADC analog watchdog 8 consecutives out-of-window samples are needed to raise flag or interrupt. On ADC3 of devices STM32H72xx and STM32H73xx */
+/**
+  * @}
+  */
+#endif /* ADC_VER_V5_V90 */
+
+/** @defgroup ADC_LL_EC_OVS_SCOPE  Oversampling - Oversampling scope
+  * @{
+  */
+#define LL_ADC_OVS_DISABLE                 (0x00000000UL)                                        /*!< ADC oversampling disabled. */
+#define LL_ADC_OVS_GRP_REGULAR_CONTINUED   (                                    ADC_CFGR2_ROVSE) /*!< ADC oversampling on conversions of ADC group regular. If group injected interrupts group regular: when ADC group injected is triggered, the oversampling on ADC group regular is temporary stopped and continued afterwards. */
+#define LL_ADC_OVS_GRP_REGULAR_RESUMED     (ADC_CFGR2_ROVSM |                   ADC_CFGR2_ROVSE) /*!< ADC oversampling on conversions of ADC group regular. If group injected interrupts group regular: when ADC group injected is triggered, the oversampling on ADC group regular is resumed from start (oversampler buffer reset). */
+#define LL_ADC_OVS_GRP_INJECTED            (                  ADC_CFGR2_JOVSE                  ) /*!< ADC oversampling on conversions of ADC group injected. */
+#define LL_ADC_OVS_GRP_INJ_REG_RESUMED     (                  ADC_CFGR2_JOVSE | ADC_CFGR2_ROVSE) /*!< ADC oversampling on conversions of both ADC groups regular and injected. If group injected interrupting group regular: when ADC group injected is triggered, the oversampling on ADC group regular is resumed from start (oversampler buffer reset). */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_OVS_DISCONT_MODE  Oversampling - Discontinuous mode
+  * @{
+  */
+#define LL_ADC_OVS_REG_CONT                (0x00000000UL)         /*!< ADC oversampling discontinuous mode: continuous mode (all conversions of oversampling ratio are done from 1 trigger) */
+#define LL_ADC_OVS_REG_DISCONT             (ADC_CFGR2_TROVS)      /*!< ADC oversampling discontinuous mode: discontinuous mode (each conversion of oversampling ratio needs a trigger) */
+/**
+  * @}
+  */
+#if defined(ADC_VER_V5_V90)
+/** @defgroup ADC_LL_EC_OVS_RATIO  Oversampling - Ratio
+  * @{
+  */
+#define LL_ADC_OVS_RATIO_2                 (0x00000000UL)                                               /*!< ADC oversampling ratio of 2 (2 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift) */
+#define LL_ADC_OVS_RATIO_4                 (                                        ADC3_CFGR2_OVSR_0)  /*!< ADC oversampling ratio of 4 (4 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift) */
+#define LL_ADC_OVS_RATIO_8                 (                    ADC3_CFGR2_OVSR_1                    )  /*!< ADC oversampling ratio of 8 (8 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift) */
+#define LL_ADC_OVS_RATIO_16                (                    ADC3_CFGR2_OVSR_1 | ADC3_CFGR2_OVSR_0)  /*!< ADC oversampling ratio of 16 (16 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift) */
+#define LL_ADC_OVS_RATIO_32                (ADC3_CFGR2_OVSR_2                                        )  /*!< ADC oversampling ratio of 32 (32 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift) */
+#define LL_ADC_OVS_RATIO_64                (ADC3_CFGR2_OVSR_2                     | ADC3_CFGR2_OVSR_0)  /*!< ADC oversampling ratio of 64 (64 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift) */
+#define LL_ADC_OVS_RATIO_128               (ADC3_CFGR2_OVSR_2 | ADC3_CFGR2_OVSR_1                    )  /*!< ADC oversampling ratio of 128 (128 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift) */
+#define LL_ADC_OVS_RATIO_256               (ADC3_CFGR2_OVSR_2 | ADC3_CFGR2_OVSR_1 | ADC3_CFGR2_OVSR_0)  /*!< ADC oversampling ratio of 256 (256 ADC conversions are performed, sum of these conversions data is computed to result as the ADC oversampling conversion data (before potential shift) */
+/**
+  * @}
+  */
+#endif  /* ADC_VER_V5_V90 */
+
+/** @defgroup ADC_LL_EC_OVS_SHIFT  Oversampling - Data shift
+  * @{
+  */
+#define LL_ADC_OVS_SHIFT_NONE              (0x00000000UL)                                                              /*!< ADC oversampling no shift (sum of the ADC conversions data is not divided to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_1           (                                                         ADC_CFGR2_OVSS_0) /*!< ADC oversampling shift of 1 (sum of the ADC conversions data is divided by 2 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_2           (                                      ADC_CFGR2_OVSS_1                   ) /*!< ADC oversampling shift of 2 (sum of the ADC conversions data is divided by 4 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_3           (                                      ADC_CFGR2_OVSS_1 | ADC_CFGR2_OVSS_0) /*!< ADC oversampling shift of 3 (sum of the ADC conversions data is divided by 8 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_4           (                   ADC_CFGR2_OVSS_2                                      ) /*!< ADC oversampling shift of 4 (sum of the ADC conversions data is divided by 16 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_5           (                   ADC_CFGR2_OVSS_2                    | ADC_CFGR2_OVSS_0) /*!< ADC oversampling shift of 5 (sum of the ADC conversions data is divided by 32 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_6           (                   ADC_CFGR2_OVSS_2 | ADC_CFGR2_OVSS_1                   ) /*!< ADC oversampling shift of 6 (sum of the ADC conversions data is divided by 64 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_7           (                   ADC_CFGR2_OVSS_2 | ADC_CFGR2_OVSS_1 | ADC_CFGR2_OVSS_0) /*!< ADC oversampling shift of 7 (sum of the ADC conversions data is divided by 128 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_8           (ADC_CFGR2_OVSS_3                                                         ) /*!< ADC oversampling shift of 8 (sum of the ADC conversions data is divided by 256 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_9           (ADC_CFGR2_OVSS_3                                       | ADC_CFGR2_OVSS_0) /*!< ADC oversampling shift of 9 (sum of the ADC conversions data is divided by 512 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_10          (ADC_CFGR2_OVSS_3                    | ADC_CFGR2_OVSS_1                   ) /*!< ADC oversampling shift of 10 (sum of the ADC conversions data is divided by 1024 to result as the ADC oversampling conversion data) */
+#define LL_ADC_OVS_SHIFT_RIGHT_11          (ADC_CFGR2_OVSS_3                    | ADC_CFGR2_OVSS_1 | ADC_CFGR2_OVSS_0) /*!< ADC oversampling shift of 11 (sum of the ADC conversions data is divided by 2048 to result as the ADC oversampling conversion data) */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_MULTI_MODE  Multimode - Mode
+  * @{
+  */
+#define LL_ADC_MULTI_INDEPENDENT           (0x00000000UL)                                                      /*!< ADC dual mode disabled (ADC independent mode) */
+#define LL_ADC_MULTI_DUAL_REG_SIMULT       (                 ADC_CCR_DUAL_2 | ADC_CCR_DUAL_1                 ) /*!< ADC dual mode enabled: group regular simultaneous */
+#define LL_ADC_MULTI_DUAL_REG_INTERL       (                 ADC_CCR_DUAL_2 | ADC_CCR_DUAL_1 | ADC_CCR_DUAL_0) /*!< ADC dual mode enabled: Combined group regular interleaved */
+#define LL_ADC_MULTI_DUAL_INJ_SIMULT       (                 ADC_CCR_DUAL_2                  | ADC_CCR_DUAL_0) /*!< ADC dual mode enabled: group injected simultaneous */
+#define LL_ADC_MULTI_DUAL_INJ_ALTERN       (ADC_CCR_DUAL_3                                   | ADC_CCR_DUAL_0) /*!< ADC dual mode enabled: group injected alternate trigger. Works only with external triggers (not internal SW start) */
+#define LL_ADC_MULTI_DUAL_REG_SIM_INJ_SIM  (                                                   ADC_CCR_DUAL_0) /*!< ADC dual mode enabled: Combined group regular simultaneous + group injected simultaneous */
+#define LL_ADC_MULTI_DUAL_REG_SIM_INJ_ALT  (                                  ADC_CCR_DUAL_1                 ) /*!< ADC dual mode enabled: Combined group regular simultaneous + group injected alternate trigger */
+#define LL_ADC_MULTI_DUAL_REG_INT_INJ_SIM  (                                  ADC_CCR_DUAL_1 | ADC_CCR_DUAL_0) /*!< ADC dual mode enabled: Combined group regular interleaved + group injected simultaneous */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_MULTI_DMA_TRANSFER  Multimode - DMA transfer
+  * @{
+  */
+#define LL_ADC_MULTI_REG_DMA_EACH_ADC        (0x00000000UL)                      /*!< ADC multimode group regular conversions are transferred by DMA: each ADC uses its own DMA channel, with its individual DMA transfer settings */
+#define LL_ADC_MULTI_REG_DMA_RES_32_10B      (ADC_CCR_DAMDF_1                  ) /*!< ADC multimode group regular conversions are transferred by DMA, one DMA channel for both ADC (DMA of ADC master). Setting for ADC resolution of 32 (16x2) down to 10 bits */
+#define LL_ADC_MULTI_REG_DMA_RES_8B          (ADC_CCR_DAMDF_1 | ADC_CCR_DAMDF_0) /*!< ADC multimode group regular conversions are transferred by DMA, one DMA channel for both ADC (DMA of ADC master). Setting for ADC resolution of 8 bits */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_MULTI_TWOSMP_DELAY  Multimode - Delay between two sampling phases
+  * @{
+  */
+#define LL_ADC_MULTI_TWOSMP_DELAY_1CYCLE_5           (0x00000000UL)                                                          /*!< ADC multimode delay between two sampling phases: 1.5 ADC clock cycle for all resolution                    */
+#define LL_ADC_MULTI_TWOSMP_DELAY_2CYCLES_5          (                                                      ADC_CCR_DELAY_0) /*!< ADC multimode delay between two sampling phases: 2.5 ADC clock cycles for all resolution                   */
+#define LL_ADC_MULTI_TWOSMP_DELAY_3CYCLES_5          (                                    ADC_CCR_DELAY_1                  ) /*!< ADC multimode delay between two sampling phases: 3.5 ADC clock cycles for all resolution                   */
+#define LL_ADC_MULTI_TWOSMP_DELAY_4CYCLES_5          (                                    ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0) /*!< ADC multimode delay between two sampling phases: 4.5 ADC clock cycles for 16, 14, 12 or 10 bits resolution */
+#define LL_ADC_MULTI_TWOSMP_DELAY_4CYCLES_5_8_BITS   (                  ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0) /*!< ADC multimode delay between two sampling phases: 4.5 ADC clock cycles  for 8 bits resolution               */
+#define LL_ADC_MULTI_TWOSMP_DELAY_5CYCLES_5          (                  ADC_CCR_DELAY_2                                    ) /*!< ADC multimode delay between two sampling phases: 5.5 ADC clock cycles for 16, 14, 12 bits resolution       */
+#define LL_ADC_MULTI_TWOSMP_DELAY_5CYCLES_5_10_BITS  (                  ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0) /*!< ADC multimode delay between two sampling phases: 5.5 ADC clock cycles for 10 bits resolution               */
+#define LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES            (ADC_CCR_DELAY_3                                                      ) /*!< ADC multimode delay between two sampling phases: 6 ADC clock cycles for 10 or 8 bits resolution            */
+#define LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES_5          (                  ADC_CCR_DELAY_2                   | ADC_CCR_DELAY_0) /*!< ADC multimode delay between two sampling phases: 6.5 ADC clock cycles for 16 or 14 bits resolution         */
+#define LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES_5_12_BITS  (                  ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0) /*!< ADC multimode delay between two sampling phases: 6.5 ADC clock cycles for 12 bits resolution               */
+#define LL_ADC_MULTI_TWOSMP_DELAY_7CYCLES_5          (                  ADC_CCR_DELAY_2 | ADC_CCR_DELAY_1 | ADC_CCR_DELAY_0) /*!< ADC multimode delay between two sampling phases: 7.5 ADC clock cycles for 16 bits resolution               */
+#define LL_ADC_MULTI_TWOSMP_DELAY_8CYCLES            (ADC_CCR_DELAY_3                                                      ) /*!< ADC multimode delay between two sampling phases: 8 ADC clock cycles for 12 bits resolution                 */
+#define LL_ADC_MULTI_TWOSMP_DELAY_9CYCLES            (ADC_CCR_DELAY_3                                                      ) /*!< ADC multimode delay between two sampling phases: 9 ADC clock cycles for 16 or 14 bits resolution           */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EC_MULTI_MASTER_SLAVE  Multimode - ADC master or slave
+  * @{
+  */
+#define LL_ADC_MULTI_MASTER                (                    ADC_CDR_RDATA_MST) /*!< In multimode, selection among several ADC instances: ADC master */
+#define LL_ADC_MULTI_SLAVE                 (ADC_CDR_RDATA_SLV                    ) /*!< In multimode, selection among several ADC instances: ADC slave */
+#define LL_ADC_MULTI_MASTER_SLAVE          (ADC_CDR_RDATA_SLV | ADC_CDR_RDATA_MST) /*!< In multimode, selection among several ADC instances: both ADC master and ADC slave */
+/**
+  * @}
+  */
+
+
+
+/** @defgroup ADC_LL_EC_HW_DELAYS  Definitions of ADC hardware constraints delays
+  * @note   Only ADC peripheral HW delays are defined in ADC LL driver driver,
+  *         not timeout values.
+  *         For details on delays values, refer to descriptions in source code
+  *         above each literal definition.
+  * @{
+  */
+
+/* Note: Only ADC peripheral HW delays are defined in ADC LL driver driver,   */
+/*       not timeout values.                                                  */
+/*       Timeout values for ADC operations are dependent to device clock      */
+/*       configuration (system clock versus ADC clock),                       */
+/*       and therefore must be defined in user application.                   */
+/*       Indications for estimation of ADC timeout delays, for this           */
+/*       STM32 series:                                                         */
+/*       - ADC calibration time: maximum delay is 16384/fADC.                   */
+/*         (refer to device datasheet, parameter "tCAL")                      */
+/*       - ADC enable time: maximum delay is 1 conversion cycle.              */
+/*         (refer to device datasheet, parameter "tSTAB")                     */
+/*       - ADC disable time: maximum delay should be a few ADC clock cycles   */
+/*       - ADC stop conversion time: maximum delay should be a few ADC clock  */
+/*         cycles                                                             */
+/*       - ADC conversion time: duration depending on ADC clock and ADC       */
+/*         configuration.                                                     */
+/*         (refer to device reference manual, section "Timing")               */
+
+/* Delay for ADC stabilization time (ADC voltage regulator start-up time)     */
+/* Delay set to maximum value (refer to device datasheet,                     */
+/* parameter "tADCVREG_STUP").                                                */
+/* Unit: us                                                                   */
+#define LL_ADC_DELAY_INTERNAL_REGUL_STAB_US ( 10UL)  /*!< Delay for ADC stabilization time (ADC voltage regulator start-up time) */
+
+/* Delay for internal voltage reference stabilization time.                   */
+/* Delay set to maximum value (refer to device datasheet,                     */
+/* parameter "ts_vrefint").                                                   */
+/* Unit: us                                                                   */
+#define LL_ADC_DELAY_VREFINT_STAB_US       (5UL)  /*!< Delay for internal voltage reference stabilization time */
+
+/* Delay for temperature sensor stabilization time.                           */
+/* Literal set to maximum value (refer to device datasheet,                   */
+/* parameter "tSTART_RUN").                                                   */
+/* Unit: us                                                                   */
+#define LL_ADC_DELAY_TEMPSENSOR_STAB_US    ( 26UL)  /*!< Delay for temperature sensor stabilization time */
+
+/* Delay required between ADC end of calibration and ADC enable.              */
+/* Note: On this STM32 series, a minimum number of ADC clock cycles            */
+/*       are required between ADC end of calibration and ADC enable.          */
+/*       Wait time can be computed in user application by waiting for the     */
+/*       equivalent number of CPU cycles, by taking into account              */
+/*       ratio of CPU clock versus ADC clock prescalers.                      */
+/* Unit: ADC clock cycles.                                                    */
+#define LL_ADC_DELAY_CALIB_ENABLE_ADC_CYCLES (  4UL)  /*!< Delay required between ADC end of calibration and ADC enable */
+
+/* Fixed timeout value for ADC linearity word bit set/clear delay.                         */
+/* Values defined to be higher than worst cases: low clock frequency,                      */
+/* maximum prescalers.                                                                     */
+/* Ex of profile low frequency : f_ADC at 4,577 Khz (minimum value                         */
+/* according to Data sheet), linearity set/clear bit delay MAX = 6 / f_ADC + 3 cycles AHB  */
+/*           6 / 4577 = 1,311ms                                                            */
+/* At maximum CPU speed (400 MHz), this means                                              */
+/*    3.58 * 400 MHz = 524400 CPU cycles                                                   */
+#define ADC_LINEARITY_BIT_TOGGLE_TIMEOUT         (524400UL)      /*!< ADC linearity set/clear bit delay */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup ADC_LL_Exported_Macros ADC Exported Macros
+  * @{
+  */
+
+/** @defgroup ADC_LL_EM_WRITE_READ Common write and read registers Macros
+  * @{
+  */
+
+/**
+  * @brief  Write a value in ADC register
+  * @param  __INSTANCE__ ADC Instance
+  * @param  __REG__ Register to be written
+  * @param  __VALUE__ Value to be written in the register
+  * @retval None
+  */
+#define LL_ADC_WriteReg(__INSTANCE__, __REG__, __VALUE__) WRITE_REG(__INSTANCE__->__REG__, (__VALUE__))
+
+/**
+  * @brief  Read a value in ADC register
+  * @param  __INSTANCE__ ADC Instance
+  * @param  __REG__ Register to be read
+  * @retval Register value
+  */
+#define LL_ADC_ReadReg(__INSTANCE__, __REG__) READ_REG(__INSTANCE__->__REG__)
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EM_HELPER_MACRO ADC helper macro
+  * @{
+  */
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief  Helper macro to convert the resolution defines to STM32H73x/2x ADC3 registers values
+  *         value corresponding to the ADC3 resolution according to the STM32H73x/2x RefMan.
+  * @note   The input can be a value from ADC3 resolution (12b, 10b, 8b,6b)
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  *         @arg @ref LL_ADC_RESOLUTION_6B
+  * @retval Returned value can be one of the following values:
+  *         @arg 0x00000000UL (value correspodning to ADC3 12 bits)
+  *         @arg ADC_CFGR_RES_0 = 0x00000004  (value corresponding to ADC3 10 bits)
+  *         @arg ADC_CFGR_RES_1 = 0x00000008 (value corresponding to ADC3 8 bits)
+  *         @arg 0x0000001C (value corresponding to ADC3 6 bits)
+  * @note   This helper macro is applicable for STM32H73x/2x devices only
+  */
+#define __LL_ADC12_RESOLUTION_TO_ADC3(__ADC_RESOLUTION__)                      \
+         (                                                                     \
+           ((__ADC_RESOLUTION__) == LL_ADC_RESOLUTION_12B)                     \
+            ?(0x00000000UL)                                                    \
+             :                                                                 \
+             ((__ADC_RESOLUTION__) == LL_ADC_RESOLUTION_10B)                   \
+               ?(ADC_CFGR_RES_0)                                               \
+                :                                                              \
+                ((__ADC_RESOLUTION__) == LL_ADC_RESOLUTION_8B)                 \
+                  ?(ADC_CFGR_RES_1)                                            \
+                   :                                                           \
+                   ((__ADC_RESOLUTION__) == LL_ADC_RESOLUTION_6B)              \
+                     ?((ADC_CFGR_RES_2|ADC_CFGR_RES_1 | ADC_CFGR_RES_0))       \
+                       :(0x00000000UL)                                         \
+         )
+
+#endif /* ADC_VER_V5_V90 */
+
+/**
+  * @brief  Helper macro to get ADC channel number in decimal format
+  *         from literals LL_ADC_CHANNEL_x.
+  * @note   Example:
+  *           __LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_4)
+  *           will return decimal number "4".
+  * @note   The input can be a value from functions where a channel
+  *         number is returned, either defined with number
+  *         or with bitfield (only one bit must be set).
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval Value between Min_Data=0 and Max_Data=18
+  */
+#define __LL_ADC_CHANNEL_TO_DECIMAL_NB(__CHANNEL__)                                        \
+  ((((__CHANNEL__) & ADC_CHANNEL_ID_BITFIELD_MASK) == 0UL)                                 \
+    ? (                                                                                    \
+       ((__CHANNEL__) & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS \
+      )                                                                                    \
+      :                                                                                    \
+      (                                                                                    \
+       (uint32_t)POSITION_VAL((__CHANNEL__))                                               \
+      )                                                                                    \
+  )
+
+/**
+  * @brief  Helper macro to get ADC channel in literal format LL_ADC_CHANNEL_x
+  *         from number in decimal format.
+  * @note   Example:
+  *           __LL_ADC_DECIMAL_NB_TO_CHANNEL(4)
+  *           will return a data equivalent to "LL_ADC_CHANNEL_4".
+  * @param  __DECIMAL_NB__ Value between Min_Data=0 and Max_Data=18
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).\n
+  *         (1, 2) For ADC channel read back from ADC register,
+  *                comparison with internal channel parameter to be done
+  *                using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
+  */
+#define __LL_ADC_DECIMAL_NB_TO_CHANNEL(__DECIMAL_NB__)                                                  \
+  (((__DECIMAL_NB__) <= 9UL)                                                                            \
+    ? (                                                                                                 \
+       ((__DECIMAL_NB__) << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS)                             |          \
+       (ADC_AWD2CR_AWD2CH_0 << (__DECIMAL_NB__))                                             |          \
+       (ADC_SMPR1_REGOFFSET | (((3UL * (__DECIMAL_NB__))) << ADC_CHANNEL_SMPx_BITOFFSET_POS))           \
+      )                                                                                                 \
+      :                                                                                                 \
+      (                                                                                                 \
+       ((__DECIMAL_NB__) << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS)                                      | \
+       (ADC_AWD2CR_AWD2CH_0 << (__DECIMAL_NB__))                                                      | \
+       (ADC_SMPR2_REGOFFSET | (((3UL * ((__DECIMAL_NB__) - 10UL))) << ADC_CHANNEL_SMPx_BITOFFSET_POS))  \
+      )                                                                                                 \
+  )
+
+/**
+  * @brief  Helper macro to determine whether the selected channel
+  *         corresponds to literal definitions of driver.
+  * @note   The different literal definitions of ADC channels are:
+  *         - ADC internal channel:
+  *           LL_ADC_CHANNEL_VREFINT, LL_ADC_CHANNEL_TEMPSENSOR, ...
+  *         - ADC external channel (channel connected to a GPIO pin):
+  *           LL_ADC_CHANNEL_1, LL_ADC_CHANNEL_2, ...
+  * @note   The channel parameter must be a value defined from literal
+  *         definition of a ADC internal channel (LL_ADC_CHANNEL_VREFINT,
+  *         LL_ADC_CHANNEL_TEMPSENSOR, ...),
+  *         ADC external channel (LL_ADC_CHANNEL_1, LL_ADC_CHANNEL_2, ...),
+  *         must not be a value from functions where a channel number is
+  *         returned from ADC registers,
+  *         because internal and external channels share the same channel
+  *         number in ADC registers. The differentiation is made only with
+  *         parameters definitions of driver.
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval Value "0" if the channel corresponds to a parameter definition of a ADC external channel (channel connected to a GPIO pin).
+  *         Value "1" if the channel corresponds to a parameter definition of a ADC internal channel.
+  */
+#define __LL_ADC_IS_CHANNEL_INTERNAL(__CHANNEL__)                              \
+  (((__CHANNEL__) & ADC_CHANNEL_ID_INTERNAL_CH_MASK) != 0UL)
+
+/**
+  * @brief  Helper macro to convert a channel defined from parameter
+  *         definition of a ADC internal channel (LL_ADC_CHANNEL_VREFINT,
+  *         LL_ADC_CHANNEL_TEMPSENSOR, ...),
+  *         to its equivalent parameter definition of a ADC external channel
+  *         (LL_ADC_CHANNEL_1, LL_ADC_CHANNEL_2, ...).
+  * @note   The channel parameter can be, additionally to a value
+  *         defined from parameter definition of a ADC internal channel
+  *         (LL_ADC_CHANNEL_VREFINT, LL_ADC_CHANNEL_TEMPSENSOR, ...),
+  *         a value defined from parameter definition of
+  *         ADC external channel (LL_ADC_CHANNEL_1, LL_ADC_CHANNEL_2, ...)
+  *         or a value from functions where a channel number is returned
+  *         from ADC registers.
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0
+  *         @arg @ref LL_ADC_CHANNEL_1
+  *         @arg @ref LL_ADC_CHANNEL_2
+  *         @arg @ref LL_ADC_CHANNEL_3
+  *         @arg @ref LL_ADC_CHANNEL_4
+  *         @arg @ref LL_ADC_CHANNEL_5
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  */
+#define __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL(__CHANNEL__)                     \
+  ((__CHANNEL__) & ~ADC_CHANNEL_ID_INTERNAL_CH_MASK)
+
+/**
+  * @brief  Helper macro to determine whether the internal channel
+  *         selected is available on the ADC instance selected.
+  * @note   The channel parameter must be a value defined from parameter
+  *         definition of a ADC internal channel (LL_ADC_CHANNEL_VREFINT,
+  *         LL_ADC_CHANNEL_TEMPSENSOR, ...),
+  *         must not be a value defined from parameter definition of
+  *         ADC external channel (LL_ADC_CHANNEL_1, LL_ADC_CHANNEL_2, ...)
+  *         or a value from functions where a channel number is
+  *         returned from ADC registers,
+  *         because internal and external channels share the same channel
+  *         number in ADC registers. The differentiation is made only with
+  *         parameters definitions of driver.
+  * @param  __ADC_INSTANCE__ ADC instance
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.
+  * @retval Value "0" if the internal channel selected is not available on the ADC instance selected.
+  *         Value "1" if the internal channel selected is available on the ADC instance selected.
+  */
+#if defined(ADC3)
+#define __LL_ADC_IS_CHANNEL_INTERNAL_AVAILABLE(__ADC_INSTANCE__, __CHANNEL__)  \
+  ((((__ADC_INSTANCE__) == ADC2)                                               \
+    &&(                                                                        \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_DAC1CH1_ADC2) ||                       \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_DAC1CH2_ADC2)                          \
+      )                                                                        \
+   )                                                                           \
+   ||                                                                          \
+   (((__ADC_INSTANCE__) == ADC3)                                               \
+    &&(                                                                        \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_TEMPSENSOR)   ||                       \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_VBAT)         ||                       \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_VREFINT)                               \
+      )                                                                        \
+   )                                                                           \
+  )
+#else
+#define __LL_ADC_IS_CHANNEL_INTERNAL_AVAILABLE(__ADC_INSTANCE__, __CHANNEL__)  \
+  ((((__ADC_INSTANCE__) == ADC2)                                               \
+    &&(                                                                        \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_DAC1CH1_ADC2) ||                       \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_DAC1CH2_ADC2) ||                       \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_TEMPSENSOR)   ||                       \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_VBAT)         ||                       \
+       ((__CHANNEL__) == LL_ADC_CHANNEL_VREFINT)                               \
+      )                                                                        \
+   )                                                                           \
+  )
+#endif
+
+/**
+  * @brief  Helper macro to define ADC analog watchdog parameter:
+  *         define a single channel to monitor with analog watchdog
+  *         from sequencer channel and groups definition.
+  * @note   To be used with function @ref LL_ADC_SetAnalogWDMonitChannels().
+  *         Example:
+  *           LL_ADC_SetAnalogWDMonitChannels(
+  *             ADC1, LL_ADC_AWD1,
+  *             __LL_ADC_ANALOGWD_CHANNEL_GROUP(LL_ADC_CHANNEL4, LL_ADC_GROUP_REGULAR))
+  * @param  __CHANNEL__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).\n
+  *         (1, 2) For ADC channel read back from ADC register,
+  *                comparison with internal channel parameter to be done
+  *                using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
+  * @param  __GROUP__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_GROUP_REGULAR
+  *         @arg @ref LL_ADC_GROUP_INJECTED
+  *         @arg @ref LL_ADC_GROUP_REGULAR_INJECTED
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_AWD_DISABLE
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_REG        (0)
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_INJ        (0)
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CH_VREFINT_REG          (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_VREFINT_INJ          (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_VREFINT_REG_INJ         (1)
+  *         @arg @ref LL_ADC_AWD_CH_TEMPSENSOR_REG       (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_TEMPSENSOR_INJ       (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_TEMPSENSOR_REG_INJ      (1)
+  *         @arg @ref LL_ADC_AWD_CH_VBAT_REG             (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_VBAT_INJ             (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_VBAT_REG_INJ            (1)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH1_ADC2_REG     (0)(2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH1_ADC2_INJ     (0)(2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH1_ADC2_REG_INJ    (2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH2_ADC2_REG     (0)(2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH2_ADC2_INJ     (0)(2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH2_ADC2_REG_INJ    (2)
+  *
+  *         (0) On STM32H7, parameter available only on analog watchdog number: AWD1.\n
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.
+  */
+#define __LL_ADC_ANALOGWD_CHANNEL_GROUP(__CHANNEL__, __GROUP__)                                           \
+  (((__GROUP__) == LL_ADC_GROUP_REGULAR)                                                                  \
+    ? (((__CHANNEL__) & ADC_CHANNEL_ID_MASK) | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL)                        \
+      :                                                                                                   \
+      ((__GROUP__) == LL_ADC_GROUP_INJECTED)                                                              \
+       ? (((__CHANNEL__) & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1SGL)                    \
+         :                                                                                                \
+         (((__CHANNEL__) & ADC_CHANNEL_ID_MASK) | ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL)  \
+  )
+
+/**
+  * @brief  Helper macro to set the value of ADC analog watchdog threshold high
+  *         or low in function of ADC resolution, when ADC resolution is
+  *         different of 16 bits.
+  * @note   To be used with function @ref LL_ADC_SetAnalogWDThresholds().
+  *         Example, with a ADC resolution of 8 bits, to set the value of
+  *         analog watchdog threshold high (on 18 bits):
+  *           LL_ADC_SetAnalogWDThresholds
+  *            (< ADCx param >,
+  *             __LL_ADC_ANALOGWD_SET_THRESHOLD_RESOLUTION(LL_ADC_RESOLUTION_8B, <threshold_value_18_bits>)
+  *            );
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @param  __AWD_THRESHOLD__ Value between Min_Data=0x000000 and Max_Data=0xFFFFFF
+  * @retval Value between Min_Data=0x000000 and Max_Data=0xFFFFFF
+  */
+#define __LL_ADC_ANALOGWD_SET_THRESHOLD_RESOLUTION(__ADC_RESOLUTION__, __AWD_THRESHOLD__) \
+  ((__AWD_THRESHOLD__) << ((__ADC_RESOLUTION__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1U )))
+
+/**
+  * @brief  Helper macro to get the value of ADC analog watchdog threshold high
+  *         or low in function of ADC resolution, when ADC resolution is
+  *         different of 16 bits.
+  * @note   To be used with function @ref LL_ADC_GetAnalogWDThresholds().
+  *         Example, with a ADC resolution of 8 bits, to get the value of
+  *         analog watchdog threshold high (on 18 bits):
+  *           < threshold_value_18_bits > = __LL_ADC_ANALOGWD_GET_THRESHOLD_RESOLUTION
+  *            (LL_ADC_RESOLUTION_8B,
+  *             LL_ADC_GetAnalogWDThresholds(<ADCx param>, LL_ADC_AWD_THRESHOLD_HIGH)
+  *            );
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @param  __AWD_THRESHOLD_16_BITS__ Value between Min_Data=0x000000 and Max_Data=0xFFFFFF
+  * @retval Value between Min_Data=0x000000 and Max_Data=0xFFFFFF
+  */
+#define __LL_ADC_ANALOGWD_GET_THRESHOLD_RESOLUTION(__ADC_RESOLUTION__, __AWD_THRESHOLD_16_BITS__) \
+  ((__AWD_THRESHOLD_16_BITS__) >> ((__ADC_RESOLUTION__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1U )))
+
+/**
+  * @brief  Helper macro to set the ADC calibration value with both single ended
+  *         and differential modes calibration factors concatenated.
+  * @note   To be used with function @ref LL_ADC_SetCalibrationOffsetFactor().
+  *         Example, to set calibration factors single ended to 0x55
+  *         and differential ended to 0x2A:
+  *           LL_ADC_SetCalibrationOffsetFactor(
+  *             ADC1,
+  *             __LL_ADC_CALIB_FACTOR_SINGLE_DIFF(0x55, 0x2A))
+  * @param  __CALIB_FACTOR_SINGLE_ENDED__ Value between Min_Data=0x00 and Max_Data=0x7F
+  * @param  __CALIB_FACTOR_DIFFERENTIAL__ Value between Min_Data=0x00 and Max_Data=0x7F
+  * @retval Value between Min_Data=0x00000000 and Max_Data=0xFFFFFFFF
+  */
+#define __LL_ADC_CALIB_FACTOR_SINGLE_DIFF(__CALIB_FACTOR_SINGLE_ENDED__, __CALIB_FACTOR_DIFFERENTIAL__)        \
+  (((__CALIB_FACTOR_DIFFERENTIAL__) << ADC_CALFACT_CALFACT_D_Pos) | (__CALIB_FACTOR_SINGLE_ENDED__))
+
+/**
+  * @brief  Helper macro to get the ADC multimode conversion data of ADC master
+  *         or ADC slave from raw value with both ADC conversion data concatenated.
+  * @note   This macro is intended to be used when multimode transfer by DMA
+  *         is enabled: refer to function @ref LL_ADC_SetMultiDMATransfer().
+  *         In this case the transferred data need to processed with this macro
+  *         to separate the conversion data of ADC master and ADC slave.
+  * @param  __ADC_MULTI_MASTER_SLAVE__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_MASTER
+  *         @arg @ref LL_ADC_MULTI_SLAVE
+  * @param  __ADC_MULTI_CONV_DATA__ Value between Min_Data=0x000 and Max_Data=0xFFF
+  * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
+  */
+#define __LL_ADC_MULTI_CONV_DATA_MASTER_SLAVE(__ADC_MULTI_MASTER_SLAVE__, __ADC_MULTI_CONV_DATA__) \
+  (((__ADC_MULTI_CONV_DATA__) >> ((ADC_CDR_RDATA_SLV_Pos) & ~(__ADC_MULTI_MASTER_SLAVE__))) & ADC_CDR_RDATA_MST)
+
+/**
+  * @brief  Helper macro to select, from a ADC instance, to which ADC instance
+  *         it has a dependence in multimode (ADC master of the corresponding
+  *         ADC common instance).
+  * @note   In case of device with multimode available and a mix of
+  *         ADC instances compliant and not compliant with multimode feature,
+  *         ADC instances not compliant with multimode feature are
+  *         considered as master instances (do not depend to
+  *         any other ADC instance).
+  * @param  __ADCx__ ADC instance
+  * @retval __ADCx__ ADC instance master of the corresponding ADC common instance
+  */
+#define __LL_ADC_MULTI_INSTANCE_MASTER(__ADCx__) \
+  ( ( ((__ADCx__) == ADC2)                                                     \
+    )?                                                                         \
+     (ADC1)                                                                    \
+     :                                                                         \
+     (__ADCx__)                                                                \
+  )
+
+/**
+  * @brief  Helper macro to select the ADC common instance
+  *         to which is belonging the selected ADC instance.
+  * @note   ADC common register instance can be used for:
+  *         - Set parameters common to several ADC instances
+  *         - Multimode (for devices with several ADC instances)
+  *         Refer to functions having argument "ADCxy_COMMON" as parameter.
+  * @param  __ADCx__ ADC instance
+  * @retval ADC common register instance
+  */
+#if defined(ADC3_COMMON)
+#define __LL_ADC_COMMON_INSTANCE(__ADCx__)                                     \
+  ((((__ADCx__) == ADC1) || ((__ADCx__) == ADC2))                              \
+    ? (                                                                        \
+       (ADC12_COMMON)                                                          \
+      )                                                                        \
+      :                                                                        \
+      (                                                                        \
+       (ADC3_COMMON)                                                           \
+      )                                                                        \
+  )
+#else
+#define __LL_ADC_COMMON_INSTANCE(__ADCx__)   (ADC12_COMMON)
+#endif
+
+/**
+  * @brief  Helper macro to check if all ADC instances sharing the same
+  *         ADC common instance are disabled.
+  * @note   This check is required by functions with setting conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled.
+  *         Refer to functions having argument "ADCxy_COMMON" as parameter.
+  * @note   On devices with only 1 ADC common instance, parameter of this macro
+  *         is useless and can be ignored (parameter kept for compatibility
+  *         with devices featuring several ADC common instances).
+  * @param  __ADCXY_COMMON__ ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval Value "0" if all ADC instances sharing the same ADC common instance
+  *         are disabled.
+  *         Value "1" if at least one ADC instance sharing the same ADC common instance
+  *         is enabled.
+  */
+#if defined(ADC3_COMMON)
+#define __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__ADCXY_COMMON__)              \
+  (((__ADCXY_COMMON__) == ADC12_COMMON)                                        \
+    ? (                                                                        \
+       (LL_ADC_IsEnabled(ADC1) |                                               \
+        LL_ADC_IsEnabled(ADC2)  )                                              \
+      )                                                                        \
+      :                                                                        \
+      (                                                                        \
+       (LL_ADC_IsEnabled(ADC3))                                                \
+      )                                                                        \
+  )
+#else
+#define __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__ADCXY_COMMON__)              \
+                        (LL_ADC_IsEnabled(ADC1) | LL_ADC_IsEnabled(ADC2))
+#endif
+
+/**
+  * @brief  Helper macro to define the ADC conversion data full-scale digital
+  *         value corresponding to the selected ADC resolution.
+  * @note   ADC conversion data full-scale corresponds to voltage range
+  *         determined by analog voltage references Vref+ and Vref-
+  *         (refer to reference manual).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @retval ADC conversion data full-scale digital value (unit: digital value of ADC conversion data)
+  */
+#define __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__)                             \
+  (0xFFFFUL >> ((__ADC_RESOLUTION__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL)))
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief  Helper macro to define the ADC conversion data full-scale digital
+  *         value corresponding to the selected ADC resolution.
+  * @note   ADC conversion data full-scale corresponds to voltage range
+  *         determined by analog voltage references Vref+ and Vref-
+  *         (refer to reference manual).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  *         @arg @ref LL_ADC_RESOLUTION_6B
+  * @retval ADC conversion data equivalent voltage value (unit: digital value of ADC conversion bitfield)
+  */
+#define __LL_ADC3_DIGITAL_SCALE(__ADC_RESOLUTION__)                             \
+    (0xFFFUL >> ((__ADC_RESOLUTION__) >> (ADC_CFGR_RES_BITOFFSET_POS_ADC3 - 1UL)))
+#endif  /* ADC_VER_V5_V90 */
+/**
+  * @brief  Helper macro to convert the ADC conversion data from
+  *         a resolution to another resolution.
+  * @param  __DATA__ ADC conversion data to be converted
+  * @param  __ADC_RESOLUTION_CURRENT__ Resolution of the data to be converted
+  *         This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @param  __ADC_RESOLUTION_TARGET__ Resolution of the data after conversion
+  *         This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @retval ADC conversion data to the requested resolution
+  */
+#if defined(ADC_VER_V5_X) || defined(ADC_VER_V5_V90)
+#define __LL_ADC_CONVERT_DATA_RESOLUTION(__DATA__,\
+                                         __ADC_RESOLUTION_CURRENT__,\
+                                         __ADC_RESOLUTION_TARGET__) \
+( (__ADC_RESOLUTION_CURRENT__ == LL_ADC_RESOLUTION_8B)                                                               \
+  ?(                                                                                                                 \
+    ((__DATA__)                                                                                                      \
+    << (((__ADC_RESOLUTION_CURRENT__) & ~(ADC_CFGR_RES_1 | ADC_CFGR_RES_0) ) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL)))  \
+   >> ((__ADC_RESOLUTION_TARGET__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL))                                            \
+   )                                                                                                                 \
+  :                                                                                                                  \
+   (                                                                                                                 \
+     (__ADC_RESOLUTION_TARGET__ == LL_ADC_RESOLUTION_8B) \
+       ? ( \
+           ((__DATA__)                                                                                                      \
+            << ((__ADC_RESOLUTION_CURRENT__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL)))                                         \
+           >> (((__ADC_RESOLUTION_TARGET__) & ~(ADC_CFGR_RES_1 | ADC_CFGR_RES_0) ) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL))    \
+           )                                                                                                                 \
+         :\
+          (\
+    ((__DATA__)                                                                                                      \
+    << ((__ADC_RESOLUTION_CURRENT__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL)))                                         \
+    >> ((__ADC_RESOLUTION_TARGET__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL))                                            \
+     )                                                                                                                 \
+   )\
+ )
+
+
+#else /* defined(ADC_VER_V5_3) */
+#define __LL_ADC_CONVERT_DATA_RESOLUTION(__DATA__,\
+                                         __ADC_RESOLUTION_CURRENT__,\
+                                         __ADC_RESOLUTION_TARGET__) \
+( (__ADC_RESOLUTION_CURRENT__ == LL_ADC_RESOLUTION_8B)                                                               \
+  ?(                                                                                                                 \
+    ((__DATA__)                                                                                                      \
+    << (((__ADC_RESOLUTION_CURRENT__) & ~(ADC_CFGR_RES_1 | ADC_CFGR_RES_0) ) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL)))  \
+   >> ((__ADC_RESOLUTION_TARGET__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL))                                            \
+   )                                                                                                                 \
+  :                                                                                                                  \
+   (                                                                                                                 \
+     (__ADC_RESOLUTION_TARGET__ == LL_ADC_RESOLUTION_8B) \
+       ? ( \
+           ((__DATA__)                                                                                                      \
+            << ((__ADC_RESOLUTION_CURRENT__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL)))                                         \
+           >> (((__ADC_RESOLUTION_TARGET__) & ~(ADC_CFGR_RES_1 | ADC_CFGR_RES_0) ) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL))                                            \
+           )                                                                                                                 \
+         :\
+          (\
+    ((__DATA__)                                                                                                      \
+    << ((__ADC_RESOLUTION_CURRENT__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL)))                                         \
+    >> ((__ADC_RESOLUTION_TARGET__) >> (ADC_CFGR_RES_BITOFFSET_POS - 1UL))                                            \
+     )                                                                                                                 \
+   )\
+ )
+
+#endif
+
+#if defined(ADC_VER_V5_V90)
+/**
+* @brief  Helper macro to convert the ADC conversion data from
+*         a resolution to another resolution.
+* @param  __DATA__ ADC conversion data to be converted
+* @param  __ADC_RESOLUTION_CURRENT__ Resolution of the data to be converted
+*         This parameter can be one of the following values:
+*         @arg @ref LL_ADC_RESOLUTION_12B
+*         @arg @ref LL_ADC_RESOLUTION_10B
+*         @arg @ref LL_ADC_RESOLUTION_8B
+*         @arg @ref LL_ADC_RESOLUTION_6B
+* @param  __ADC_RESOLUTION_TARGET__ Resolution of the data after conversion
+*         This parameter can be one of the following values:
+*         @arg @ref LL_ADC_RESOLUTION_12B
+*         @arg @ref LL_ADC_RESOLUTION_10B
+*         @arg @ref LL_ADC_RESOLUTION_8B
+*         @arg @ref LL_ADC_RESOLUTION_6B
+* @retval ADC conversion data to the requested resolution
+*/
+#define __LL_ADC_CONVERT_DATA_RESOLUTION_ADC3(__DATA__,\
+                                         __ADC_RESOLUTION_CURRENT__,\
+                                         __ADC_RESOLUTION_TARGET__)            \
+  (((__DATA__)                                                                 \
+    << ((__ADC_RESOLUTION_CURRENT__) >> (ADC_CFGR_RES_BITOFFSET_POS_ADC3 - 1UL)))  \
+   >> ((__ADC_RESOLUTION_TARGET__) >> (ADC_CFGR_RES_BITOFFSET_POS_ADC3 - 1UL))     \
+  )
+#endif  /* ADC_VER_V5_V90 */
+/**
+  * @brief  Helper macro to calculate the voltage (unit: mVolt)
+  *         corresponding to a ADC conversion data (unit: digital value).
+  * @note   Analog reference voltage (Vref+) must be either known from
+  *         user board environment or can be calculated using ADC measurement
+  *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
+  * @param  __VREFANALOG_VOLTAGE__ Analog reference voltage (unit: mV)
+  * @param  __ADC_DATA__ ADC conversion data (resolution 16 bits)
+  *                       (unit: digital value).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @retval ADC conversion data equivalent voltage value (unit: mVolt)
+  */
+#define __LL_ADC_CALC_DATA_TO_VOLTAGE(__VREFANALOG_VOLTAGE__,\
+                                      __ADC_DATA__,\
+                                      __ADC_RESOLUTION__)                      \
+  ((__ADC_DATA__) * (__VREFANALOG_VOLTAGE__)                                   \
+   / __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__)                                \
+  )
+
+/**
+  * @brief  Helper macro to calculate analog reference voltage (Vref+)
+  *         (unit: mVolt) from ADC conversion data of internal voltage
+  *         reference VrefInt.
+  * @note   Computation is using VrefInt calibration value
+  *         stored in system memory for each device during production.
+  * @note   This voltage depends on user board environment: voltage level
+  *         connected to pin Vref+.
+  *         On devices with small package, the pin Vref+ is not present
+  *         and internally bonded to pin Vdda.
+  * @note   On this STM32 series, calibration data of internal voltage reference
+  *         VrefInt corresponds to a resolution of 16 bits,
+  *         this is the recommended ADC resolution to convert voltage of
+  *         internal voltage reference VrefInt.
+  *         Otherwise, this macro performs the processing to scale
+  *         ADC conversion data to 16 bits.
+  * @param  __VREFINT_ADC_DATA__ ADC conversion data (resolution 16 bits)
+  *         of internal voltage reference VrefInt (unit: digital value).
+  * @param  __ADC_RESOLUTION__ This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @retval Analog reference voltage (unit: mV)
+  */
+#define __LL_ADC_CALC_VREFANALOG_VOLTAGE(__VREFINT_ADC_DATA__,\
+                                         __ADC_RESOLUTION__)                   \
+  (((uint32_t)(*VREFINT_CAL_ADDR) * VREFINT_CAL_VREF)                          \
+    / __LL_ADC_CONVERT_DATA_RESOLUTION((__VREFINT_ADC_DATA__),                 \
+                                       (__ADC_RESOLUTION__),                   \
+                                       LL_ADC_RESOLUTION_12B)                  \
+  )
+
+/**
+  * @brief  Helper macro to calculate the temperature (unit: degree Celsius)
+  *         from ADC conversion data of internal temperature sensor.
+  * @note   Computation is using temperature sensor calibration values
+  *         stored in system memory for each device during production.
+  * @note   Calculation formula:
+  *           Temperature = ((TS_ADC_DATA - TS_CAL1)
+  *                           * (TS_CAL2_TEMP - TS_CAL1_TEMP))
+  *                         / (TS_CAL2 - TS_CAL1) + TS_CAL1_TEMP
+  *           with TS_ADC_DATA = temperature sensor raw data measured by ADC
+  *                Avg_Slope = (TS_CAL2 - TS_CAL1)
+  *                            / (TS_CAL2_TEMP - TS_CAL1_TEMP)
+  *                TS_CAL1   = equivalent TS_ADC_DATA at temperature
+  *                            TEMP_DEGC_CAL1 (calibrated in factory)
+  *                TS_CAL2   = equivalent TS_ADC_DATA at temperature
+  *                            TEMP_DEGC_CAL2 (calibrated in factory)
+  *         Caution: Calculation relevancy under reserve that calibration
+  *                  parameters are correct (address and data).
+  *                  To calculate temperature using temperature sensor
+  *                  datasheet typical values (generic values less, therefore
+  *                  less accurate than calibrated values),
+  *                  use helper macro @ref __LL_ADC_CALC_TEMPERATURE_TYP_PARAMS().
+  * @note   As calculation input, the analog reference voltage (Vref+) must be
+  *         defined as it impacts the ADC LSB equivalent voltage.
+  * @note   Analog reference voltage (Vref+) must be either known from
+  *         user board environment or can be calculated using ADC measurement
+  *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
+  * @note   On this STM32 series, calibration data of temperature sensor
+  *         corresponds to a resolution of 16 bits,
+  *         this is the recommended ADC resolution to convert voltage of
+  *         temperature sensor.
+  *         Otherwise, this macro performs the processing to scale
+  *         ADC conversion data to 16 bits.
+  * @param  __VREFANALOG_VOLTAGE__  Analog reference voltage (unit: mV)
+  * @param  __TEMPSENSOR_ADC_DATA__ ADC conversion data of internal
+  *                                 temperature sensor (unit: digital value).
+  * @param  __ADC_RESOLUTION__      ADC resolution at which internal temperature
+  *                                 sensor voltage has been measured.
+  *         This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @retval Temperature (unit: degree Celsius)
+  */
+#define __LL_ADC_CALC_TEMPERATURE(__VREFANALOG_VOLTAGE__,\
+                                  __TEMPSENSOR_ADC_DATA__,\
+                                  __ADC_RESOLUTION__)                              \
+  (((( ((int32_t)((__LL_ADC_CONVERT_DATA_RESOLUTION((__TEMPSENSOR_ADC_DATA__),     \
+                                                    (__ADC_RESOLUTION__),          \
+                                                    LL_ADC_RESOLUTION_16B)         \
+                   * (__VREFANALOG_VOLTAGE__))                                     \
+                  / TEMPSENSOR_CAL_VREFANALOG)                                     \
+        - (int32_t) *TEMPSENSOR_CAL1_ADDR)                                         \
+     ) * (int32_t)(TEMPSENSOR_CAL2_TEMP - TEMPSENSOR_CAL1_TEMP)                    \
+    ) / (int32_t)((int32_t)*TEMPSENSOR_CAL2_ADDR - (int32_t)*TEMPSENSOR_CAL1_ADDR) \
+   ) + TEMPSENSOR_CAL1_TEMP                                                        \
+  )
+
+/**
+  * @brief  Helper macro to calculate the temperature (unit: degree Celsius)
+  *         from ADC conversion data of internal temperature sensor.
+  * @note   Computation is using temperature sensor typical values
+  *         (refer to device datasheet).
+  * @note   Calculation formula:
+  *           Temperature = (TS_TYP_CALx_VOLT(uV) - TS_ADC_DATA * Conversion_uV)
+  *                         / Avg_Slope + CALx_TEMP
+  *           with TS_ADC_DATA      = temperature sensor raw data measured by ADC
+  *                                   (unit: digital value)
+  *                Avg_Slope        = temperature sensor slope
+  *                                   (unit: uV/Degree Celsius)
+  *                TS_TYP_CALx_VOLT = temperature sensor digital value at
+  *                                   temperature CALx_TEMP (unit: mV)
+  *         Caution: Calculation relevancy under reserve the temperature sensor
+  *                  of the current device has characteristics in line with
+  *                  datasheet typical values.
+  *                  If temperature sensor calibration values are available on
+  *                  on this device (presence of macro __LL_ADC_CALC_TEMPERATURE()),
+  *                  temperature calculation will be more accurate using
+  *                  helper macro @ref __LL_ADC_CALC_TEMPERATURE().
+  * @note   As calculation input, the analog reference voltage (Vref+) must be
+  *         defined as it impacts the ADC LSB equivalent voltage.
+  * @note   Analog reference voltage (Vref+) must be either known from
+  *         user board environment or can be calculated using ADC measurement
+  *         and ADC helper macro @ref __LL_ADC_CALC_VREFANALOG_VOLTAGE().
+  * @note   ADC measurement data must correspond to a resolution of 16 bits
+  *         (full scale digital value 4095). If not the case, the data must be
+  *         preliminarily rescaled to an equivalent resolution of 16 bits.
+  * @param  __TEMPSENSOR_TYP_AVGSLOPE__   Device datasheet data: Temperature sensor slope typical value (unit: uV/DegCelsius).
+  *                                       On STM32H7, refer to device datasheet parameter "Avg_Slope".
+  * @param  __TEMPSENSOR_TYP_CALX_V__     Device datasheet data: Temperature sensor voltage typical value (at temperature and Vref+ defined in parameters below) (unit: mV).
+  *                                       On STM32H7, refer to device datasheet parameter "V30" (corresponding to TS_CAL1).
+  * @param  __TEMPSENSOR_CALX_TEMP__      Device datasheet data: Temperature at which temperature sensor voltage (see parameter above) is corresponding (unit: mV)
+  * @param  __VREFANALOG_VOLTAGE__        Analog voltage reference (Vref+) voltage (unit: mV)
+  * @param  __TEMPSENSOR_ADC_DATA__       ADC conversion data of internal temperature sensor (unit: digital value).
+  * @param  __ADC_RESOLUTION__            ADC resolution at which internal temperature sensor voltage has been measured.
+  *         This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @retval Temperature (unit: degree Celsius)
+  */
+#define __LL_ADC_CALC_TEMPERATURE_TYP_PARAMS(__TEMPSENSOR_TYP_AVGSLOPE__,\
+                                             __TEMPSENSOR_TYP_CALX_V__,\
+                                             __TEMPSENSOR_CALX_TEMP__,\
+                                             __VREFANALOG_VOLTAGE__,\
+                                             __TEMPSENSOR_ADC_DATA__,\
+                                             __ADC_RESOLUTION__)               \
+  ((( (                                                                        \
+       (int32_t)((((__TEMPSENSOR_ADC_DATA__) * (__VREFANALOG_VOLTAGE__))       \
+                  / __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__))                \
+                 * 1000UL)                                                     \
+       -                                                                       \
+       (int32_t)(((__TEMPSENSOR_TYP_CALX_V__))                                 \
+                 * 1000UL)                                                     \
+      )                                                                        \
+    ) / (int32_t)(__TEMPSENSOR_TYP_AVGSLOPE__)                                 \
+   ) + (int32_t)(__TEMPSENSOR_CALX_TEMP__)                                     \
+  )
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup ADC_LL_Exported_Functions ADC Exported Functions
+  * @{
+  */
+
+/** @defgroup ADC_LL_EF_DMA_Management ADC DMA management
+  * @{
+  */
+
+/**
+  * @brief  Function to help to configure DMA transfer from ADC: retrieve the
+  *         ADC register address from ADC instance and a list of ADC registers
+  *         intended to be used (most commonly) with DMA transfer.
+  * @note   These ADC registers are data registers:
+  *         when ADC conversion data is available in ADC data registers,
+  *         ADC generates a DMA transfer request.
+  * @note   This macro is intended to be used with LL DMA driver, refer to
+  *         function "LL_DMA_ConfigAddresses()".
+  *         Example:
+  *           LL_DMA_ConfigAddresses(DMA1,
+  *                                  LL_DMA_CHANNEL_1,
+  *                                  LL_ADC_DMA_GetRegAddr(ADC1, LL_ADC_DMA_REG_REGULAR_DATA),
+  *                                  (uint32_t)&< array or variable >,
+  *                                  LL_DMA_DIRECTION_PERIPH_TO_MEMORY);
+  * @note   For devices with several ADC: in multimode, some devices
+  *         use a different data register outside of ADC instance scope
+  *         (common data register). This macro manages this register difference,
+  *         only ADC instance has to be set as parameter.
+  * @rmtoll DR       RDATA          LL_ADC_DMA_GetRegAddr\n
+  *         CDR      RDATA_MST      LL_ADC_DMA_GetRegAddr\n
+  *         CDR      RDATA_SLV      LL_ADC_DMA_GetRegAddr
+  * @param  ADCx ADC instance
+  * @param  Register This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_DMA_REG_REGULAR_DATA
+  *         @arg @ref LL_ADC_DMA_REG_REGULAR_DATA_MULTI (1)
+  *
+  *         (1) Available on devices with several ADC instances.
+  * @retval ADC register address
+  */
+__STATIC_INLINE uint32_t LL_ADC_DMA_GetRegAddr(const ADC_TypeDef *ADCx, uint32_t Register)
+{
+  uint32_t data_reg_addr;
+
+  if (Register == LL_ADC_DMA_REG_REGULAR_DATA)
+  {
+    /* Retrieve address of register DR */
+    data_reg_addr = (uint32_t) & (ADCx->DR);
+  }
+  else /* (Register == LL_ADC_DMA_REG_REGULAR_DATA_MULTI) */
+  {
+    /* Retrieve address of register CDR */
+    data_reg_addr = (uint32_t) & ((__LL_ADC_COMMON_INSTANCE(ADCx))->CDR);
+  }
+
+  return data_reg_addr;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Configuration_ADC_Common Configuration of ADC hierarchical scope: common to several ADC instances
+  * @{
+  */
+
+/**
+  * @brief  Set parameter common to several ADC: Clock source and prescaler.
+  * @note   On this STM32 series, if ADC group injected is used, some
+  *         clock ratio constraints between ADC clock and AHB clock
+  *         must be respected.
+  *         Refer to reference manual.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled.
+  *         This check can be done with function @ref LL_ADC_IsEnabled() for each
+  *         ADC instance or by using helper macro helper macro
+  *         @ref __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE().
+  * @rmtoll CCR      CKMODE         LL_ADC_SetCommonClock\n
+  *         CCR      PRESC          LL_ADC_SetCommonClock
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  CommonClock This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CLOCK_SYNC_PCLK_DIV1
+  *         @arg @ref LL_ADC_CLOCK_SYNC_PCLK_DIV2
+  *         @arg @ref LL_ADC_CLOCK_SYNC_PCLK_DIV4
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV1
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV2
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV4
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV6
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV8
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV10
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV12
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV16
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV32
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV64
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV128
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV256
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetCommonClock(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t CommonClock)
+{
+  MODIFY_REG(ADCxy_COMMON->CCR, ADC_CCR_CKMODE | ADC_CCR_PRESC, CommonClock);
+}
+
+/**
+  * @brief  Get parameter common to several ADC: Clock source and prescaler.
+  * @rmtoll CCR      CKMODE         LL_ADC_GetCommonClock\n
+  *         CCR      PRESC          LL_ADC_GetCommonClock
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_CLOCK_SYNC_PCLK_DIV1
+  *         @arg @ref LL_ADC_CLOCK_SYNC_PCLK_DIV2
+  *         @arg @ref LL_ADC_CLOCK_SYNC_PCLK_DIV4
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV1
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV2
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV4
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV6
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV8
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV10
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV12
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV16
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV32
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV64
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV128
+  *         @arg @ref LL_ADC_CLOCK_ASYNC_DIV256
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetCommonClock(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return (uint32_t)(READ_BIT(ADCxy_COMMON->CCR, ADC_CCR_CKMODE | ADC_CCR_PRESC));
+}
+
+/**
+  * @brief  Set parameter common to several ADC: measurement path to internal
+  *         channels (VrefInt, temperature sensor, ...).
+  * @note   One or several values can be selected.
+  *         Example: (LL_ADC_PATH_INTERNAL_VREFINT |
+  *                   LL_ADC_PATH_INTERNAL_TEMPSENSOR)
+  * @note   Stabilization time of measurement path to internal channel:
+  *         After enabling internal paths, before starting ADC conversion,
+  *         a delay is required for internal voltage reference and
+  *         temperature sensor stabilization time.
+  *         Refer to device datasheet.
+  *         Refer to literal @ref LL_ADC_DELAY_VREFINT_STAB_US.
+  *         Refer to literal @ref LL_ADC_DELAY_TEMPSENSOR_STAB_US.
+  * @note   ADC internal channel sampling time constraint:
+  *         For ADC conversion of internal channels,
+  *         a sampling time minimum value is required.
+  *         Refer to device datasheet.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled.
+  *         This check can be done with function @ref LL_ADC_IsEnabled() for each
+  *         ADC instance or by using helper macro helper macro
+  *         @ref __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE().
+  * @rmtoll CCR      VREFEN         LL_ADC_SetCommonPathInternalCh\n
+  *         CCR      TSEN           LL_ADC_SetCommonPathInternalCh\n
+  *         CCR      VBATEN         LL_ADC_SetCommonPathInternalCh
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  PathInternal This parameter can be a combination of the following values:
+  *         @arg @ref LL_ADC_PATH_INTERNAL_NONE
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VREFINT
+  *         @arg @ref LL_ADC_PATH_INTERNAL_TEMPSENSOR
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VBAT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetCommonPathInternalCh(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t PathInternal)
+{
+  MODIFY_REG(ADCxy_COMMON->CCR, ADC_CCR_VREFEN | ADC_CCR_TSEN | ADC_CCR_VBATEN, PathInternal);
+}
+
+/**
+  * @brief  Get parameter common to several ADC: measurement path to internal
+  *         channels (VrefInt, temperature sensor, ...).
+  * @note   One or several values can be selected.
+  *         Example: (LL_ADC_PATH_INTERNAL_VREFINT |
+  *                   LL_ADC_PATH_INTERNAL_TEMPSENSOR)
+  * @rmtoll CCR      VREFEN         LL_ADC_GetCommonPathInternalCh\n
+  *         CCR      TSEN           LL_ADC_GetCommonPathInternalCh\n
+  *         CCR      VBATEN         LL_ADC_GetCommonPathInternalCh
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval Returned value can be a combination of the following values:
+  *         @arg @ref LL_ADC_PATH_INTERNAL_NONE
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VREFINT
+  *         @arg @ref LL_ADC_PATH_INTERNAL_TEMPSENSOR
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VBAT
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetCommonPathInternalCh(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return (uint32_t)(READ_BIT(ADCxy_COMMON->CCR, ADC_CCR_VREFEN | ADC_CCR_TSEN | ADC_CCR_VBATEN));
+}
+
+/**
+  * @brief  Set parameter common to several ADC: measurement path to
+  *         internal channels (VrefInt, temperature sensor, ...).
+  *         Add paths to the current configuration.
+  * @note   One or several values can be selected.
+  *         Example: (LL_ADC_PATH_INTERNAL_VREFINT |
+  *                   LL_ADC_PATH_INTERNAL_TEMPSENSOR)
+  * @note   Stabilization time of measurement path to internal channel:
+  *         After enabling internal paths, before starting ADC conversion,
+  *         a delay is required for internal voltage reference and
+  *         temperature sensor stabilization time.
+  *         Refer to device datasheet.
+  *         Refer to literal @ref LL_ADC_DELAY_VREFINT_STAB_US.
+  *         Refer to literal @ref LL_ADC_DELAY_TEMPSENSOR_STAB_US.
+  * @note   ADC internal channel sampling time constraint:
+  *         For ADC conversion of internal channels,
+  *         a sampling time minimum value is required.
+  *         Refer to device datasheet.
+  * @rmtoll CCR      VREFEN         LL_ADC_SetCommonPathInternalChAdd\n
+  *         CCR      TSEN           LL_ADC_SetCommonPathInternalChAdd\n
+  *         CCR      VBATEN        LL_ADC_SetCommonPathInternalChAdd
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  PathInternal This parameter can be a combination of the following values:
+  *         @arg @ref LL_ADC_PATH_INTERNAL_NONE
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VREFINT
+  *         @arg @ref LL_ADC_PATH_INTERNAL_TEMPSENSOR
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VBAT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetCommonPathInternalChAdd(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t PathInternal)
+{
+  SET_BIT(ADCxy_COMMON->CCR, PathInternal);
+}
+
+/**
+  * @brief  Set parameter common to several ADC: measurement path to
+  *         internal channels (VrefInt, temperature sensor, ...).
+  *         Remove paths to the current configuration.
+  * @note   One or several values can be selected.
+  *         Example: (LL_ADC_PATH_INTERNAL_VREFINT |
+  *                   LL_ADC_PATH_INTERNAL_TEMPSENSOR)
+  * @rmtoll CCR      VREFEN         LL_ADC_SetCommonPathInternalChRem\n
+  *         CCR      TSEN           LL_ADC_SetCommonPathInternalChRem\n
+  *         CCR      VBATEN        LL_ADC_SetCommonPathInternalChRem
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  PathInternal This parameter can be a combination of the following values:
+  *         @arg @ref LL_ADC_PATH_INTERNAL_NONE
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VREFINT
+  *         @arg @ref LL_ADC_PATH_INTERNAL_TEMPSENSOR
+  *         @arg @ref LL_ADC_PATH_INTERNAL_VBAT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetCommonPathInternalChRem(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t PathInternal)
+{
+  CLEAR_BIT(ADCxy_COMMON->CCR, PathInternal);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Configuration_ADC_Instance Configuration of ADC hierarchical scope: ADC instance
+  * @{
+  */
+
+/**
+  * @brief  Set ADC calibration factor in the mode single-ended
+  *         or differential (for devices with differential mode available).
+  * @note   This function is intended to set calibration parameters
+  *         without having to perform a new calibration using
+  *         @ref LL_ADC_StartCalibration().
+  * @note   For devices with differential mode available:
+  *         Calibration of offset is specific to each of
+  *         single-ended and differential modes
+  *         (calibration factor must be specified for each of these
+  *         differential modes, if used afterwards and if the application
+  *         requires their calibration).
+  *         Calibration of linearity is common to both
+  *         single-ended and differential modes
+  *         (calibration factor can be specified only once).
+  * @note   In case of setting calibration factors of both modes single ended
+  *         and differential (parameter LL_ADC_BOTH_SINGLE_DIFF_ENDED):
+  *         both calibration factors must be concatenated.
+  *         To perform this processing, use helper macro
+  *         @ref __LL_ADC_CALIB_FACTOR_SINGLE_DIFF().
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be enabled, without calibration on going, without conversion
+  *         on going on group regular.
+  * @rmtoll CALFACT  CALFACT_S      LL_ADC_SetCalibrationOffsetFactor\n
+  *         CALFACT  CALFACT_D      LL_ADC_SetCalibrationOffsetFactor
+  * @param  ADCx ADC instance
+  * @param  SingleDiff This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_SINGLE_ENDED
+  *         @arg @ref LL_ADC_DIFFERENTIAL_ENDED
+  *         @arg @ref LL_ADC_BOTH_SINGLE_DIFF_ENDED
+  * @param  CalibrationFactor Value between Min_Data=0x00 and Max_Data=0x7F
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetCalibrationOffsetFactor(ADC_TypeDef *ADCx, uint32_t SingleDiff, uint32_t CalibrationFactor)
+{
+#if defined(ADC_VER_V5_V90)
+  MODIFY_REG(ADCx->CALFACT_RES13,
+             SingleDiff & ADC_SINGLEDIFF_CALIB_FACTOR_MASK,
+             CalibrationFactor << (((SingleDiff & ADC_SINGLEDIFF_CALIB_F_BIT_D_MASK) >> ADC_SINGLEDIFF_CALIB_F_BIT_D_SHIFT4) & ~(SingleDiff & ADC_CALFACT_CALFACT_S)));
+#else
+  MODIFY_REG(ADCx->CALFACT,
+             SingleDiff & ADC_SINGLEDIFF_CALIB_FACTOR_MASK,
+             CalibrationFactor << (((SingleDiff & ADC_SINGLEDIFF_CALIB_F_BIT_D_MASK) >> ADC_SINGLEDIFF_CALIB_F_BIT_D_SHIFT4) & ~(SingleDiff & ADC_CALFACT_CALFACT_S)));
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Get ADC calibration factor in the mode single-ended
+  *         or differential (for devices with differential mode available).
+  * @note   Calibration factors are set by hardware after performing
+  *         a calibration run using function @ref LL_ADC_StartCalibration().
+  * @note   For devices with differential mode available:
+  *         Calibration of offset is specific to each of
+  *         single-ended and differential modes
+  *         Calibration of linearity is common to both
+  *         single-ended and differential modes
+  * @rmtoll CALFACT  CALFACT_S      LL_ADC_GetCalibrationOffsetFactor\n
+  *         CALFACT  CALFACT_D      LL_ADC_GetCalibrationOffsetFactor
+  * @param  ADCx ADC instance
+  * @param  SingleDiff This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_SINGLE_ENDED
+  *         @arg @ref LL_ADC_DIFFERENTIAL_ENDED
+  * @retval Value between Min_Data=0x00 and Max_Data=0x7F
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetCalibrationOffsetFactor(const ADC_TypeDef *ADCx, uint32_t SingleDiff)
+{
+  /* Retrieve bits with position in register depending on parameter           */
+  /* "SingleDiff".                                                            */
+  /* Parameter used with mask "ADC_SINGLEDIFF_CALIB_FACTOR_MASK" because      */
+  /* containing other bits reserved for other purpose.                        */
+#if defined(ADC_VER_V5_V90)
+  return (uint32_t)(READ_BIT(ADCx->CALFACT_RES13, (SingleDiff & ADC_SINGLEDIFF_CALIB_FACTOR_MASK)) >> ((SingleDiff & ADC_SINGLEDIFF_CALIB_F_BIT_D_MASK) >> ADC_SINGLEDIFF_CALIB_F_BIT_D_SHIFT4));
+#else
+  return (uint32_t)(READ_BIT(ADCx->CALFACT, (SingleDiff & ADC_SINGLEDIFF_CALIB_FACTOR_MASK)) >> ((SingleDiff & ADC_SINGLEDIFF_CALIB_F_BIT_D_MASK) >> ADC_SINGLEDIFF_CALIB_F_BIT_D_SHIFT4));
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Set ADC Linear calibration factor in the mode single-ended.
+  * @note   This function is intended to set linear calibration parameters
+  *         without having to perform a new calibration using
+  *         @ref LL_ADC_StartCalibration().
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be enabled, without calibration on going, without conversion
+  *         on going on group regular.
+  * @rmtoll CALFACT2  LINCALFACT      LL_ADC_SetCalibrationLinearFactor\n
+  *         CALFACT2  LINCALFACT      LL_ADC_SetCalibrationLinearFactor
+  * @param  ADCx ADC instance
+  * @param  LinearityWord This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD1
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD2
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD3
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD4
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD5
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD6
+  * @param  CalibrationFactor Value between Min_Data=0x00 and Max_Data=0x3FFFFFFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetCalibrationLinearFactor(ADC_TypeDef *ADCx, uint32_t LinearityWord, uint32_t CalibrationFactor)
+{
+#if defined(ADC_VER_V5_V90)
+  if (ADCx != ADC3)
+  {
+    uint32_t timeout_cpu_cycles = ADC_LINEARITY_BIT_TOGGLE_TIMEOUT;
+    MODIFY_REG(ADCx->CALFACT2_RES14, ADC_CALFACT2_LINCALFACT, CalibrationFactor);
+    MODIFY_REG(ADCx->CR, ADC_CR_ADCALLIN, LinearityWord);
+    while ((READ_BIT(ADCx->CR, LinearityWord) == 0UL) && (timeout_cpu_cycles > 0UL))
+    {
+      timeout_cpu_cycles--;
+    }
+  }
+#else
+  uint32_t timeout_cpu_cycles = ADC_LINEARITY_BIT_TOGGLE_TIMEOUT;
+  MODIFY_REG(ADCx->CALFACT2, ADC_CALFACT2_LINCALFACT, CalibrationFactor);
+  MODIFY_REG(ADCx->CR, ADC_CR_ADCALLIN, LinearityWord);
+  while ((READ_BIT(ADCx->CR, LinearityWord) == 0UL) && (timeout_cpu_cycles > 0UL))
+  {
+    timeout_cpu_cycles--;
+  }
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Get ADC Linear calibration factor in the mode single-ended.
+  * @note   Calibration factors are set by hardware after performing
+  *         a calibration run using function @ref LL_ADC_StartCalibration().
+  * @rmtoll CALFACT2  LINCALFACT      LL_ADC_GetCalibrationLinearFactor\n
+  *         CALFACT2  LINCALFACT      LL_ADC_GetCalibrationLinearFactor
+  * @param  ADCx ADC instance
+  * @param  LinearityWord This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD1
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD2
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD3
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD4
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD5
+  *         @arg @ref LL_ADC_CALIB_LINEARITY_WORD6
+  * @retval Value between Min_Data=0x00 and Max_Data=0x3FFFFFFF
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetCalibrationLinearFactor(ADC_TypeDef *ADCx, uint32_t LinearityWord)
+{
+  uint32_t timeout_cpu_cycles = ADC_LINEARITY_BIT_TOGGLE_TIMEOUT;
+  CLEAR_BIT(ADCx->CR, LinearityWord);
+  while ((READ_BIT(ADCx->CR, LinearityWord) != 0UL) && (timeout_cpu_cycles > 0UL))
+  {
+    timeout_cpu_cycles--;
+  }
+#if defined(ADC_VER_V5_V90)
+  return (uint32_t)(READ_BIT(ADCx->CALFACT2_RES14, ADC_CALFACT2_LINCALFACT));
+#else
+  return (uint32_t)(READ_BIT(ADCx->CALFACT2, ADC_CALFACT2_LINCALFACT));
+#endif /* ADC_VER_V5_V90 */
+}
+/**
+  * @brief  Set ADC resolution.
+  *         Refer to reference manual for alignments formats
+  *         dependencies to ADC resolutions.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR     RES            LL_ADC_SetResolution
+  * @param  ADCx ADC instance
+  * @param  Resolution This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetResolution(ADC_TypeDef *ADCx, uint32_t Resolution)
+{
+#if defined(ADC_VER_V5_3)
+
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_RES, Resolution);
+
+#elif defined(ADC_VER_V5_V90)
+  if (ADCx == ADC3)
+  {
+    MODIFY_REG(ADCx->CFGR, ADC3_CFGR_RES, ((__LL_ADC12_RESOLUTION_TO_ADC3(Resolution)  & (ADC_CFGR_RES_1 | ADC_CFGR_RES_0)) << 1UL));
+  }
+  else
+  {
+    if ((DBGMCU->IDCODE & 0x30000000UL) == 0x10000000UL) /* Rev.Y */
+    {
+      MODIFY_REG(ADCx->CFGR, ADC_CFGR_RES, Resolution);
+    }
+    else /* Rev.V */
+    {
+      if (LL_ADC_RESOLUTION_8B == Resolution)
+      {
+        MODIFY_REG(ADCx->CFGR, ADC_CFGR_RES, Resolution | 0x0000000CUL);
+      }
+      else
+      {
+        MODIFY_REG(ADCx->CFGR, ADC_CFGR_RES, Resolution);
+      }
+    }
+  }
+#else /* ADC_VER_V5_V90 */
+  if ((DBGMCU->IDCODE & 0x30000000UL) == 0x10000000UL) /* Rev.Y */
+  {
+    MODIFY_REG(ADCx->CFGR, ADC_CFGR_RES, Resolution);
+  }
+  else /* Rev.V */
+  {
+    if (LL_ADC_RESOLUTION_8B == Resolution)
+    {
+      MODIFY_REG(ADCx->CFGR, ADC_CFGR_RES, Resolution | 0x0000000CUL);
+    }
+    else
+    {
+      MODIFY_REG(ADCx->CFGR, ADC_CFGR_RES, Resolution);
+    }
+  }
+
+#endif /* ADC_VER_V5_X*/
+}
+
+/**
+  * @brief  Get ADC resolution.
+  *         Refer to reference manual for alignments formats
+  *         dependencies to ADC resolutions.
+  * @rmtoll CFGR     RES            LL_ADC_GetResolution
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_RESOLUTION_16B (1)
+  *         @arg @ref LL_ADC_RESOLUTION_14B
+  *         @arg @ref LL_ADC_RESOLUTION_12B
+  *         @arg @ref LL_ADC_RESOLUTION_10B
+  *         @arg @ref LL_ADC_RESOLUTION_8B
+  *         @arg @ref LL_ADC_RESOLUTION_6B  (2)
+  *         (1): Specific to ADC instance: ADC1, ADC2
+  *         (2): Specific to ADC instance: ADC3
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetResolution(const ADC_TypeDef *ADCx)
+{
+#if defined (ADC_VER_V5_3)
+
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_RES));
+
+#elif defined(ADC_VER_V5_V90)
+  if (ADCx == ADC3)
+  {
+    return (uint32_t)(READ_BIT(ADCx->CFGR, ADC3_CFGR_RES));
+  }
+  else
+  {
+    if ((uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_RES)) == 0x0000001CUL)
+    {
+      return (LL_ADC_RESOLUTION_8B);
+    }
+    else
+    {
+      return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_RES));
+    }
+  }
+
+#else  /* ADC_VER_V5_V90 */
+  if ((DBGMCU->IDCODE & 0x30000000UL) == 0x10000000UL) /* Rev.Y */
+  {
+    return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_RES));
+  }
+  else /* Rev.V */
+  {
+    if ((uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_RES)) == 0x0000001CUL)
+    {
+      return (LL_ADC_RESOLUTION_8B);
+    }
+    else
+    {
+      return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_RES));
+    }
+  }
+
+#endif /* ADC_VER_V5_X */
+}
+
+/**
+  * @brief  Set ADC low power mode.
+  * @note   Description of ADC low power modes:
+  *         - ADC low power mode "auto wait": Dynamic low power mode,
+  *           ADC conversions occurrences are limited to the minimum necessary
+  *           in order to reduce power consumption.
+  *           New ADC conversion starts only when the previous
+  *           unitary conversion data (for ADC group regular)
+  *           or previous sequence conversions data (for ADC group injected)
+  *           has been retrieved by user software.
+  *           In the meantime, ADC remains idle: does not performs any
+  *           other conversion.
+  *           This mode allows to automatically adapt the ADC conversions
+  *           triggers to the speed of the software that reads the data.
+  *           Moreover, this avoids risk of overrun for low frequency
+  *           applications.
+  *           How to use this low power mode:
+  *           - It is not recommended to use with interruption or DMA
+  *             since these modes have to clear immediately the EOC flag
+  *             (by CPU to free the IRQ pending event or by DMA).
+  *             Auto wait will work but fort a very short time, discarding
+  *             its intended benefit (except specific case of high load of CPU
+  *             or DMA transfers which can justify usage of auto wait).
+  *           - Do use with polling: 1. Start conversion,
+  *             2. Later on, when conversion data is needed: poll for end of
+  *             conversion  to ensure that conversion is completed and
+  *             retrieve ADC conversion data. This will trig another
+  *             ADC conversion start.
+  *         - ADC low power mode "auto power-off" (feature available on
+  *           this device if parameter LL_ADC_LP_AUTOPOWEROFF is available):
+  *           the ADC automatically powers-off after a conversion and
+  *           automatically wakes up when a new conversion is triggered
+  *           (with startup time between trigger and start of sampling).
+  *           This feature can be combined with low power mode "auto wait".
+  * @note   With ADC low power mode "auto wait", the ADC conversion data read
+  *         is corresponding to previous ADC conversion start, independently
+  *         of delay during which ADC was idle.
+  *         Therefore, the ADC conversion data may be outdated: does not
+  *         correspond to the current voltage level on the selected
+  *         ADC channel.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR     AUTDLY         LL_ADC_SetLowPowerMode
+  * @param  ADCx ADC instance
+  * @param  LowPowerMode This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_LP_MODE_NONE
+  *         @arg @ref LL_ADC_LP_AUTOWAIT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetLowPowerMode(ADC_TypeDef *ADCx, uint32_t LowPowerMode)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_AUTDLY, LowPowerMode);
+}
+
+/**
+  * @brief  Get ADC low power mode:
+  * @note   Description of ADC low power modes:
+  *         - ADC low power mode "auto wait": Dynamic low power mode,
+  *           ADC conversions occurrences are limited to the minimum necessary
+  *           in order to reduce power consumption.
+  *           New ADC conversion starts only when the previous
+  *           unitary conversion data (for ADC group regular)
+  *           or previous sequence conversions data (for ADC group injected)
+  *           has been retrieved by user software.
+  *           In the meantime, ADC remains idle: does not performs any
+  *           other conversion.
+  *           This mode allows to automatically adapt the ADC conversions
+  *           triggers to the speed of the software that reads the data.
+  *           Moreover, this avoids risk of overrun for low frequency
+  *           applications.
+  *           How to use this low power mode:
+  *           - It is not recommended to use with interruption or DMA
+  *             since these modes have to clear immediately the EOC flag
+  *             (by CPU to free the IRQ pending event or by DMA).
+  *             Auto wait will work but fort a very short time, discarding
+  *             its intended benefit (except specific case of high load of CPU
+  *             or DMA transfers which can justify usage of auto wait).
+  *           - Do use with polling: 1. Start conversion,
+  *             2. Later on, when conversion data is needed: poll for end of
+  *             conversion  to ensure that conversion is completed and
+  *             retrieve ADC conversion data. This will trig another
+  *             ADC conversion start.
+  *         - ADC low power mode "auto power-off" (feature available on
+  *           this device if parameter LL_ADC_LP_AUTOPOWEROFF is available):
+  *           the ADC automatically powers-off after a conversion and
+  *           automatically wakes up when a new conversion is triggered
+  *           (with startup time between trigger and start of sampling).
+  *           This feature can be combined with low power mode "auto wait".
+  * @note   With ADC low power mode "auto wait", the ADC conversion data read
+  *         is corresponding to previous ADC conversion start, independently
+  *         of delay during which ADC was idle.
+  *         Therefore, the ADC conversion data may be outdated: does not
+  *         correspond to the current voltage level on the selected
+  *         ADC channel.
+  * @rmtoll CFGR     AUTDLY         LL_ADC_GetLowPowerMode
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_LP_MODE_NONE
+  *         @arg @ref LL_ADC_LP_AUTOWAIT
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetLowPowerMode(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_AUTDLY));
+}
+
+/**
+  * @brief  Set ADC selected Channel.
+  * @note   This function set the pre-selection of channel configuration.
+  * @note   Caution: Channel selections is dependent to ADC instance and IP version:
+  *         For STM32H72x/3x This is applicable only for ADC1/ADC2
+  *         For Rest of STM32H7xxx This is applicable only all the ADCs instances.
+  *
+  * @param  ADCx ADC instance
+  * @param  Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0
+  *         @arg @ref LL_ADC_CHANNEL_1
+  *         @arg @ref LL_ADC_CHANNEL_2
+  *         @arg @ref LL_ADC_CHANNEL_3
+  *         @arg @ref LL_ADC_CHANNEL_4
+  *         @arg @ref LL_ADC_CHANNEL_5
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetChannelPreselection(ADC_TypeDef *ADCx, uint32_t Channel)
+{
+#if defined(ADC_VER_V5_V90)
+    if (ADCx != ADC3)
+    {
+      /* ADC channels preselection */
+      ADCx->PCSEL_RES0 |= (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(Channel) & 0x1FUL));
+    }
+#else
+    /* ADC channels preselection */
+    ADCx->PCSEL |= (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(Channel) & 0x1FUL));
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Gets ADC pre-selected Channel.
+  * @note   This function gets the pre-selected ADC channel.
+  * @note   Caution: Channel selections is dependent to ADC instance and IP version:
+  *         For STM32H72x/3x This is applicable only for ADC1/ADC2
+  *         For Rest of STM32H7xxx This is applicable on all the ADCs instances.
+  *
+  * @param  ADCx ADC instance
+  * @param  Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0
+  *         @arg @ref LL_ADC_CHANNEL_1
+  *         @arg @ref LL_ADC_CHANNEL_2
+  *         @arg @ref LL_ADC_CHANNEL_3
+  *         @arg @ref LL_ADC_CHANNEL_4
+  *         @arg @ref LL_ADC_CHANNEL_5
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  * @retval the preselection state of Channel (!= 0 : pre-selected, == 0 : not pre-selected)
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetChannelPreselection(const ADC_TypeDef *ADCx, uint32_t Channel)
+{
+#if defined(ADC_VER_V5_V90)
+    if (ADCx != ADC3)
+    {
+    /* Gets preselected ADC channel */
+    return (uint32_t)(READ_BIT(ADCx->PCSEL_RES0, 1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(Channel) & 0x1FUL)));
+    }
+    else
+    {
+    return 0UL;
+    }
+#else
+    /* Gets preselected ADC channel */
+    return (uint32_t)(READ_BIT(ADCx->PCSEL, 1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(Channel) & 0x1FUL)));
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Set ADC selected offset number 1, 2, 3 or 4.
+  * @note   This function set the 2 items of offset configuration:
+  *         - ADC channel to which the offset programmed will be applied
+  *           (independently of channel mapped on ADC group regular
+  *           or group injected)
+  *         - Offset level (offset to be subtracted from the raw
+  *           converted data).
+  * @note   Caution: Offset format is dependent to ADC resolution:
+  *         offset has to be left-aligned on bit 15 (handling maximum ADC resolution 16 bit),
+  *         the LSB (right bits) are set to 0.
+  * @note   This function enables the offset, by default. It can be forced
+  *         to disable state using function LL_ADC_SetOffsetState().
+  * @note   If a channel is mapped on several offsets numbers, only the offset
+  *         with the lowest value is considered for the subtraction.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @note   On STM32H7, some fast channels are available: fast analog inputs
+  *         coming from GPIO pads (ADC_IN0..5).
+  * @rmtoll OFR1     OFFSET1_CH     LL_ADC_SetOffset\n
+  *         OFR1     OFFSET1        LL_ADC_SetOffset\n
+  *         OFR1     OFFSET1_EN     LL_ADC_SetOffset\n
+  *         OFR2     OFFSET2_CH     LL_ADC_SetOffset\n
+  *         OFR2     OFFSET2        LL_ADC_SetOffset\n
+  *         OFR2     OFFSET2_EN     LL_ADC_SetOffset\n
+  *         OFR3     OFFSET3_CH     LL_ADC_SetOffset\n
+  *         OFR3     OFFSET3        LL_ADC_SetOffset\n
+  *         OFR3     OFFSET3_EN     LL_ADC_SetOffset\n
+  *         OFR4     OFFSET4_CH     LL_ADC_SetOffset\n
+  *         OFR4     OFFSET4        LL_ADC_SetOffset\n
+  *         OFR4     OFFSET4_EN     LL_ADC_SetOffset
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @param  Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @param  OffsetLevel Value between Min_Data=0x000 and Max_Data=0x3FFFFFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetOffset(ADC_TypeDef *ADCx, uint32_t Offsety, uint32_t Channel, uint32_t OffsetLevel)
+{
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+#if defined(ADC_VER_V5_V90)
+  if (ADCx == ADC3)
+  {
+    MODIFY_REG(*preg,
+               ADC3_OFR1_OFFSET1_EN | ADC_OFR1_OFFSET1_CH | (ADC_OFR1_OFFSET1 & 0xFFFUL),
+               ADC3_OFR1_OFFSET1_EN | (Channel & ADC_CHANNEL_ID_NUMBER_MASK) | OffsetLevel);
+  }
+  else
+#endif /* ADC_VER_V5_V90 */
+  {
+    MODIFY_REG(*preg,
+               ADC_OFR1_OFFSET1_CH | ADC_OFR1_OFFSET1,
+               (Channel & ADC_CHANNEL_ID_NUMBER_MASK) | OffsetLevel);
+  }
+}
+
+/**
+  * @brief  Get for the ADC selected offset number 1, 2, 3 or 4:
+  *         Channel to which the offset programmed will be applied
+  *         (independently of channel mapped on ADC group regular
+  *         or group injected)
+  * @note   Usage of the returned channel number:
+  *         - To reinject this channel into another function LL_ADC_xxx:
+  *           the returned channel number is only partly formatted on definition
+  *           of literals LL_ADC_CHANNEL_x. Therefore, it has to be compared
+  *           with parts of literals LL_ADC_CHANNEL_x or using
+  *           helper macro @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
+  *           Then the selected literal LL_ADC_CHANNEL_x can be used
+  *           as parameter for another function.
+  *         - To get the channel number in decimal format:
+  *           process the returned value with the helper macro
+  *           @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
+  * @note   On STM32H7, some fast channels are available: fast analog inputs
+  *         coming from GPIO pads (ADC_IN0..5).
+  * @rmtoll OFR1     OFFSET1_CH     LL_ADC_GetOffsetChannel\n
+  *         OFR2     OFFSET2_CH     LL_ADC_GetOffsetChannel\n
+  *         OFR3     OFFSET3_CH     LL_ADC_GetOffsetChannel\n
+  *         OFR4     OFFSET4_CH     LL_ADC_GetOffsetChannel
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).\n
+  *         (1, 2) For ADC channel read back from ADC register,
+  *                comparison with internal channel parameter to be done
+  *                using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetChannel(const ADC_TypeDef *ADCx, uint32_t Offsety)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+
+  return (uint32_t) READ_BIT(*preg, ADC_OFR1_OFFSET1_CH);
+}
+
+/**
+  * @brief  Get for the ADC selected offset number 1, 2, 3 or 4:
+  *         Offset level (offset to be subtracted from the raw
+  *         converted data).
+  * @note   Caution: Offset format is dependent to ADC resolution:
+  *         offset has to be left-aligned on bit 15 (handling maximum ADC resolution 16 bit),
+  *         the LSB (right bits) are set to 0.
+  * @rmtoll OFR1     OFFSET1        LL_ADC_GetOffsetLevel\n
+  *         OFR2     OFFSET2        LL_ADC_GetOffsetLevel\n
+  *         OFR3     OFFSET3        LL_ADC_GetOffsetLevel\n
+  *         OFR4     OFFSET4        LL_ADC_GetOffsetLevel
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @retval Value between Min_Data=0x000 and Max_Data=0x3FFFFFF
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetLevel(const ADC_TypeDef *ADCx, uint32_t Offsety)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+
+  return (uint32_t) READ_BIT(*preg, ADC_OFR1_OFFSET1);
+}
+
+
+/**
+  * @brief  Set data right shift for the ADC selected offset number 1, 2, 3 or 4:
+  *         signed offset saturation if enabled or disabled.
+  * @rmtoll CFGR2    RSHIFT          LL_ADC_SetDataRightShift\n
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @param  RigthShift This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_RSHIFT_ENABLE
+  *         @arg @ref LL_ADC_OFFSET_RSHIFT_DISABLE
+  * @retval Returned None
+  */
+__STATIC_INLINE void LL_ADC_SetDataRightShift(ADC_TypeDef *ADCx, uint32_t Offsety, uint32_t RigthShift)
+{
+  MODIFY_REG(ADCx->CFGR2, (ADC_CFGR2_RSHIFT1 | ADC_CFGR2_RSHIFT2 | ADC_CFGR2_RSHIFT3 | ADC_CFGR2_RSHIFT4), RigthShift << (Offsety & 0x1FUL));
+}
+
+/**
+  * @brief  Get data right shift for the ADC selected offset number 1, 2, 3 or 4:
+  *         signed offset saturation if enabled or disabled.
+  * @rmtoll CFGR2    RSHIFT          LL_ADC_GetDataRightShift\n
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_RSHIFT_ENABLE
+  *         @arg @ref LL_ADC_OFFSET_RSHIFT_DISABLE
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetDataRightShift(const ADC_TypeDef *ADCx, uint32_t Offsety)
+{
+  return (uint32_t)((READ_BIT(ADCx->CFGR2, (ADC_CFGR2_RSHIFT1 << (Offsety & 0x1FUL)))) >> (Offsety & 0x1FUL));
+}
+
+/**
+  * @brief  Set signed saturation for the ADC selected offset number 1, 2, 3 or 4:
+  *         signed offset saturation if enabled or disabled.
+  * @rmtoll OFR1     SSATE          LL_ADC_SetOffsetSignedSaturation\n
+  *         OFR2     SSATE          LL_ADC_SetOffsetSignedSaturation\n
+  *         OFR3     SSATE          LL_ADC_SetOffsetSignedSaturation\n
+  *         OFR4     SSATE          LL_ADC_SetOffsetSignedSaturation
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @param  OffsetSignedSaturation This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_SIGNED_SATURATION_ENABLE
+  *         @arg @ref LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE
+  * @retval Returned None
+  */
+__STATIC_INLINE void LL_ADC_SetOffsetSignedSaturation(ADC_TypeDef *ADCx, uint32_t Offsety, uint32_t OffsetSignedSaturation)
+{
+#if defined(ADC_VER_V5_V90)
+  if (ADCx == ADC3)
+  {
+    /* Function not available on this instance */
+  }
+  else
+#endif  /* ADC_VER_V5_V90 */
+  {
+    __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+    MODIFY_REG(*preg, ADC_OFR1_SSATE, OffsetSignedSaturation);
+  }
+}
+
+/**
+  * @brief  Get signed saturation for the ADC selected offset number 1, 2, 3 or 4:
+  *         signed offset saturation if enabled or disabled.
+  * @rmtoll OFR1     SSATE          LL_ADC_GetOffsetSignedSaturation\n
+  *         OFR2     SSATE          LL_ADC_GetOffsetSignedSaturation\n
+  *         OFR3     SSATE          LL_ADC_GetOffsetSignedSaturation\n
+  *         OFR4     SSATE          LL_ADC_GetOffsetSignedSaturation
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_SIGNED_SATURATION_ENABLE
+  *         @arg @ref LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetSignedSaturation(const ADC_TypeDef *ADCx, uint32_t Offsety)
+{
+#if defined(ADC_VER_V5_V90)
+  if (ADCx == ADC3)
+  {
+    /* Function not available on this instance */
+    return 0UL;
+  }
+  else
+#endif  /* ADC_VER_V5_V90 */
+  {
+    const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+    return (uint32_t) READ_BIT(*preg, ADC_OFR1_SSATE);
+  }
+}
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief  Set for the ADC selected offset number 1, 2, 3 or 4:
+  *         choose offset saturation mode.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll OFR1     SATEN          LL_ADC_SetOffsetSaturation\n
+  *         OFR2     SATEN          LL_ADC_SetOffsetSaturation\n
+  *         OFR3     SATEN          LL_ADC_SetOffsetSaturation\n
+  *         OFR4     SATEN          LL_ADC_SetOffsetSaturation
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @param  OffsetSaturation This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_SATURATION_ENABLE
+  *         @arg @ref LL_ADC_OFFSET_SATURATION_DISABLE
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetOffsetSaturation(ADC_TypeDef *ADCx, uint32_t Offsety, uint32_t OffsetSaturation)
+{
+  if (ADCx == ADC3)
+  {
+    __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+
+    MODIFY_REG(*preg,
+               ADC3_OFR1_SATEN,
+               OffsetSaturation);
+  }
+}
+
+/**
+  * @brief  Get for the ADC selected offset number 1, 2, 3 or 4:
+  *         offset saturation if enabled or disabled.
+  * @rmtoll OFR1     SATEN          LL_ADC_GetOffsetSaturation\n
+  *         OFR2     SATEN          LL_ADC_GetOffsetSaturation\n
+  *         OFR3     SATEN          LL_ADC_GetOffsetSaturation\n
+  *         OFR4     SATEN          LL_ADC_GetOffsetSaturation
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_SATURATION_ENABLE
+  *         @arg @ref LL_ADC_OFFSET_SATURATION_DISABLE
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetSaturation(const ADC_TypeDef *ADCx, uint32_t Offsety)
+{
+  if (ADCx == ADC3)
+  {
+    const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+
+    return (uint32_t) READ_BIT(*preg, ADC3_OFR1_SATEN);
+  }else
+  {
+    return 0UL;
+  }
+}
+
+/**
+  * @brief  Set for the ADC selected offset number 1, 2, 3 or 4:
+  *         choose offset sign.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll OFR1     OFFSETPOS      LL_ADC_SetOffsetSign\n
+  *         OFR2     OFFSETPOS      LL_ADC_SetOffsetSign\n
+  *         OFR3     OFFSETPOS      LL_ADC_SetOffsetSign\n
+  *         OFR4     OFFSETPOS      LL_ADC_SetOffsetSign
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @param  OffsetSign This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_SIGN_NEGATIVE
+  *         @arg @ref LL_ADC_OFFSET_SIGN_POSITIVE
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetOffsetSign(ADC_TypeDef *ADCx, uint32_t Offsety, uint32_t OffsetSign)
+{
+  if (ADCx == ADC3)
+  {
+    __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+
+    MODIFY_REG(*preg,
+               ADC3_OFR1_OFFSETPOS,
+               OffsetSign);
+  }
+}
+
+/**
+  * @brief  Get for the ADC selected offset number 1, 2, 3 or 4:
+  *         offset sign if positive or negative.
+  * @rmtoll OFR1     OFFSETPOS      LL_ADC_GetOffsetSign\n
+  *         OFR2     OFFSETPOS      LL_ADC_GetOffsetSign\n
+  *         OFR3     OFFSETPOS      LL_ADC_GetOffsetSign\n
+  *         OFR4     OFFSETPOS      LL_ADC_GetOffsetSign
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_SIGN_NEGATIVE
+  *         @arg @ref LL_ADC_OFFSET_SIGN_POSITIVE
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetSign(const ADC_TypeDef *ADCx, uint32_t Offsety)
+{
+  if (ADCx == ADC3)
+  {
+    const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+
+    return (uint32_t) READ_BIT(*preg, ADC3_OFR1_OFFSETPOS);
+  }
+  else
+  {
+    return 0UL;
+  }
+}
+
+/**
+  * @brief  Set for the ADC selected offset number 1, 2, 3 or 4:
+  *         force offset state disable or enable
+  *         without modifying offset channel or offset value.
+  * @note   This function should be needed only in case of offset to be
+  *         enabled-disabled dynamically, and should not be needed in other cases:
+  *         function LL_ADC_SetOffset() automatically enables the offset.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll OFR1     OFFSET1_EN     LL_ADC_SetOffsetState\n
+  *         OFR2     OFFSET2_EN     LL_ADC_SetOffsetState\n
+  *         OFR3     OFFSET3_EN     LL_ADC_SetOffsetState\n
+  *         OFR4     OFFSET4_EN     LL_ADC_SetOffsetState
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @param  OffsetState This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_DISABLE
+  *         @arg @ref LL_ADC_OFFSET_ENABLE
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetOffsetState(ADC_TypeDef *ADCx, uint32_t Offsety, uint32_t OffsetState)
+{
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+  if (ADCx == ADC3)
+  {
+    MODIFY_REG(*preg,
+               ADC3_OFR1_OFFSET1_EN,
+               OffsetState);
+  }
+  else
+  {
+    MODIFY_REG(*preg,
+               ADC_OFR1_SSATE,
+               OffsetState);
+  }
+}
+
+/**
+  * @brief  Get for the ADC selected offset number 1, 2, 3 or 4:
+  *         offset state disabled or enabled.
+  * @rmtoll OFR1     OFFSET1_EN     LL_ADC_GetOffsetState\n
+  *         OFR2     OFFSET2_EN     LL_ADC_GetOffsetState\n
+  *         OFR3     OFFSET3_EN     LL_ADC_GetOffsetState\n
+  *         OFR4     OFFSET4_EN     LL_ADC_GetOffsetState
+  * @param  ADCx ADC instance
+  * @param  Offsety This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_1
+  *         @arg @ref LL_ADC_OFFSET_2
+  *         @arg @ref LL_ADC_OFFSET_3
+  *         @arg @ref LL_ADC_OFFSET_4
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_OFFSET_DISABLE
+  *         @arg @ref LL_ADC_OFFSET_ENABLE
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetOffsetState(const ADC_TypeDef *ADCx, uint32_t Offsety)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->OFR1, Offsety);
+  if (ADCx == ADC3)
+  {
+    return (uint32_t) READ_BIT(*preg, ADC3_OFR1_OFFSET1_EN);
+  }
+  else
+  {
+    return (uint32_t) READ_BIT(*preg, ADC_OFR1_SSATE);
+  }
+}
+
+#endif  /* ADC_VER_V5_V90 */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Configuration_ADC_Group_Regular Configuration of ADC hierarchical scope: group regular
+  * @{
+  */
+
+/**
+  * @brief  Set ADC group regular conversion trigger source:
+  *         internal (SW start) or from external peripheral (timer event,
+  *         external interrupt line).
+  * @note   On this STM32 series, setting trigger source to external trigger
+  *         also set trigger polarity to rising edge
+  *         (default setting for compatibility with some ADC on other
+  *         STM32 families having this setting set by HW default value).
+  *         In case of need to modify trigger edge, use
+  *         function @ref LL_ADC_REG_SetTriggerEdge().
+  * @note   Availability of parameters of trigger sources from timer
+  *         depends on timers availability on the selected device.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @rmtoll CFGR     EXTSEL         LL_ADC_REG_SetTriggerSource\n
+  *         CFGR     EXTEN          LL_ADC_REG_SetTriggerSource
+  * @param  ADCx ADC instance
+  * @param  TriggerSource This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_TRIG_SOFTWARE
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_CH1
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_CH2
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_CH3
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM2_CH2
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM3_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM4_CH4
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_EXTI_LINE11
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM8_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM8_TRGO2
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_TRGO2
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM2_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM4_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM6_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM15_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM3_CH4
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_HRTIM_TRG1
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_HRTIM_TRG3
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_LPTIM1_OUT
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_LPTIM2_OUT
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_LPTIM3_OUT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetTriggerSource(ADC_TypeDef *ADCx, uint32_t TriggerSource)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_EXTEN | ADC_CFGR_EXTSEL, TriggerSource);
+}
+
+/**
+  * @brief  Get ADC group regular conversion trigger source:
+  *         internal (SW start) or from external peripheral (timer event,
+  *         external interrupt line).
+  * @note   To determine whether group regular trigger source is
+  *         internal (SW start) or external, without detail
+  *         of which peripheral is selected as external trigger,
+  *         (equivalent to
+  *         "if(LL_ADC_REG_GetTriggerSource(ADC1) == LL_ADC_REG_TRIG_SOFTWARE)")
+  *         use function @ref LL_ADC_REG_IsTriggerSourceSWStart.
+  * @note   Availability of parameters of trigger sources from timer
+  *         depends on timers availability on the selected device.
+  * @rmtoll CFGR     EXTSEL         LL_ADC_REG_GetTriggerSource\n
+  *         CFGR     EXTEN          LL_ADC_REG_GetTriggerSource
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_REG_TRIG_SOFTWARE
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_CH1
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_CH2
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_CH3
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM2_CH2
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM3_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM4_CH4
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_EXTI_LINE11
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM8_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM8_TRGO2
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM1_TRGO2
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM2_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM4_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM6_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM15_TRGO
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_TIM3_CH4
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_HRTIM_TRG1
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_HRTIM_TRG3
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_LPTIM1_OUT
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_LPTIM2_OUT
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_LPTIM3_OUT
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerSource(const ADC_TypeDef *ADCx)
+{
+  __IO uint32_t TriggerSource = READ_BIT(ADCx->CFGR, ADC_CFGR_EXTSEL | ADC_CFGR_EXTEN);
+
+  /* Value for shift of {0; 4; 8; 12} depending on value of bitfield          */
+  /* corresponding to ADC_CFGR_EXTEN {0; 1; 2; 3}.                            */
+  uint32_t ShiftExten = ((TriggerSource & ADC_CFGR_EXTEN) >> (ADC_REG_TRIG_EXTEN_BITOFFSET_POS - 2UL));
+
+  /* Set bitfield corresponding to ADC_CFGR_EXTEN and ADC_CFGR_EXTSEL         */
+  /* to match with triggers literals definition.                              */
+  return ((TriggerSource
+           & (ADC_REG_TRIG_SOURCE_MASK >> ShiftExten) & ADC_CFGR_EXTSEL)
+          | ((ADC_REG_TRIG_EDGE_MASK >> ShiftExten) & ADC_CFGR_EXTEN)
+         );
+}
+
+/**
+  * @brief  Get ADC group regular conversion trigger source internal (SW start)
+  *         or external.
+  * @note   In case of group regular trigger source set to external trigger,
+  *         to determine which peripheral is selected as external trigger,
+  *         use function @ref LL_ADC_REG_GetTriggerSource().
+  * @rmtoll CFGR     EXTEN          LL_ADC_REG_IsTriggerSourceSWStart
+  * @param  ADCx ADC instance
+  * @retval Value "0" if trigger source external trigger
+  *         Value "1" if trigger source SW start.
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_IsTriggerSourceSWStart(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CFGR, ADC_CFGR_EXTEN) == (LL_ADC_REG_TRIG_SOFTWARE & ADC_CFGR_EXTEN)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Set ADC group regular conversion trigger polarity.
+  * @note   Applicable only for trigger source set to external trigger.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @rmtoll CFGR     EXTEN          LL_ADC_REG_SetTriggerEdge
+  * @param  ADCx ADC instance
+  * @param  ExternalTriggerEdge This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_RISING
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_FALLING
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_RISINGFALLING
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetTriggerEdge(ADC_TypeDef *ADCx, uint32_t ExternalTriggerEdge)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_EXTEN, ExternalTriggerEdge);
+}
+
+/**
+  * @brief  Get ADC group regular conversion trigger polarity.
+  * @note   Applicable only for trigger source set to external trigger.
+  * @rmtoll CFGR     EXTEN          LL_ADC_REG_GetTriggerEdge
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_RISING
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_FALLING
+  *         @arg @ref LL_ADC_REG_TRIG_EXT_RISINGFALLING
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetTriggerEdge(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_EXTEN));
+}
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief  Set ADC sampling mode.
+  * @note   This function set the ADC conversion sampling mode
+  * @note   This mode applies to regular group only.
+  * @note   Set sampling mode is applied to all conversion of regular group.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @rmtoll CFGR2    BULB           LL_ADC_REG_SetSamplingMode\n
+  *         CFGR2    SMPTRIG        LL_ADC_REG_SetSamplingMode
+  * @param  ADCx ADC instance
+  * @param  SamplingMode This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_SAMPLING_MODE_NORMAL
+  *         @arg @ref LL_ADC_REG_SAMPLING_MODE_BULB
+  *         @arg @ref LL_ADC_REG_SAMPLING_MODE_TRIGGER_CONTROLED
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetSamplingMode(ADC_TypeDef *ADCx, uint32_t SamplingMode)
+{
+  if (ADCx != ADC3)
+  {
+    /* Function not available on this instance */
+  }
+  else
+  {
+    MODIFY_REG(ADCx->CFGR2, ADC3_CFGR2_BULB | ADC3_CFGR2_SMPTRIG, SamplingMode);
+  }
+}
+#endif  /* ADC_VER_V5_V90 */
+
+/**
+  * @brief  Set ADC group regular sequencer length and scan direction.
+  * @note   Description of ADC group regular sequencer features:
+  *         - For devices with sequencer fully configurable
+  *           (function "LL_ADC_REG_SetSequencerRanks()" available):
+  *           sequencer length and each rank affectation to a channel
+  *           are configurable.
+  *           This function performs configuration of:
+  *           - Sequence length: Number of ranks in the scan sequence.
+  *           - Sequence direction: Unless specified in parameters, sequencer
+  *             scan direction is forward (from rank 1 to rank n).
+  *           Sequencer ranks are selected using
+  *           function "LL_ADC_REG_SetSequencerRanks()".
+  *         - For devices with sequencer not fully configurable
+  *           (function "LL_ADC_REG_SetSequencerChannels()" available):
+  *           sequencer length and each rank affectation to a channel
+  *           are defined by channel number.
+  *           This function performs configuration of:
+  *           - Sequence length: Number of ranks in the scan sequence is
+  *             defined by number of channels set in the sequence,
+  *             rank of each channel is fixed by channel HW number.
+  *             (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
+  *           - Sequence direction: Unless specified in parameters, sequencer
+  *             scan direction is forward (from lowest channel number to
+  *             highest channel number).
+  *           Sequencer ranks are selected using
+  *           function "LL_ADC_REG_SetSequencerChannels()".
+  * @note   Sequencer disabled is equivalent to sequencer of 1 rank:
+  *         ADC conversion on only 1 channel.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @rmtoll SQR1     L              LL_ADC_REG_SetSequencerLength
+  * @param  ADCx ADC instance
+  * @param  SequencerNbRanks This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_DISABLE
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_2RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_3RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_4RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_5RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_6RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_7RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_8RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_9RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_10RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_11RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_12RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_13RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_14RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_15RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_16RANKS
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t SequencerNbRanks)
+{
+  MODIFY_REG(ADCx->SQR1, ADC_SQR1_L, SequencerNbRanks);
+}
+
+/**
+  * @brief  Get ADC group regular sequencer length and scan direction.
+  * @note   Description of ADC group regular sequencer features:
+  *         - For devices with sequencer fully configurable
+  *           (function "LL_ADC_REG_SetSequencerRanks()" available):
+  *           sequencer length and each rank affectation to a channel
+  *           are configurable.
+  *           This function retrieves:
+  *           - Sequence length: Number of ranks in the scan sequence.
+  *           - Sequence direction: Unless specified in parameters, sequencer
+  *             scan direction is forward (from rank 1 to rank n).
+  *           Sequencer ranks are selected using
+  *           function "LL_ADC_REG_SetSequencerRanks()".
+  *         - For devices with sequencer not fully configurable
+  *           (function "LL_ADC_REG_SetSequencerChannels()" available):
+  *           sequencer length and each rank affectation to a channel
+  *           are defined by channel number.
+  *           This function retrieves:
+  *           - Sequence length: Number of ranks in the scan sequence is
+  *             defined by number of channels set in the sequence,
+  *             rank of each channel is fixed by channel HW number.
+  *             (channel 0 fixed on rank 0, channel 1 fixed on rank1, ...).
+  *           - Sequence direction: Unless specified in parameters, sequencer
+  *             scan direction is forward (from lowest channel number to
+  *             highest channel number).
+  *           Sequencer ranks are selected using
+  *           function "LL_ADC_REG_SetSequencerChannels()".
+  * @note   Sequencer disabled is equivalent to sequencer of 1 rank:
+  *         ADC conversion on only 1 channel.
+  * @rmtoll SQR1     L              LL_ADC_REG_GetSequencerLength
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_DISABLE
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_2RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_3RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_4RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_5RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_6RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_7RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_8RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_9RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_10RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_11RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_12RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_13RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_14RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_15RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_SCAN_ENABLE_16RANKS
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerLength(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->SQR1, ADC_SQR1_L));
+}
+
+/**
+  * @brief  Set ADC group regular sequencer discontinuous mode:
+  *         sequence subdivided and scan conversions interrupted every selected
+  *         number of ranks.
+  * @note   It is not possible to enable both ADC group regular
+  *         continuous mode and sequencer discontinuous mode.
+  * @note   It is not possible to enable both ADC auto-injected mode
+  *         and ADC group regular sequencer discontinuous mode.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @rmtoll CFGR     DISCEN         LL_ADC_REG_SetSequencerDiscont\n
+  *         CFGR     DISCNUM        LL_ADC_REG_SetSequencerDiscont
+  * @param  ADCx ADC instance
+  * @param  SeqDiscont This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_DISABLE
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_1RANK
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_2RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_3RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_4RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_5RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_6RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_7RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_8RANKS
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetSequencerDiscont(ADC_TypeDef *ADCx, uint32_t SeqDiscont)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_DISCEN | ADC_CFGR_DISCNUM, SeqDiscont);
+}
+
+/**
+  * @brief  Get ADC group regular sequencer discontinuous mode:
+  *         sequence subdivided and scan conversions interrupted every selected
+  *         number of ranks.
+  * @rmtoll CFGR     DISCEN         LL_ADC_REG_GetSequencerDiscont\n
+  *         CFGR     DISCNUM        LL_ADC_REG_GetSequencerDiscont
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_DISABLE
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_1RANK
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_2RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_3RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_4RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_5RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_6RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_7RANKS
+  *         @arg @ref LL_ADC_REG_SEQ_DISCONT_8RANKS
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerDiscont(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_DISCEN | ADC_CFGR_DISCNUM));
+}
+
+/**
+  * @brief  Set ADC group regular sequence: channel on the selected
+  *         scan sequence rank.
+  * @note   This function performs configuration of:
+  *         - Channels ordering into each rank of scan sequence:
+  *           whatever channel can be placed into whatever rank.
+  * @note   On this STM32 series, ADC group regular sequencer is
+  *         fully configurable: sequencer length and each rank
+  *         affectation to a channel are configurable.
+  *         Refer to description of function @ref LL_ADC_REG_SetSequencerLength().
+  * @note   Depending on devices and packages, some channels may not be available.
+  *         Refer to device datasheet for channels availability.
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
+  *         TempSensor, ...), measurement paths to internal channels must be
+  *         enabled separately.
+  *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @rmtoll SQR1     SQ1            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR1     SQ2            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR1     SQ3            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR1     SQ4            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR2     SQ5            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR2     SQ6            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR2     SQ7            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR2     SQ8            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR2     SQ9            LL_ADC_REG_SetSequencerRanks\n
+  *         SQR3     SQ10           LL_ADC_REG_SetSequencerRanks\n
+  *         SQR3     SQ11           LL_ADC_REG_SetSequencerRanks\n
+  *         SQR3     SQ12           LL_ADC_REG_SetSequencerRanks\n
+  *         SQR3     SQ13           LL_ADC_REG_SetSequencerRanks\n
+  *         SQR3     SQ14           LL_ADC_REG_SetSequencerRanks\n
+  *         SQR4     SQ15           LL_ADC_REG_SetSequencerRanks\n
+  *         SQR4     SQ16           LL_ADC_REG_SetSequencerRanks
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_RANK_1
+  *         @arg @ref LL_ADC_REG_RANK_2
+  *         @arg @ref LL_ADC_REG_RANK_3
+  *         @arg @ref LL_ADC_REG_RANK_4
+  *         @arg @ref LL_ADC_REG_RANK_5
+  *         @arg @ref LL_ADC_REG_RANK_6
+  *         @arg @ref LL_ADC_REG_RANK_7
+  *         @arg @ref LL_ADC_REG_RANK_8
+  *         @arg @ref LL_ADC_REG_RANK_9
+  *         @arg @ref LL_ADC_REG_RANK_10
+  *         @arg @ref LL_ADC_REG_RANK_11
+  *         @arg @ref LL_ADC_REG_RANK_12
+  *         @arg @ref LL_ADC_REG_RANK_13
+  *         @arg @ref LL_ADC_REG_RANK_14
+  *         @arg @ref LL_ADC_REG_RANK_15
+  *         @arg @ref LL_ADC_REG_RANK_16
+  * @param  Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Rank, uint32_t Channel)
+{
+  /* Set bits with content of parameter "Channel" with bits position          */
+  /* in register and register position depending on parameter "Rank".         */
+  /* Parameters "Rank" and "Channel" are used with masks because containing   */
+  /* other bits reserved for other purpose.                                   */
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->SQR1, ((Rank & ADC_REG_SQRX_REGOFFSET_MASK) >> ADC_SQRX_REGOFFSET_POS));
+
+  MODIFY_REG(*preg,
+             ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0 << (Rank & ADC_REG_RANK_ID_SQRX_MASK),
+             ((Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (Rank & ADC_REG_RANK_ID_SQRX_MASK));
+}
+
+/**
+  * @brief  Get ADC group regular sequence: channel on the selected
+  *         scan sequence rank.
+  * @note   On this STM32 series, ADC group regular sequencer is
+  *         fully configurable: sequencer length and each rank
+  *         affectation to a channel are configurable.
+  *         Refer to description of function @ref LL_ADC_REG_SetSequencerLength().
+  * @note   Depending on devices and packages, some channels may not be available.
+  *         Refer to device datasheet for channels availability.
+  * @note   Usage of the returned channel number:
+  *         - To reinject this channel into another function LL_ADC_xxx:
+  *           the returned channel number is only partly formatted on definition
+  *           of literals LL_ADC_CHANNEL_x. Therefore, it has to be compared
+  *           with parts of literals LL_ADC_CHANNEL_x or using
+  *           helper macro @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
+  *           Then the selected literal LL_ADC_CHANNEL_x can be used
+  *           as parameter for another function.
+  *         - To get the channel number in decimal format:
+  *           process the returned value with the helper macro
+  *           @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
+  * @rmtoll SQR1     SQ1            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR1     SQ2            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR1     SQ3            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR1     SQ4            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR2     SQ5            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR2     SQ6            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR2     SQ7            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR2     SQ8            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR2     SQ9            LL_ADC_REG_GetSequencerRanks\n
+  *         SQR3     SQ10           LL_ADC_REG_GetSequencerRanks\n
+  *         SQR3     SQ11           LL_ADC_REG_GetSequencerRanks\n
+  *         SQR3     SQ12           LL_ADC_REG_GetSequencerRanks\n
+  *         SQR3     SQ13           LL_ADC_REG_GetSequencerRanks\n
+  *         SQR3     SQ14           LL_ADC_REG_GetSequencerRanks\n
+  *         SQR4     SQ15           LL_ADC_REG_GetSequencerRanks\n
+  *         SQR4     SQ16           LL_ADC_REG_GetSequencerRanks
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_RANK_1
+  *         @arg @ref LL_ADC_REG_RANK_2
+  *         @arg @ref LL_ADC_REG_RANK_3
+  *         @arg @ref LL_ADC_REG_RANK_4
+  *         @arg @ref LL_ADC_REG_RANK_5
+  *         @arg @ref LL_ADC_REG_RANK_6
+  *         @arg @ref LL_ADC_REG_RANK_7
+  *         @arg @ref LL_ADC_REG_RANK_8
+  *         @arg @ref LL_ADC_REG_RANK_9
+  *         @arg @ref LL_ADC_REG_RANK_10
+  *         @arg @ref LL_ADC_REG_RANK_11
+  *         @arg @ref LL_ADC_REG_RANK_12
+  *         @arg @ref LL_ADC_REG_RANK_13
+  *         @arg @ref LL_ADC_REG_RANK_14
+  *         @arg @ref LL_ADC_REG_RANK_15
+  *         @arg @ref LL_ADC_REG_RANK_16
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).\n
+  *         (1, 2) For ADC channel read back from ADC register,
+  *                comparison with internal channel parameter to be done
+  *                using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetSequencerRanks(const ADC_TypeDef *ADCx, uint32_t Rank)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->SQR1, ((Rank & ADC_REG_SQRX_REGOFFSET_MASK) >> ADC_SQRX_REGOFFSET_POS));
+
+  return (uint32_t)((READ_BIT(*preg,
+                              ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0 << (Rank & ADC_REG_RANK_ID_SQRX_MASK))
+                     >> (Rank & ADC_REG_RANK_ID_SQRX_MASK)) << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS
+                   );
+}
+
+/**
+  * @brief  Set ADC continuous conversion mode on ADC group regular.
+  * @note   Description of ADC continuous conversion mode:
+  *         - single mode: one conversion per trigger
+  *         - continuous mode: after the first trigger, following
+  *           conversions launched successively automatically.
+  * @note   It is not possible to enable both ADC group regular
+  *         continuous mode and sequencer discontinuous mode.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @rmtoll CFGR     CONT           LL_ADC_REG_SetContinuousMode
+  * @param  ADCx ADC instance
+  * @param  Continuous This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_CONV_SINGLE
+  *         @arg @ref LL_ADC_REG_CONV_CONTINUOUS
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetContinuousMode(ADC_TypeDef *ADCx, uint32_t Continuous)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_CONT, Continuous);
+}
+
+/**
+  * @brief  Get ADC continuous conversion mode on ADC group regular.
+  * @note   Description of ADC continuous conversion mode:
+  *         - single mode: one conversion per trigger
+  *         - continuous mode: after the first trigger, following
+  *           conversions launched successively automatically.
+  * @rmtoll CFGR     CONT           LL_ADC_REG_GetContinuousMode
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_REG_CONV_SINGLE
+  *         @arg @ref LL_ADC_REG_CONV_CONTINUOUS
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetContinuousMode(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_CONT));
+}
+/**
+  * @brief  Set ADC data transfer mode
+  * @note   Conversion data can be either:
+  *            - Available in Data Register
+  *            - Transferred by DMA in one shot mode
+  *            - Transferred by DMA in circular mode
+  *            - Transferred to DFSDM data register
+  * @rmtoll CFGR     DMNGT           LL_ADC_REG_SetDataTransferMode
+  * @param  ADCx ADC instance
+  * @param  DataTransferMode Select Data Management configuration
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetDataTransferMode(ADC_TypeDef *ADCx, uint32_t DataTransferMode)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_DMNGT, DataTransferMode);
+}
+
+#if defined(ADC_VER_V5_V90)
+/**
+  * @brief  Enable DMA requests for ADC3.
+  * @rmtoll CFGR     DMAEN          LL_ADC_REG_SetDMATransfer\n
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableDMAReq (ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->CFGR, ADC3_CFGR_DMAEN);
+}
+
+__STATIC_INLINE void LL_ADC_DisableDMAReq(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT (ADCx->CFGR, ADC3_CFGR_DMAEN);
+}
+
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledDMAReq (const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CFGR, ADC3_CFGR_DMAEN) == (ADC3_CFGR_DMAEN)) ? 1UL : 0UL);
+}
+/**
+  * @brief  Set ADC group regular conversion data transfer: no transfer or
+  *         transfer by DMA, and DMA requests mode.
+  * @note   If transfer by DMA selected, specifies the DMA requests
+  *         mode:
+  *         - Limited mode (One shot mode): DMA transfer requests are stopped
+  *           when number of DMA data transfers (number of
+  *           ADC conversions) is reached.
+  *           This ADC mode is intended to be used with DMA mode non-circular.
+  *         - Unlimited mode: DMA transfer requests are unlimited,
+  *           whatever number of DMA data transfers (number of
+  *           ADC conversions).
+  *           This ADC mode is intended to be used with DMA mode circular.
+  * @note   If ADC DMA requests mode is set to unlimited and DMA is set to
+  *         mode non-circular:
+  *         when DMA transfers size will be reached, DMA will stop transfers of
+  *         ADC conversions data ADC will raise an overrun error
+  *        (overrun flag and interruption if enabled).
+  * @note   For devices with several ADC instances: ADC multimode DMA
+  *         settings are available using function @ref LL_ADC_SetMultiDMATransfer().
+  * @note   To configure DMA source address (peripheral address),
+  *         use function @ref LL_ADC_DMA_GetRegAddr().
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR     DMAEN          LL_ADC_REG_SetDMATransferMode\n
+  *         CFGR     DMACFG         LL_ADC_REG_SetDMATransferMode
+  * @param  ADCx ADC instance
+  * @param  DMATransfer This parameter can be one of the following values:
+  *         @arg @ref LL_ADC3_REG_DMA_TRANSFER_NONE
+  *         @arg @ref LL_ADC3_REG_DMA_TRANSFER_LIMITED
+  *         @arg @ref LL_ADC3_REG_DMA_TRANSFER_UNLIMITED
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetDMATransferMode(ADC_TypeDef *ADCx, uint32_t DMATransfer)
+{
+  if (ADCx == ADC3)
+  {
+    MODIFY_REG(ADCx->CFGR, ADC3_CFGR_DMAEN | ADC3_CFGR_DMACFG, DMATransfer);
+  }
+}
+
+/**
+  * @brief  Get ADC group regular conversion data transfer: no transfer or
+  *         transfer by DMA, and DMA requests mode.
+  * @note   If transfer by DMA selected, specifies the DMA requests
+  *         mode:
+  *         - Limited mode (One shot mode): DMA transfer requests are stopped
+  *           when number of DMA data transfers (number of
+  *           ADC conversions) is reached.
+  *           This ADC mode is intended to be used with DMA mode non-circular.
+  *         - Unlimited mode: DMA transfer requests are unlimited,
+  *           whatever number of DMA data transfers (number of
+  *           ADC conversions).
+  *           This ADC mode is intended to be used with DMA mode circular.
+  * @note   If ADC DMA requests mode is set to unlimited and DMA is set to
+  *         mode non-circular:
+  *         when DMA transfers size will be reached, DMA will stop transfers of
+  *         ADC conversions data ADC will raise an overrun error
+  *         (overrun flag and interruption if enabled).
+  * @note   For devices with several ADC instances: ADC multimode DMA
+  *         settings are available using function @ref LL_ADC_GetMultiDMATransfer().
+  * @note   To configure DMA source address (peripheral address),
+  *         use function @ref LL_ADC_DMA_GetRegAddr().
+  * @rmtoll CFGR     DMAEN          LL_ADC_REG_GetDMATransfer\n
+  *         CFGR     DMACFG         LL_ADC_REG_GetDMATransfer
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC3_REG_DMA_TRANSFER_NONE
+  *         @arg @ref LL_ADC3_REG_DMA_TRANSFER_LIMITED
+  *         @arg @ref LL_ADC3_REG_DMA_TRANSFER_UNLIMITED
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetDMATransferMode(const ADC_TypeDef *ADCx)
+{
+  if (ADCx == ADC3)
+  {
+    return (uint32_t)(READ_BIT(ADCx->CFGR, ADC3_CFGR_DMAEN | ADC3_CFGR_DMACFG));
+  }
+   else
+  {
+    return 0UL;
+  }
+}
+
+#endif  /* ADC_VER_V5_V90 */
+
+/**
+  * @brief  Get ADC data transfer mode
+  * @note   Conversion data can be either:
+  *            - Available in Data Register
+  *            - Transferred by DMA in one shot mode
+  *            - Transferred by DMA in circular mode
+  *            - Transferred to DFSDM data register
+  * @rmtoll CFGR     DMNGT           LL_ADC_REG_GetDataTransferMode
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_REG_DR_TRANSFER
+  *         @arg @ref LL_ADC_REG_DMA_TRANSFER_LIMITED
+  *         @arg @ref LL_ADC_REG_DMA_TRANSFER_UNLIMITED
+  *         @arg @ref LL_ADC_REG_DFSDM_TRANSFER
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetDataTransferMode(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_DMNGT));
+}
+
+
+/**
+  * @brief  Set ADC group regular behavior in case of overrun:
+  *         data preserved or overwritten.
+  * @note   Compatibility with devices without feature overrun:
+  *         other devices without this feature have a behavior
+  *         equivalent to data overwritten.
+  *         The default setting of overrun is data preserved.
+  *         Therefore, for compatibility with all devices, parameter
+  *         overrun should be set to data overwritten.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @rmtoll CFGR     OVRMOD         LL_ADC_REG_SetOverrun
+  * @param  ADCx ADC instance
+  * @param  Overrun This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_REG_OVR_DATA_PRESERVED
+  *         @arg @ref LL_ADC_REG_OVR_DATA_OVERWRITTEN
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_SetOverrun(ADC_TypeDef *ADCx, uint32_t Overrun)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_OVRMOD, Overrun);
+}
+
+/**
+  * @brief  Get ADC group regular behavior in case of overrun:
+  *         data preserved or overwritten.
+  * @rmtoll CFGR     OVRMOD         LL_ADC_REG_GetOverrun
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_REG_OVR_DATA_PRESERVED
+  *         @arg @ref LL_ADC_REG_OVR_DATA_OVERWRITTEN
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_GetOverrun(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_OVRMOD));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Configuration_ADC_Group_Injected Configuration of ADC hierarchical scope: group injected
+  * @{
+  */
+
+/**
+  * @brief  Set ADC group injected conversion trigger source:
+  *         internal (SW start) or from external peripheral (timer event,
+  *         external interrupt line).
+  * @note   On this STM32 series, setting trigger source to external trigger
+  *         also set trigger polarity to rising edge
+  *         (default setting for compatibility with some ADC on other
+  *         STM32 families having this setting set by HW default value).
+  *         In case of need to modify trigger edge, use
+  *         function @ref LL_ADC_INJ_SetTriggerEdge().
+  * @note   Availability of parameters of trigger sources from timer
+  *         depends on timers availability on the selected device.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must not be disabled. Can be enabled with or without conversion
+  *         on going on either groups regular or injected.
+  * @rmtoll JSQR     JEXTSEL        LL_ADC_INJ_SetTriggerSource\n
+  *         JSQR     JEXTEN         LL_ADC_INJ_SetTriggerSource
+  * @param  ADCx ADC instance
+  * @param  TriggerSource This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_TRIG_SOFTWARE
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM2_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM2_CH1
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM4_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_EXTI_LINE15
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_TRGO2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_TRGO2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH3
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH1
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM6_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM15_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_HRTIM_TRG2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_HRTIM_TRG4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM1_OUT
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM2_OUT
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM3_OUT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_SetTriggerSource(ADC_TypeDef *ADCx, uint32_t TriggerSource)
+{
+  MODIFY_REG(ADCx->JSQR, ADC_JSQR_JEXTSEL | ADC_JSQR_JEXTEN, TriggerSource);
+}
+
+/**
+  * @brief  Get ADC group injected conversion trigger source:
+  *         internal (SW start) or from external peripheral (timer event,
+  *         external interrupt line).
+  * @note   To determine whether group injected trigger source is
+  *         internal (SW start) or external, without detail
+  *         of which peripheral is selected as external trigger,
+  *         (equivalent to
+  *         "if(LL_ADC_INJ_GetTriggerSource(ADC1) == LL_ADC_INJ_TRIG_SOFTWARE)")
+  *         use function @ref LL_ADC_INJ_IsTriggerSourceSWStart.
+  * @note   Availability of parameters of trigger sources from timer
+  *         depends on timers availability on the selected device.
+  * @rmtoll JSQR     JEXTSEL        LL_ADC_INJ_GetTriggerSource\n
+  *         JSQR     JEXTEN         LL_ADC_INJ_GetTriggerSource
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_TRIG_SOFTWARE
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM2_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM2_CH1
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM4_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_EXTI_LINE15
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_TRGO2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_TRGO2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH3
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH1
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM6_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM15_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_HRTIM_TRG2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_HRTIM_TRG4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM1_OUT
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM2_OUT
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM3_OUT
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetTriggerSource(const ADC_TypeDef *ADCx)
+{
+  __IO uint32_t TriggerSource = READ_BIT(ADCx->JSQR, ADC_JSQR_JEXTSEL | ADC_JSQR_JEXTEN);
+
+  /* Value for shift of {0; 4; 8; 12} depending on value of bitfield          */
+  /* corresponding to ADC_JSQR_JEXTEN {0; 1; 2; 3}.                           */
+  uint32_t ShiftJexten = ((TriggerSource & ADC_JSQR_JEXTEN) >> (ADC_INJ_TRIG_EXTEN_BITOFFSET_POS - 2UL));
+
+  /* Set bitfield corresponding to ADC_JSQR_JEXTEN and ADC_JSQR_JEXTSEL       */
+  /* to match with triggers literals definition.                              */
+  return ((TriggerSource
+           & (ADC_INJ_TRIG_SOURCE_MASK >> ShiftJexten) & ADC_JSQR_JEXTSEL)
+          | ((ADC_INJ_TRIG_EDGE_MASK >> ShiftJexten) & ADC_JSQR_JEXTEN)
+         );
+}
+
+/**
+  * @brief  Get ADC group injected conversion trigger source internal (SW start)
+            or external
+  * @note   In case of group injected trigger source set to external trigger,
+  *         to determine which peripheral is selected as external trigger,
+  *         use function @ref LL_ADC_INJ_GetTriggerSource.
+  * @rmtoll JSQR     JEXTEN         LL_ADC_INJ_IsTriggerSourceSWStart
+  * @param  ADCx ADC instance
+  * @retval Value "0" if trigger source external trigger
+  *         Value "1" if trigger source SW start.
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_IsTriggerSourceSWStart(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->JSQR, ADC_JSQR_JEXTEN) == (LL_ADC_INJ_TRIG_SOFTWARE & ADC_JSQR_JEXTEN)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Set ADC group injected conversion trigger polarity.
+  *         Applicable only for trigger source set to external trigger.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must not be disabled. Can be enabled with or without conversion
+  *         on going on either groups regular or injected.
+  * @rmtoll JSQR     JEXTEN         LL_ADC_INJ_SetTriggerEdge
+  * @param  ADCx ADC instance
+  * @param  ExternalTriggerEdge This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_RISING
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_FALLING
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_RISINGFALLING
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_SetTriggerEdge(ADC_TypeDef *ADCx, uint32_t ExternalTriggerEdge)
+{
+  MODIFY_REG(ADCx->JSQR, ADC_JSQR_JEXTEN, ExternalTriggerEdge);
+}
+
+/**
+  * @brief  Get ADC group injected conversion trigger polarity.
+  *         Applicable only for trigger source set to external trigger.
+  * @rmtoll JSQR     JEXTEN         LL_ADC_INJ_GetTriggerEdge
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_RISING
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_FALLING
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_RISINGFALLING
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetTriggerEdge(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->JSQR, ADC_JSQR_JEXTEN));
+}
+
+/**
+  * @brief  Set ADC group injected sequencer length and scan direction.
+  * @note   This function performs configuration of:
+  *         - Sequence length: Number of ranks in the scan sequence.
+  *         - Sequence direction: Unless specified in parameters, sequencer
+  *           scan direction is forward (from rank 1 to rank n).
+  * @note   Sequencer disabled is equivalent to sequencer of 1 rank:
+  *         ADC conversion on only 1 channel.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must not be disabled. Can be enabled with or without conversion
+  *         on going on either groups regular or injected.
+  * @rmtoll JSQR     JL             LL_ADC_INJ_SetSequencerLength
+  * @param  ADCx ADC instance
+  * @param  SequencerNbRanks This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_DISABLE
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_2RANKS
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_3RANKS
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_4RANKS
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_SetSequencerLength(ADC_TypeDef *ADCx, uint32_t SequencerNbRanks)
+{
+  MODIFY_REG(ADCx->JSQR, ADC_JSQR_JL, SequencerNbRanks);
+}
+
+/**
+  * @brief  Get ADC group injected sequencer length and scan direction.
+  * @note   This function retrieves:
+  *         - Sequence length: Number of ranks in the scan sequence.
+  *         - Sequence direction: Unless specified in parameters, sequencer
+  *           scan direction is forward (from rank 1 to rank n).
+  * @note   Sequencer disabled is equivalent to sequencer of 1 rank:
+  *         ADC conversion on only 1 channel.
+  * @rmtoll JSQR     JL             LL_ADC_INJ_GetSequencerLength
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_DISABLE
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_2RANKS
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_3RANKS
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_4RANKS
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerLength(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->JSQR, ADC_JSQR_JL));
+}
+
+/**
+  * @brief  Set ADC group injected sequencer discontinuous mode:
+  *         sequence subdivided and scan conversions interrupted every selected
+  *         number of ranks.
+  * @note   It is not possible to enable both ADC group injected
+  *         auto-injected mode and sequencer discontinuous mode.
+  * @rmtoll CFGR     JDISCEN        LL_ADC_INJ_SetSequencerDiscont
+  * @param  ADCx ADC instance
+  * @param  SeqDiscont This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_SEQ_DISCONT_DISABLE
+  *         @arg @ref LL_ADC_INJ_SEQ_DISCONT_1RANK
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_SetSequencerDiscont(ADC_TypeDef *ADCx, uint32_t SeqDiscont)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_JDISCEN, SeqDiscont);
+}
+
+/**
+  * @brief  Get ADC group injected sequencer discontinuous mode:
+  *         sequence subdivided and scan conversions interrupted every selected
+  *         number of ranks.
+  * @rmtoll CFGR     JDISCEN        LL_ADC_INJ_GetSequencerDiscont
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_SEQ_DISCONT_DISABLE
+  *         @arg @ref LL_ADC_INJ_SEQ_DISCONT_1RANK
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerDiscont(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_JDISCEN));
+}
+
+/**
+  * @brief  Set ADC group injected sequence: channel on the selected
+  *         sequence rank.
+  * @note   Depending on devices and packages, some channels may not be available.
+  *         Refer to device datasheet for channels availability.
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
+  *         TempSensor, ...), measurement paths to internal channels must be
+  *         enabled separately.
+  *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
+  * @note   On STM32H7, some fast channels are available: fast analog inputs
+  *         coming from GPIO pads (ADC_IN0..5).
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must not be disabled. Can be enabled with or without conversion
+  *         on going on either groups regular or injected.
+  * @rmtoll JSQR     JSQ1           LL_ADC_INJ_SetSequencerRanks\n
+  *         JSQR     JSQ2           LL_ADC_INJ_SetSequencerRanks\n
+  *         JSQR     JSQ3           LL_ADC_INJ_SetSequencerRanks\n
+  *         JSQR     JSQ4           LL_ADC_INJ_SetSequencerRanks
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_RANK_1
+  *         @arg @ref LL_ADC_INJ_RANK_2
+  *         @arg @ref LL_ADC_INJ_RANK_3
+  *         @arg @ref LL_ADC_INJ_RANK_4
+  * @param  Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_SetSequencerRanks(ADC_TypeDef *ADCx, uint32_t Rank, uint32_t Channel)
+{
+  /* Set bits with content of parameter "Channel" with bits position          */
+  /* in register depending on parameter "Rank".                               */
+  /* Parameters "Rank" and "Channel" are used with masks because containing   */
+  /* other bits reserved for other purpose.                                   */
+  MODIFY_REG(ADCx->JSQR,
+             (ADC_CHANNEL_ID_NUMBER_MASK >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (Rank & ADC_INJ_RANK_ID_JSQR_MASK),
+             ((Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (Rank & ADC_INJ_RANK_ID_JSQR_MASK));
+}
+
+/**
+  * @brief  Get ADC group injected sequence: channel on the selected
+  *         sequence rank.
+  * @note   Depending on devices and packages, some channels may not be available.
+  *         Refer to device datasheet for channels availability.
+  * @note   Usage of the returned channel number:
+  *         - To reinject this channel into another function LL_ADC_xxx:
+  *           the returned channel number is only partly formatted on definition
+  *           of literals LL_ADC_CHANNEL_x. Therefore, it has to be compared
+  *           with parts of literals LL_ADC_CHANNEL_x or using
+  *           helper macro @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
+  *           Then the selected literal LL_ADC_CHANNEL_x can be used
+  *           as parameter for another function.
+  *         - To get the channel number in decimal format:
+  *           process the returned value with the helper macro
+  *           @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
+  * @rmtoll JSQR     JSQ1           LL_ADC_INJ_GetSequencerRanks\n
+  *         JSQR     JSQ2           LL_ADC_INJ_GetSequencerRanks\n
+  *         JSQR     JSQ3           LL_ADC_INJ_GetSequencerRanks\n
+  *         JSQR     JSQ4           LL_ADC_INJ_GetSequencerRanks
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_RANK_1
+  *         @arg @ref LL_ADC_INJ_RANK_2
+  *         @arg @ref LL_ADC_INJ_RANK_3
+  *         @arg @ref LL_ADC_INJ_RANK_4
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).\n
+  *         (1, 2) For ADC channel read back from ADC register,
+  *                comparison with internal channel parameter to be done
+  *                using helper macro @ref __LL_ADC_CHANNEL_INTERNAL_TO_EXTERNAL().
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetSequencerRanks(const ADC_TypeDef *ADCx, uint32_t Rank)
+{
+  return (uint32_t)((READ_BIT(ADCx->JSQR,
+                             (ADC_CHANNEL_ID_NUMBER_MASK >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (Rank & ADC_INJ_RANK_ID_JSQR_MASK))
+                    >> (Rank & ADC_INJ_RANK_ID_JSQR_MASK)) << ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS
+                   );
+}
+
+/**
+  * @brief  Set ADC group injected conversion trigger:
+  *         independent or from ADC group regular.
+  * @note   This mode can be used to extend number of data registers
+  *         updated after one ADC conversion trigger and with data
+  *         permanently kept (not erased by successive conversions of scan of
+  *         ADC sequencer ranks), up to 5 data registers:
+  *         1 data register on ADC group regular, 4 data registers
+  *         on ADC group injected.
+  * @note   If ADC group injected injected trigger source is set to an
+  *         external trigger, this feature must be must be set to
+  *         independent trigger.
+  *         ADC group injected automatic trigger is compliant only with
+  *         group injected trigger source set to SW start, without any
+  *         further action on  ADC group injected conversion start or stop:
+  *         in this case, ADC group injected is controlled only
+  *         from ADC group regular.
+  * @note   It is not possible to enable both ADC group injected
+  *         auto-injected mode and sequencer discontinuous mode.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR     JAUTO          LL_ADC_INJ_SetTrigAuto
+  * @param  ADCx ADC instance
+  * @param  TrigAuto This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_TRIG_INDEPENDENT
+  *         @arg @ref LL_ADC_INJ_TRIG_FROM_GRP_REGULAR
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_SetTrigAuto(ADC_TypeDef *ADCx, uint32_t TrigAuto)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_JAUTO, TrigAuto);
+}
+
+/**
+  * @brief  Get ADC group injected conversion trigger:
+  *         independent or from ADC group regular.
+  * @rmtoll CFGR     JAUTO          LL_ADC_INJ_GetTrigAuto
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_TRIG_INDEPENDENT
+  *         @arg @ref LL_ADC_INJ_TRIG_FROM_GRP_REGULAR
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetTrigAuto(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_JAUTO));
+}
+
+/**
+  * @brief  Set ADC group injected contexts queue mode.
+  * @note   A context is a setting of group injected sequencer:
+  *         - group injected trigger
+  *         - sequencer length
+  *         - sequencer ranks
+  *         If contexts queue is disabled:
+  *         - only 1 sequence can be configured
+  *           and is active perpetually.
+  *         If contexts queue is enabled:
+  *         - up to 2 contexts can be queued
+  *           and are checked in and out as a FIFO stack (first-in, first-out).
+  *         - If a new context is set when queues is full, error is triggered
+  *           by interruption "Injected Queue Overflow".
+  *         - Two behaviors are possible when all contexts have been processed:
+  *           the contexts queue can maintain the last context active perpetually
+  *           or can be empty and injected group triggers are disabled.
+  *         - Triggers can be only external (not internal SW start)
+  *         - Caution: The sequence must be fully configured in one time
+  *           (one write of register JSQR makes a check-in of a new context
+  *           into the queue).
+  *           Therefore functions to set separately injected trigger and
+  *           sequencer channels cannot be used, register JSQR must be set
+  *           using function @ref LL_ADC_INJ_ConfigQueueContext().
+  * @note   This parameter can be modified only when no conversion is on going
+  *         on either groups regular or injected.
+  * @note   A modification of the context mode (bit JQDIS) causes the contexts
+  *         queue to be flushed and the register JSQR is cleared.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR     JQM            LL_ADC_INJ_SetQueueMode\n
+  *         CFGR     JQDIS          LL_ADC_INJ_SetQueueMode
+  * @param  ADCx ADC instance
+  * @param  QueueMode This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_QUEUE_DISABLE
+  *         @arg @ref LL_ADC_INJ_QUEUE_2CONTEXTS_LAST_ACTIVE
+  *         @arg @ref LL_ADC_INJ_QUEUE_2CONTEXTS_END_EMPTY
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_SetQueueMode(ADC_TypeDef *ADCx, uint32_t QueueMode)
+{
+  MODIFY_REG(ADCx->CFGR, ADC_CFGR_JQM | ADC_CFGR_JQDIS, QueueMode);
+}
+
+/**
+  * @brief  Get ADC group injected context queue mode.
+  * @rmtoll CFGR     JQM            LL_ADC_INJ_GetQueueMode\n
+  *         CFGR     JQDIS          LL_ADC_INJ_GetQueueMode
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_QUEUE_DISABLE
+  *         @arg @ref LL_ADC_INJ_QUEUE_2CONTEXTS_LAST_ACTIVE
+  *         @arg @ref LL_ADC_INJ_QUEUE_2CONTEXTS_END_EMPTY
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_GetQueueMode(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR, ADC_CFGR_JQM | ADC_CFGR_JQDIS));
+}
+
+/**
+  * @brief  Set one context on ADC group injected that will be checked in
+  *         contexts queue.
+  * @note   A context is a setting of group injected sequencer:
+  *         - group injected trigger
+  *         - sequencer length
+  *         - sequencer ranks
+  *         This function is intended to be used when contexts queue is enabled,
+  *         because the sequence must be fully configured in one time
+  *         (functions to set separately injected trigger and sequencer channels
+  *         cannot be used):
+  *         Refer to function @ref LL_ADC_INJ_SetQueueMode().
+  * @note   In the contexts queue, only the active context can be read.
+  *         The parameters of this function can be read using functions:
+  *         @arg @ref LL_ADC_INJ_GetTriggerSource()
+  *         @arg @ref LL_ADC_INJ_GetTriggerEdge()
+  *         @arg @ref LL_ADC_INJ_GetSequencerRanks()
+  * @note   On this STM32 series, to measure internal channels (VrefInt,
+  *         TempSensor, ...), measurement paths to internal channels must be
+  *         enabled separately.
+  *         This can be done using function @ref LL_ADC_SetCommonPathInternalCh().
+  * @note   On STM32H7, some fast channels are available: fast analog inputs
+  *         coming from GPIO pads (ADC_IN0..5).
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must not be disabled. Can be enabled with or without conversion
+  *         on going on either groups regular or injected.
+  * @rmtoll JSQR     JEXTSEL        LL_ADC_INJ_ConfigQueueContext\n
+  *         JSQR     JEXTEN         LL_ADC_INJ_ConfigQueueContext\n
+  *         JSQR     JL             LL_ADC_INJ_ConfigQueueContext\n
+  *         JSQR     JSQ1           LL_ADC_INJ_ConfigQueueContext\n
+  *         JSQR     JSQ2           LL_ADC_INJ_ConfigQueueContext\n
+  *         JSQR     JSQ3           LL_ADC_INJ_ConfigQueueContext\n
+  *         JSQR     JSQ4           LL_ADC_INJ_ConfigQueueContext
+  * @param  ADCx ADC instance
+  * @param  TriggerSource This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_TRIG_SOFTWARE
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM2_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM2_CH1
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM4_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_EXTI_LINE15
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_CH4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM1_TRGO2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM8_TRGO2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH3
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM3_CH1
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM6_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_TIM15_TRGO
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_HRTIM_TRG2
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_HRTIM_TRG4
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM1_OUT
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM2_OUT
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_LPTIM3_OUT
+  * @param  ExternalTriggerEdge This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_RISING
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_FALLING
+  *         @arg @ref LL_ADC_INJ_TRIG_EXT_RISINGFALLING
+  *
+  *         Note: This parameter is discarded in case of SW start:
+  *               parameter "TriggerSource" set to "LL_ADC_INJ_TRIG_SOFTWARE".
+  * @param  SequencerNbRanks This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_DISABLE
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_2RANKS
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_3RANKS
+  *         @arg @ref LL_ADC_INJ_SEQ_SCAN_ENABLE_4RANKS
+  * @param  Rank1_Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @param  Rank2_Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @param  Rank3_Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @param  Rank4_Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_ConfigQueueContext(ADC_TypeDef *ADCx,
+                                                   uint32_t TriggerSource,
+                                                   uint32_t ExternalTriggerEdge,
+                                                   uint32_t SequencerNbRanks,
+                                                   uint32_t Rank1_Channel,
+                                                   uint32_t Rank2_Channel,
+                                                   uint32_t Rank3_Channel,
+                                                   uint32_t Rank4_Channel)
+{
+  /* Set bits with content of parameter "Rankx_Channel" with bits position    */
+  /* in register depending on literal "LL_ADC_INJ_RANK_x".                    */
+  /* Parameters "Rankx_Channel" and "LL_ADC_INJ_RANK_x" are used with masks   */
+  /* because containing other bits reserved for other purpose.                */
+  /* If parameter "TriggerSource" is set to SW start, then parameter          */
+  /* "ExternalTriggerEdge" is discarded.                                      */
+  uint32_t is_trigger_not_sw = (uint32_t)((TriggerSource != LL_ADC_INJ_TRIG_SOFTWARE) ? 1UL : 0UL);
+  MODIFY_REG(ADCx->JSQR,
+             ADC_JSQR_JEXTSEL |
+             ADC_JSQR_JEXTEN  |
+             ADC_JSQR_JSQ4    |
+             ADC_JSQR_JSQ3    |
+             ADC_JSQR_JSQ2    |
+             ADC_JSQR_JSQ1    |
+             ADC_JSQR_JL,
+             (TriggerSource & ADC_JSQR_JEXTSEL)        |
+             (ExternalTriggerEdge * (is_trigger_not_sw)) |
+             (((Rank4_Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (LL_ADC_INJ_RANK_4 & ADC_INJ_RANK_ID_JSQR_MASK)) |
+             (((Rank3_Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (LL_ADC_INJ_RANK_3 & ADC_INJ_RANK_ID_JSQR_MASK)) |
+             (((Rank2_Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (LL_ADC_INJ_RANK_2 & ADC_INJ_RANK_ID_JSQR_MASK)) |
+             (((Rank1_Channel & ADC_CHANNEL_ID_NUMBER_MASK) >> ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS) << (LL_ADC_INJ_RANK_1 & ADC_INJ_RANK_ID_JSQR_MASK)) |
+             SequencerNbRanks
+            );
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Configuration_Channels Configuration of ADC hierarchical scope: channels
+  * @{
+  */
+
+/**
+  * @brief  Set sampling time of the selected ADC channel
+  *         Unit: ADC clock cycles.
+  * @note   On this device, sampling time is on channel scope: independently
+  *         of channel mapped on ADC group regular or injected.
+  * @note   In case of internal channel (VrefInt, TempSensor, ...) to be
+  *         converted:
+  *         sampling time constraints must be respected (sampling time can be
+  *         adjusted in function of ADC clock frequency and sampling time
+  *         setting).
+  *         Refer to device datasheet for timings values (parameters TS_vrefint,
+  *         TS_temp, ...).
+  * @note   Conversion time is the addition of sampling time and processing time.
+  *         On this STM32 series, ADC processing time is:
+  *         - 12.5 ADC clock cycles at ADC resolution 12 bits
+  *         - 10.5 ADC clock cycles at ADC resolution 10 bits
+  *         - 8.5 ADC clock cycles at ADC resolution 8 bits
+  *         - 6.5 ADC clock cycles at ADC resolution 6 bits
+  * @note   In case of ADC conversion of internal channel (VrefInt,
+  *         temperature sensor, ...), a sampling time minimum value
+  *         is required.
+  *         Refer to device datasheet.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll SMPR1    SMP0           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP1           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP2           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP3           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP4           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP5           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP6           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP7           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP8           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR1    SMP9           LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP10          LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP11          LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP12          LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP13          LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP14          LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP15          LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP16          LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP17          LL_ADC_SetChannelSamplingTime\n
+  *         SMPR2    SMP18          LL_ADC_SetChannelSamplingTime
+  * @param  ADCx ADC instance
+  * @param  Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @param  SamplingTime This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_SAMPLINGTIME_1CYCLE_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_2CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_8CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_16CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_32CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_64CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_387CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_810CYCLES_5
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetChannelSamplingTime(ADC_TypeDef *ADCx, uint32_t Channel, uint32_t SamplingTime)
+{
+  /* Set bits with content of parameter "SamplingTime" with bits position     */
+  /* in register and register position depending on parameter "Channel".      */
+  /* Parameter "Channel" is used with masks because containing                */
+  /* other bits reserved for other purpose.                                   */
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->SMPR1, ((Channel & ADC_CHANNEL_SMPRX_REGOFFSET_MASK) >> ADC_SMPRX_REGOFFSET_POS));
+
+  MODIFY_REG(*preg,
+             ADC_SMPR1_SMP0 << ((Channel & ADC_CHANNEL_SMPx_BITOFFSET_MASK) >> ADC_CHANNEL_SMPx_BITOFFSET_POS),
+             SamplingTime   << ((Channel & ADC_CHANNEL_SMPx_BITOFFSET_MASK) >> ADC_CHANNEL_SMPx_BITOFFSET_POS));
+}
+
+/**
+  * @brief  Get sampling time of the selected ADC channel
+  *         Unit: ADC clock cycles.
+  * @note   On this device, sampling time is on channel scope: independently
+  *         of channel mapped on ADC group regular or injected.
+  * @note   Conversion time is the addition of sampling time and processing time.
+  *         On this STM32 series, ADC processing time is:
+  *         - 12.5 ADC clock cycles at ADC resolution 12 bits
+  *         - 10.5 ADC clock cycles at ADC resolution 10 bits
+  *         - 8.5 ADC clock cycles at ADC resolution 8 bits
+  *         - 6.5 ADC clock cycles at ADC resolution 6 bits
+  * @rmtoll SMPR1    SMP0           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP1           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP2           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP3           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP4           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP5           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP6           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP7           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP8           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR1    SMP9           LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP10          LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP11          LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP12          LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP13          LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP14          LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP15          LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP16          LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP17          LL_ADC_GetChannelSamplingTime\n
+  *         SMPR2    SMP18          LL_ADC_GetChannelSamplingTime
+  * @param  ADCx ADC instance
+  * @param  Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_0           (3)
+  *         @arg @ref LL_ADC_CHANNEL_1           (3)
+  *         @arg @ref LL_ADC_CHANNEL_2           (3)
+  *         @arg @ref LL_ADC_CHANNEL_3           (3)
+  *         @arg @ref LL_ADC_CHANNEL_4           (3)
+  *         @arg @ref LL_ADC_CHANNEL_5           (3)
+  *         @arg @ref LL_ADC_CHANNEL_6
+  *         @arg @ref LL_ADC_CHANNEL_7
+  *         @arg @ref LL_ADC_CHANNEL_8
+  *         @arg @ref LL_ADC_CHANNEL_9
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  *         @arg @ref LL_ADC_CHANNEL_VREFINT      (1)
+  *         @arg @ref LL_ADC_CHANNEL_TEMPSENSOR   (1)
+  *         @arg @ref LL_ADC_CHANNEL_VBAT         (1)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH1_ADC2 (2)
+  *         @arg @ref LL_ADC_CHANNEL_DAC1CH2_ADC2 (2)
+  *
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.\n
+  *         (3) On STM32H7, fast channel (0.125 us for 14-bit resolution (ADC conversion rate up to 8 Ms/s)).
+  *             Other channels are slow channels (conversion rate: refer to reference manual).
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_SAMPLINGTIME_1CYCLE_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_2CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_8CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_16CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_32CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_64CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_387CYCLES_5
+  *         @arg @ref LL_ADC_SAMPLINGTIME_810CYCLES_5
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetChannelSamplingTime(const ADC_TypeDef *ADCx, uint32_t Channel)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->SMPR1, ((Channel & ADC_CHANNEL_SMPRX_REGOFFSET_MASK) >> ADC_SMPRX_REGOFFSET_POS));
+
+  return (uint32_t)(READ_BIT(*preg,
+                             ADC_SMPR1_SMP0 << ((Channel & ADC_CHANNEL_SMPx_BITOFFSET_MASK) >> ADC_CHANNEL_SMPx_BITOFFSET_POS))
+                    >> ((Channel & ADC_CHANNEL_SMPx_BITOFFSET_MASK) >> ADC_CHANNEL_SMPx_BITOFFSET_POS)
+                   );
+}
+
+/**
+  * @brief  Set mode single-ended or differential input of the selected
+  *         ADC channel.
+  * @note   Channel ending is on channel scope: independently of channel mapped
+  *         on ADC group regular or injected.
+  *         In differential mode: Differential measurement is carried out
+  *         between the selected channel 'i' (positive input) and
+  *         channel 'i+1' (negative input). Only channel 'i' has to be
+  *         configured, channel 'i+1' is configured automatically.
+  * @note   Refer to Reference Manual to ensure the selected channel is
+  *         available in differential mode.
+  *         For example, internal channels (VrefInt, TempSensor, ...) are
+  *         not available in differential mode.
+  * @note   When configuring a channel 'i' in differential mode,
+  *         the channel 'i+1' is not usable separately.
+  * @note   On STM32H7, some channels are internally fixed to single-ended inputs
+  *         configuration:
+  *         - ADC1: Channels 0, 6, 7, 8, 9, 13, 14, 15, 17, and 19
+  *         - ADC2: Channels 0, 6, 7, 8, 9, 13, 14, 15 and 19
+  *         - ADC3: Channels 0, 6, 7, 8, 9, 12, 16, 17, and 19
+  * @note   For ADC channels configured in differential mode, both inputs
+  *         should be biased at (Vref+)/2 +/-200mV.
+  *         (Vref+ is the analog voltage reference)
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be ADC disabled.
+  * @note   One or several values can be selected.
+  *         Example: (LL_ADC_CHANNEL_4 | LL_ADC_CHANNEL_12 | ...)
+  * @rmtoll DIFSEL   DIFSEL         LL_ADC_SetChannelSingleDiff
+  * @param  ADCx ADC instance
+  * @param  Channel This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_1
+  *         @arg @ref LL_ADC_CHANNEL_2
+  *         @arg @ref LL_ADC_CHANNEL_3
+  *         @arg @ref LL_ADC_CHANNEL_4
+  *         @arg @ref LL_ADC_CHANNEL_5
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  * @param  SingleDiff This parameter can be a combination of the following values:
+  *         @arg @ref LL_ADC_SINGLE_ENDED
+  *         @arg @ref LL_ADC_DIFFERENTIAL_ENDED
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetChannelSingleDiff(ADC_TypeDef *ADCx, uint32_t Channel, uint32_t SingleDiff)
+{
+#if defined(ADC_VER_V5_V90)
+  /* Bits of channels in single or differential mode are set only for         */
+  /* differential mode (for single mode, mask of bits allowed to be set is    */
+  /* shifted out of range of bits of channels in single or differential mode. */
+  if (ADCx == ADC3)
+  {
+    MODIFY_REG(ADCx->LTR2_DIFSEL,
+               Channel & ADC_SINGLEDIFF_CHANNEL_MASK,
+               (Channel & ADC_SINGLEDIFF_CHANNEL_MASK) & (ADC_DIFSEL_DIFSEL >> (SingleDiff & ADC_SINGLEDIFF_CHANNEL_SHIFT_MASK)));
+  }
+  else
+  {
+    MODIFY_REG(ADCx->DIFSEL_RES12,
+               Channel & ADC_SINGLEDIFF_CHANNEL_MASK,
+               (Channel & ADC_SINGLEDIFF_CHANNEL_MASK) & (ADC_DIFSEL_DIFSEL >> (SingleDiff & ADC_SINGLEDIFF_CHANNEL_SHIFT_MASK)));
+  }
+#else  /* ADC_VER_V5_V90 */
+  /* Bits of channels in single or differential mode are set only for         */
+  /* differential mode (for single mode, mask of bits allowed to be set is    */
+  /* shifted out of range of bits of channels in single or differential mode. */
+  MODIFY_REG(ADCx->DIFSEL,
+             Channel & ADC_SINGLEDIFF_CHANNEL_MASK,
+             (Channel & ADC_SINGLEDIFF_CHANNEL_MASK) & (ADC_DIFSEL_DIFSEL >> (SingleDiff & ADC_SINGLEDIFF_CHANNEL_SHIFT_MASK)));
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Get mode single-ended or differential input of the selected
+  *         ADC channel.
+  * @note   When configuring a channel 'i' in differential mode,
+  *         the channel 'i+1' is not usable separately.
+  *         Therefore, to ensure a channel is configured in single-ended mode,
+  *         the configuration of channel itself and the channel 'i-1' must be
+  *         read back (to ensure that the selected channel channel has not been
+  *         configured in differential mode by the previous channel).
+  * @note   Refer to Reference Manual to ensure the selected channel is
+  *         available in differential mode.
+  *         For example, internal channels (VrefInt, TempSensor, ...) are
+  *         not available in differential mode.
+  * @note   When configuring a channel 'i' in differential mode,
+  *         the channel 'i+1' is not usable separately.
+  * @note   On STM32H7, some channels are internally fixed to single-ended inputs
+  *         configuration:
+  *         - ADC1: Channels 0, 6, 7, 8, 9, 13, 14, 15, 17, and 19
+  *         - ADC2: Channels 0, 6, 7, 8, 9, 13, 14, 15 and 19
+  *         - ADC3: Channels 0, 6, 7, 8, 9, 12, 16, 17, and 19
+  * @note   One or several values can be selected. In this case, the value
+  *         returned is null if all channels are in single ended-mode.
+  *         Example: (LL_ADC_CHANNEL_4 | LL_ADC_CHANNEL_12 | ...)
+  * @rmtoll DIFSEL   DIFSEL         LL_ADC_GetChannelSingleDiff
+  * @param  ADCx ADC instance
+  * @param  Channel This parameter can be a combination of the following values:
+  *         @arg @ref LL_ADC_CHANNEL_1
+  *         @arg @ref LL_ADC_CHANNEL_2
+  *         @arg @ref LL_ADC_CHANNEL_3
+  *         @arg @ref LL_ADC_CHANNEL_4
+  *         @arg @ref LL_ADC_CHANNEL_5
+  *         @arg @ref LL_ADC_CHANNEL_10
+  *         @arg @ref LL_ADC_CHANNEL_11
+  *         @arg @ref LL_ADC_CHANNEL_12
+  *         @arg @ref LL_ADC_CHANNEL_13
+  *         @arg @ref LL_ADC_CHANNEL_14
+  *         @arg @ref LL_ADC_CHANNEL_15
+  *         @arg @ref LL_ADC_CHANNEL_16
+  *         @arg @ref LL_ADC_CHANNEL_17
+  *         @arg @ref LL_ADC_CHANNEL_18
+  *         @arg @ref LL_ADC_CHANNEL_19
+  * @retval 0: channel in single-ended mode, else: channel in differential mode
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetChannelSingleDiff(const ADC_TypeDef *ADCx, uint32_t Channel)
+{
+#if defined(ADC_VER_V5_V90)
+  return (uint32_t)(READ_BIT(ADCx->DIFSEL_RES12, (Channel & ADC_SINGLEDIFF_CHANNEL_MASK)));
+#else
+  return (uint32_t)(READ_BIT(ADCx->DIFSEL, (Channel & ADC_SINGLEDIFF_CHANNEL_MASK)));
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Configuration_ADC_AnalogWatchdog Configuration of ADC transversal scope: analog watchdog
+  * @{
+  */
+
+/**
+  * @brief  Set ADC analog watchdog monitored channels:
+  *         a single channel, multiple channels or all channels,
+  *         on ADC groups regular and-or injected.
+  * @note   Once monitored channels are selected, analog watchdog
+  *         is enabled.
+  * @note   In case of need to define a single channel to monitor
+  *         with analog watchdog from sequencer channel definition,
+  *         use helper macro @ref __LL_ADC_ANALOGWD_CHANNEL_GROUP().
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
+  *         instance:
+  *         - AWD standard (instance AWD1):
+  *           - channels monitored: can monitor 1 channel or all channels.
+  *           - groups monitored: ADC groups regular and-or injected.
+  *           - resolution: resolution is not limited (corresponds to
+  *             ADC resolution configured).
+  *         - AWD flexible (instances AWD2, AWD3):
+  *           - channels monitored: flexible on channels monitored, selection is
+  *             channel wise, from from 1 to all channels.
+  *             Specificity of this analog watchdog: Multiple channels can
+  *             be selected. For example:
+  *             (LL_ADC_AWD_CHANNEL4_REG_INJ | LL_ADC_AWD_CHANNEL5_REG_INJ | ...)
+  *           - groups monitored: not selection possible (monitoring on both
+  *             groups regular and injected).
+  *             Channels selected are monitored on groups regular and injected:
+  *             LL_ADC_AWD_CHANNELxx_REG_INJ (do not use parameters
+  *             LL_ADC_AWD_CHANNELxx_REG and LL_ADC_AWD_CHANNELxx_INJ)
+  *           - resolution: resolution is limited to 8 bits: if ADC resolution is
+  *             12 bits the 4 LSB are ignored, if ADC resolution is 10 bits
+  *             the 2 LSB are ignored.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR     AWD1CH         LL_ADC_SetAnalogWDMonitChannels\n
+  *         CFGR     AWD1SGL        LL_ADC_SetAnalogWDMonitChannels\n
+  *         CFGR     AWD1EN         LL_ADC_SetAnalogWDMonitChannels\n
+  *         CFGR     JAWD1EN        LL_ADC_SetAnalogWDMonitChannels\n
+  *         AWD2CR   AWD2CH         LL_ADC_SetAnalogWDMonitChannels\n
+  *         AWD3CR   AWD3CH         LL_ADC_SetAnalogWDMonitChannels
+  * @param  ADCx ADC instance
+  * @param  AWDy This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD1
+  *         @arg @ref LL_ADC_AWD2
+  *         @arg @ref LL_ADC_AWD3
+  * @param  AWDChannelGroup This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD_DISABLE
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_REG        (0)
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_INJ        (0)
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CH_VREFINT_REG          (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_VREFINT_INJ          (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_VREFINT_REG_INJ         (1)
+  *         @arg @ref LL_ADC_AWD_CH_TEMPSENSOR_REG       (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_TEMPSENSOR_INJ       (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_TEMPSENSOR_REG_INJ      (1)
+  *         @arg @ref LL_ADC_AWD_CH_VBAT_REG             (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_VBAT_INJ             (0)(1)
+  *         @arg @ref LL_ADC_AWD_CH_VBAT_REG_INJ            (1)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH1_ADC2_REG     (0)(2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH1_ADC2_INJ     (0)(2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH1_ADC2_REG_INJ    (2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH2_ADC2_REG     (0)(2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH2_ADC2_INJ     (0)(2)
+  *         @arg @ref LL_ADC_AWD_CH_DAC1CH2_ADC2_REG_INJ    (2)
+  *
+  *         (0) On STM32H7, parameter available only on analog watchdog number: AWD1.\n
+  *         (1) On STM32H7, parameter available only on ADC instance: ADC3.\n
+  *         (2) On STM32H7, parameter available only on ADC instance: ADC2.
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetAnalogWDMonitChannels(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDChannelGroup)
+{
+  /* Set bits with content of parameter "AWDChannelGroup" with bits position  */
+  /* in register and register position depending on parameter "AWDy".         */
+  /* Parameters "AWDChannelGroup" and "AWDy" are used with masks because      */
+  /* containing other bits reserved for other purpose.                        */
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->CFGR, ((AWDy & ADC_AWD_CRX_REGOFFSET_MASK) >> ADC_AWD_CRX_REGOFFSET_POS)
+                                                      + ((AWDy & ADC_AWD_CR12_REGOFFSETGAP_MASK) * ADC_AWD_CR12_REGOFFSETGAP_VAL));
+
+  MODIFY_REG(*preg,
+             (AWDy & ADC_AWD_CR_ALL_CHANNEL_MASK),
+             AWDChannelGroup & AWDy);
+}
+
+/**
+  * @brief  Get ADC analog watchdog monitored channel.
+  * @note   Usage of the returned channel number:
+  *         - To reinject this channel into another function LL_ADC_xxx:
+  *           the returned channel number is only partly formatted on definition
+  *           of literals LL_ADC_CHANNEL_x. Therefore, it has to be compared
+  *           with parts of literals LL_ADC_CHANNEL_x or using
+  *           helper macro @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
+  *           Then the selected literal LL_ADC_CHANNEL_x can be used
+  *           as parameter for another function.
+  *         - To get the channel number in decimal format:
+  *           process the returned value with the helper macro
+  *           @ref __LL_ADC_CHANNEL_TO_DECIMAL_NB().
+  *           Applicable only when the analog watchdog is set to monitor
+  *           one channel.
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
+  *         instance:
+  *         - AWD standard (instance AWD1):
+  *           - channels monitored: can monitor 1 channel or all channels.
+  *           - groups monitored: ADC groups regular and-or injected.
+  *           - resolution: resolution is not limited (corresponds to
+  *             ADC resolution configured).
+  *         - AWD flexible (instances AWD2, AWD3):
+  *           - channels monitored: flexible on channels monitored, selection is
+  *             channel wise, from from 1 to all channels.
+  *             Specificity of this analog watchdog: Multiple channels can
+  *             be selected. For example:
+  *             (LL_ADC_AWD_CHANNEL4_REG_INJ | LL_ADC_AWD_CHANNEL5_REG_INJ | ...)
+  *           - groups monitored: not selection possible (monitoring on both
+  *             groups regular and injected).
+  *             Channels selected are monitored on groups regular and injected:
+  *             LL_ADC_AWD_CHANNELxx_REG_INJ (do not use parameters
+  *             LL_ADC_AWD_CHANNELxx_REG and LL_ADC_AWD_CHANNELxx_INJ)
+  *           - resolution: resolution is limited to 8 bits: if ADC resolution is
+  *             12 bits the 4 LSB are ignored, if ADC resolution is 10 bits
+  *             the 2 LSB are ignored.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR     AWD1CH         LL_ADC_GetAnalogWDMonitChannels\n
+  *         CFGR     AWD1SGL        LL_ADC_GetAnalogWDMonitChannels\n
+  *         CFGR     AWD1EN         LL_ADC_GetAnalogWDMonitChannels\n
+  *         CFGR     JAWD1EN        LL_ADC_GetAnalogWDMonitChannels\n
+  *         AWD2CR   AWD2CH         LL_ADC_GetAnalogWDMonitChannels\n
+  *         AWD3CR   AWD3CH         LL_ADC_GetAnalogWDMonitChannels
+  * @param  ADCx ADC instance
+  * @param  AWDy This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD1
+  *         @arg @ref LL_ADC_AWD2 (1)
+  *         @arg @ref LL_ADC_AWD3 (1)
+  *
+  *         (1) On this AWD number, monitored channel can be retrieved
+  *             if only 1 channel is programmed (or none or all channels).
+  *             This function cannot retrieve monitored channel if
+  *             multiple channels are programmed simultaneously
+  *             by bitfield.
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_AWD_DISABLE
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_REG        (0)
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_INJ        (0)
+  *         @arg @ref LL_ADC_AWD_ALL_CHANNELS_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_0_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_1_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_2_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_3_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_4_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_5_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_6_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_7_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_8_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_REG           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_INJ           (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_9_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_10_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_11_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_12_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_13_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_14_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_15_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_16_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_17_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_18_REG_INJ
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_REG          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_INJ          (0)
+  *         @arg @ref LL_ADC_AWD_CHANNEL_19_REG_INJ
+  *
+  *         (0) On STM32H7, parameter available only on analog watchdog number: AWD1.
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetAnalogWDMonitChannels(const ADC_TypeDef *ADCx, uint32_t AWDy)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->CFGR, ((AWDy & ADC_AWD_CRX_REGOFFSET_MASK) >> ADC_AWD_CRX_REGOFFSET_POS)
+                                                            + ((AWDy & ADC_AWD_CR12_REGOFFSETGAP_MASK) * ADC_AWD_CR12_REGOFFSETGAP_VAL));
+
+  uint32_t AnalogWDMonitChannels = (READ_BIT(*preg, AWDy) & AWDy & ADC_AWD_CR_ALL_CHANNEL_MASK);
+
+  /* If "AnalogWDMonitChannels" == 0, then the selected AWD is disabled       */
+  /* (parameter value LL_ADC_AWD_DISABLE).                                    */
+  /* Else, the selected AWD is enabled and is monitoring a group of channels  */
+  /* or a single channel.                                                     */
+  if (AnalogWDMonitChannels != 0UL)
+  {
+    if (AWDy == LL_ADC_AWD1)
+    {
+      if ((AnalogWDMonitChannels & ADC_CFGR_AWD1SGL) == 0UL)
+      {
+        /* AWD monitoring a group of channels */
+        AnalogWDMonitChannels = ((AnalogWDMonitChannels
+                                  | (ADC_AWD_CR23_CHANNEL_MASK)
+                                 )
+                                 & (~(ADC_CFGR_AWD1CH))
+                                );
+      }
+      else
+      {
+        /* AWD monitoring a single channel */
+        AnalogWDMonitChannels = (AnalogWDMonitChannels
+                                 | (ADC_AWD2CR_AWD2CH_0 << (AnalogWDMonitChannels >> ADC_CFGR_AWD1CH_Pos))
+                                );
+      }
+    }
+    else
+    {
+      if ((AnalogWDMonitChannels & ADC_AWD_CR23_CHANNEL_MASK) == ADC_AWD_CR23_CHANNEL_MASK)
+      {
+        /* AWD monitoring a group of channels */
+        AnalogWDMonitChannels = (ADC_AWD_CR23_CHANNEL_MASK
+                                 | ((ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN))
+                                );
+      }
+      else
+      {
+        /* AWD monitoring a single channel */
+        /* AWD monitoring a group of channels */
+        AnalogWDMonitChannels = (AnalogWDMonitChannels
+                                 | (ADC_CFGR_JAWD1EN | ADC_CFGR_AWD1EN | ADC_CFGR_AWD1SGL)
+                                 | (__LL_ADC_CHANNEL_TO_DECIMAL_NB(AnalogWDMonitChannels) << ADC_CFGR_AWD1CH_Pos)
+                                );
+      }
+    }
+  }
+
+  return AnalogWDMonitChannels;
+}
+
+/**
+  * @brief  Set ADC analog watchdog threshold value of threshold
+  *         high or low.
+  * @note   In case of ADC resolution different of 12 bits,
+  *         analog watchdog thresholds data require a specific shift.
+  *         Use helper macro @ref __LL_ADC_ANALOGWD_SET_THRESHOLD_RESOLUTION().
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
+  *         instance:
+  *         - AWD standard (instance AWD1):
+  *           - channels monitored: can monitor 1 channel or all channels.
+  *           - groups monitored: ADC groups regular and-or injected.
+  *           - resolution: resolution is not limited (corresponds to
+  *             ADC resolution configured).
+  *         - AWD flexible (instances AWD2, AWD3):
+  *           - channels monitored: flexible on channels monitored, selection is
+  *             channel wise, from from 1 to all channels.
+  *             Specificity of this analog watchdog: Multiple channels can
+  *             be selected. For example:
+  *             (LL_ADC_AWD_CHANNEL4_REG_INJ | LL_ADC_AWD_CHANNEL5_REG_INJ | ...)
+  *           - groups monitored: not selection possible (monitoring on both
+  *             groups regular and injected).
+  *             Channels selected are monitored on groups regular and injected:
+  *             LL_ADC_AWD_CHANNELxx_REG_INJ (do not use parameters
+  *             LL_ADC_AWD_CHANNELxx_REG and LL_ADC_AWD_CHANNELxx_INJ)
+  *           - resolution: resolution is limited to 8 bits: if ADC resolution is
+  *             12 bits the 4 LSB are ignored, if ADC resolution is 10 bits
+  *             the 2 LSB are ignored.
+  * @note   If ADC oversampling is enabled, ADC analog watchdog thresholds are
+  *         impacted: the comparison of analog watchdog thresholds is done
+  *         on oversampling intermediate computation (after ratio, before shift
+  *         application): intermediate register bitfield [32:7]
+  *         (26 most significant bits).
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either ADC groups regular or injected.
+  * @rmtoll TR1      HT1            LL_ADC_SetAnalogWDThresholds\n
+  *         TR2      HT2            LL_ADC_SetAnalogWDThresholds\n
+  *         TR3      HT3            LL_ADC_SetAnalogWDThresholds\n
+  *         TR1      LT1            LL_ADC_SetAnalogWDThresholds\n
+  *         TR2      LT2            LL_ADC_SetAnalogWDThresholds\n
+  *         TR3      LT3            LL_ADC_SetAnalogWDThresholds
+  * @param  ADCx ADC instance
+  * @param  AWDy This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD1
+  *         @arg @ref LL_ADC_AWD2
+  *         @arg @ref LL_ADC_AWD3
+  * @param  AWDThresholdsHighLow This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD_THRESHOLD_HIGH
+  *         @arg @ref LL_ADC_AWD_THRESHOLD_LOW
+  * @param  AWDThresholdValue Value between Min_Data=0x000 and Max_Data=0xFFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdsHighLow, uint32_t AWDThresholdValue)
+{
+#if defined(ADC_VER_V5_V90)
+  if (ADCx == ADC3)
+  {
+    /* Set bits with content of parameter "AWDThresholdValue" with bits         */
+    /* position in register and register position depending on parameters       */
+    /* "AWDThresholdsHighLow" and "AWDy".                                       */
+    /* Parameters "AWDy" and "AWDThresholdValue" are used with masks because    */
+    /* containing other bits reserved for other purpose.                        */
+    __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->LTR1_TR1, ((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS));
+
+    MODIFY_REG(*preg,
+               (ADC3_TR1_LT1 << (AWDThresholdsHighLow * ADC3_TR1_HT1_Pos)),
+               AWDThresholdValue << (((AWDThresholdsHighLow * ADC3_TR1_HT1) & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4));
+  }
+  else
+  {
+    /* Set bits with content of parameter "AWDThresholdValue" with bits         */
+    /* position in register and register position depending on parameters       */
+    /* "AWDThresholdsHighLow" and "AWDy".                                       */
+    /* Parameters "AWDy" and "AWDThresholdValue" are used with masks because    */
+    /* containing other bits reserved for other purpose.                        */
+    __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->LTR1_TR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS) * 2UL)
+                                                        + ((AWDy & ADC_AWD_TR12_REGOFFSETGAP_MASK) * ADC_AWD_TR12_REGOFFSETGAP_VAL)
+                                                        + (AWDThresholdsHighLow));
+
+    MODIFY_REG(*preg, ADC_LTR_LT, AWDThresholdValue);
+  }
+#else
+  /* Set bits with content of parameter "AWDThresholdValue" with bits         */
+  /* position in register and register position depending on parameters       */
+  /* "AWDThresholdsHighLow" and "AWDy".                                       */
+  /* Parameters "AWDy" and "AWDThresholdValue" are used with masks because    */
+  /* containing other bits reserved for other purpose.                        */
+  __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->LTR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS) * 2UL)
+                                                      + ((AWDy & ADC_AWD_TR12_REGOFFSETGAP_MASK) * ADC_AWD_TR12_REGOFFSETGAP_VAL)
+                                                      + (AWDThresholdsHighLow));
+
+  MODIFY_REG(*preg, ADC_LTR_LT, AWDThresholdValue);
+#endif  /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Get ADC analog watchdog threshold value of threshold high,
+  *         threshold low or raw data with ADC thresholds high and low
+  *         concatenated.
+  * @note   In case of ADC resolution different of 12 bits,
+  *         analog watchdog thresholds data require a specific shift.
+  *         Use helper macro @ref __LL_ADC_ANALOGWD_GET_THRESHOLD_RESOLUTION().
+  * @rmtoll TR1      HT1            LL_ADC_GetAnalogWDThresholds\n
+  *         TR2      HT2            LL_ADC_GetAnalogWDThresholds\n
+  *         TR3      HT3            LL_ADC_GetAnalogWDThresholds\n
+  *         TR1      LT1            LL_ADC_GetAnalogWDThresholds\n
+  *         TR2      LT2            LL_ADC_GetAnalogWDThresholds\n
+  *         TR3      LT3            LL_ADC_GetAnalogWDThresholds
+  * @param  ADCx ADC instance
+  * @param  AWDy This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD1
+  *         @arg @ref LL_ADC_AWD2
+  *         @arg @ref LL_ADC_AWD3
+  * @param  AWDThresholdsHighLow This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD_THRESHOLD_HIGH
+  *         @arg @ref LL_ADC_AWD_THRESHOLD_LOW
+  * @retval Value between Min_Data=0x000 and Max_Data=0x3FFFFFF
+*/
+__STATIC_INLINE uint32_t LL_ADC_GetAnalogWDThresholds(const ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdsHighLow)
+{
+#if defined(ADC_VER_V5_V90)
+  if (ADCx == ADC3)
+  {
+    const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->LTR1_TR1,
+                                                     ((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS));
+
+    return (uint32_t)(READ_BIT(*preg,
+                               (ADC3_TR1_LT1 << (AWDThresholdsHighLow * ADC3_TR1_HT1_Pos)))
+                      >> (((AWDThresholdsHighLow & ADC_AWD_TRX_BIT_HIGH_MASK) >> ADC_AWD_TRX_BIT_HIGH_SHIFT4)
+                          & ~(AWDThresholdsHighLow & ADC3_TR1_LT1)));
+  }
+  else
+  {
+    const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->LTR1_TR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS) * 2UL)
+                                                                   + ((AWDy & ADC_AWD_TR12_REGOFFSETGAP_MASK) * ADC_AWD_TR12_REGOFFSETGAP_VAL)
+                                                                   + (AWDThresholdsHighLow));
+
+    return (uint32_t)(READ_BIT(*preg, ADC_LTR_LT));
+  }
+#else
+   const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->LTR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS) * 2UL)
+                                                                   + ((AWDy & ADC_AWD_TR12_REGOFFSETGAP_MASK) * ADC_AWD_TR12_REGOFFSETGAP_VAL)
+                                                                   + (AWDThresholdsHighLow));
+
+  return (uint32_t)(READ_BIT(*preg, ADC_LTR_LT));
+#endif /* ADC_VER_V5_V90 */
+}
+
+#if defined(ADC_VER_V5_V90)
+
+/**
+  * @brief  Set ADC analog watchdog thresholds value of both thresholds
+  *         high and low. Applicable for devices STM32H72xx and STM32H73xx.
+  * @note   If value of only one threshold high or low must be set,
+  *         use function @ref LL_ADC_SetAnalogWDThresholds().
+  * @note   In case of ADC resolution different of 12 bits,
+  *         analog watchdog thresholds data require a specific shift.
+  *         Use helper macro @ref __LL_ADC_ANALOGWD_SET_THRESHOLD_RESOLUTION().
+  * @note   On this STM32 series, there are 2 kinds of analog watchdog
+  *         instance:
+  *         - AWD standard (instance AWD1):
+  *           - channels monitored: can monitor 1 channel or all channels.
+  *           - groups monitored: ADC groups regular and-or injected.
+  *           - resolution: resolution is not limited (corresponds to
+  *             ADC resolution configured).
+  *         - AWD flexible (instances AWD2, AWD3):
+  *           - channels monitored: flexible on channels monitored, selection is
+  *             channel wise, from from 1 to all channels.
+  *             Specificity of this analog watchdog: Multiple channels can
+  *             be selected. For example:
+  *             (LL_ADC_AWD_CHANNEL4_REG_INJ | LL_ADC_AWD_CHANNEL5_REG_INJ | ...)
+  *           - groups monitored: not selection possible (monitoring on both
+  *             groups regular and injected).
+  *             Channels selected are monitored on groups regular and injected:
+  *             LL_ADC_AWD_CHANNELxx_REG_INJ (do not use parameters
+  *             LL_ADC_AWD_CHANNELxx_REG and LL_ADC_AWD_CHANNELxx_INJ)
+  *           - resolution: resolution is limited to 8 bits: if ADC resolution is
+  *             12 bits the 4 LSB are ignored, if ADC resolution is 10 bits
+  *             the 2 LSB are ignored.
+  * @rmtoll TR1      HT1            LL_ADC_ConfigAnalogWDThresholds\n
+  *         TR2      HT2            LL_ADC_ConfigAnalogWDThresholds\n
+  *         TR3      HT3            LL_ADC_ConfigAnalogWDThresholds\n
+  *         TR1      LT1            LL_ADC_ConfigAnalogWDThresholds\n
+  *         TR2      LT2            LL_ADC_ConfigAnalogWDThresholds\n
+  *         TR3      LT3            LL_ADC_ConfigAnalogWDThresholds
+  * @param  ADCx ADC instance
+  * @param  AWDy This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD1
+  *         @arg @ref LL_ADC_AWD2
+  *         @arg @ref LL_ADC_AWD3
+  * @param  AWDThresholdHighValue Value between Min_Data=0x000 and Max_Data=0xFFF
+  * @param  AWDThresholdLowValue Value between Min_Data=0x000 and Max_Data=0xFFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ConfigAnalogWDThresholds(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t AWDThresholdHighValue, uint32_t AWDThresholdLowValue)
+{
+  /* Set bits with content of parameter "AWDThresholdxxxValue" with bits      */
+  /* position in register and register position depending on parameter        */
+  /* "AWDy".                                                                  */
+  /* Parameters "AWDy" and "AWDThresholdxxxValue" are used with masks because */
+  /* containing other bits reserved for other purpose.                        */
+  if (ADCx == ADC3)
+  {
+    __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->LTR1_TR1,
+                                               ((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS));
+
+    MODIFY_REG(*preg,
+               ADC3_TR1_HT1 | ADC3_TR1_LT1,
+               (AWDThresholdHighValue << ADC3_TR1_HT1_Pos) | AWDThresholdLowValue);
+  }
+  else
+  {
+    __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->LTR1_TR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS) * 2UL)
+                                                        + ((AWDy & ADC_AWD_TR12_REGOFFSETGAP_MASK) * ADC_AWD_TR12_REGOFFSETGAP_VAL)
+                                                        + (LL_ADC_AWD_THRESHOLD_LOW));
+    __IO uint32_t *preg2 = __ADC_PTR_REG_OFFSET(ADCx->LTR1_TR1, (((AWDy & ADC_AWD_TRX_REGOFFSET_MASK) >> ADC_AWD_TRX_REGOFFSET_POS) * 2UL)
+                                                         + ((AWDy & ADC_AWD_TR12_REGOFFSETGAP_MASK) * ADC_AWD_TR12_REGOFFSETGAP_VAL)
+                                                         + (LL_ADC_AWD_THRESHOLD_HIGH));
+
+    MODIFY_REG(*preg, ADC_LTR_LT, AWDThresholdLowValue);
+    MODIFY_REG(*preg2, ADC_HTR_HT, AWDThresholdHighValue);
+  }
+}
+
+
+/**
+  * @brief  Set ADC analog watchdog filtering configuration
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  *         Applicable on ADC3 of devices STM32H72xx and STM32H73xx.
+  *  @note  On this STM32 series, this feature is only available on first
+  *         analog watchdog (AWD1)
+  * @rmtoll TR1      AWDFILT        LL_ADC_SetAWDFilteringConfiguration
+  * @param  ADCx ADC instance
+  * @param  AWDy This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD1
+  * @param  FilteringConfig This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD_FILTERING_NONE
+  *         @arg @ref LL_ADC_AWD_FILTERING_2SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_3SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_4SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_5SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_6SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_7SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_8SAMPLES
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetAWDFilteringConfiguration(ADC_TypeDef *ADCx, uint32_t AWDy, uint32_t FilteringConfig)
+{
+  if (ADCx == ADC3)
+  {
+    /* Prevent unused argument(s) compilation warning */
+    (void)(AWDy);
+    MODIFY_REG(ADCx->LTR1_TR1, ADC3_TR1_AWDFILT, FilteringConfig);
+  }
+}
+
+/**
+  * @brief  Get ADC analog watchdog filtering configuration
+  *  @note  On this STM32 series, this feature is only available on first
+  *         analog watchdog (AWD1)
+  *         Applicable on ADC3 of devices STM32H72xx and STM32H73xx.
+  * @rmtoll TR1      AWDFILT        LL_ADC_GetAWDFilteringConfiguration
+  * @param  ADCx ADC instance
+  * @param  AWDy This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_AWD1
+  * @retval Returned value can be:
+  *         @arg @ref LL_ADC_AWD_FILTERING_NONE
+  *         @arg @ref LL_ADC_AWD_FILTERING_2SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_3SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_4SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_5SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_6SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_7SAMPLES
+  *         @arg @ref LL_ADC_AWD_FILTERING_8SAMPLES
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetAWDFilteringConfiguration(const ADC_TypeDef *ADCx, uint32_t AWDy)
+{
+  if (ADCx == ADC3)
+  {
+    /* Prevent unused argument(s) compilation warning */
+    (void)(AWDy);
+    return (uint32_t)(READ_BIT(ADCx->LTR1_TR1, ADC3_TR1_AWDFILT));
+  }
+  else
+  {
+    /* Function not available on this instance, return 0 */
+    return 0UL;
+  }
+}
+#endif /* ADC_VER_V5_V90 */
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Configuration_ADC_oversampling Configuration of ADC transversal scope: oversampling
+  * @{
+  */
+
+/**
+  * @brief  Set ADC oversampling scope: ADC groups regular and-or injected
+  *         (availability of ADC group injected depends on STM32 families).
+  * @note   If both groups regular and injected are selected,
+  *         specify behavior of ADC group injected interrupting
+  *         group regular: when ADC group injected is triggered,
+  *         the oversampling on ADC group regular is either
+  *         temporary stopped and continued, or resumed from start
+  *         (oversampler buffer reset).
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR2    ROVSE          LL_ADC_SetOverSamplingScope\n
+  *         CFGR2    JOVSE          LL_ADC_SetOverSamplingScope\n
+  *         CFGR2    ROVSM          LL_ADC_SetOverSamplingScope
+  * @param  ADCx ADC instance
+  * @param  OvsScope This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OVS_DISABLE
+  *         @arg @ref LL_ADC_OVS_GRP_REGULAR_CONTINUED
+  *         @arg @ref LL_ADC_OVS_GRP_REGULAR_RESUMED
+  *         @arg @ref LL_ADC_OVS_GRP_INJECTED
+  *         @arg @ref LL_ADC_OVS_GRP_INJ_REG_RESUMED
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetOverSamplingScope(ADC_TypeDef *ADCx, uint32_t OvsScope)
+{
+  MODIFY_REG(ADCx->CFGR2, ADC_CFGR2_ROVSE | ADC_CFGR2_JOVSE | ADC_CFGR2_ROVSM, OvsScope);
+}
+
+/**
+  * @brief  Get ADC oversampling scope: ADC groups regular and-or injected
+  *         (availability of ADC group injected depends on STM32 families).
+  * @note   If both groups regular and injected are selected,
+  *         specify behavior of ADC group injected interrupting
+  *         group regular: when ADC group injected is triggered,
+  *         the oversampling on ADC group regular is either
+  *         temporary stopped and continued, or resumed from start
+  *         (oversampler buffer reset).
+  * @rmtoll CFGR2    ROVSE          LL_ADC_GetOverSamplingScope\n
+  *         CFGR2    JOVSE          LL_ADC_GetOverSamplingScope\n
+  *         CFGR2    ROVSM          LL_ADC_GetOverSamplingScope
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_OVS_DISABLE
+  *         @arg @ref LL_ADC_OVS_GRP_REGULAR_CONTINUED
+  *         @arg @ref LL_ADC_OVS_GRP_REGULAR_RESUMED
+  *         @arg @ref LL_ADC_OVS_GRP_INJECTED
+  *         @arg @ref LL_ADC_OVS_GRP_INJ_REG_RESUMED
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingScope(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_ROVSE | ADC_CFGR2_JOVSE | ADC_CFGR2_ROVSM));
+}
+
+/**
+  * @brief  Set ADC oversampling discontinuous mode (triggered mode)
+  *         on the selected ADC group.
+  * @note   Number of oversampled conversions are done either in:
+  *         - continuous mode (all conversions of oversampling ratio
+  *           are done from 1 trigger)
+  *         - discontinuous mode (each conversion of oversampling ratio
+  *           needs a trigger)
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on group regular.
+  * @note   On this STM32 series, oversampling discontinuous mode
+  *         (triggered mode) can be used only when oversampling is
+  *         set on group regular only and in resumed mode.
+  * @rmtoll CFGR2    TROVS          LL_ADC_SetOverSamplingDiscont
+  * @param  ADCx ADC instance
+  * @param  OverSamplingDiscont This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OVS_REG_CONT
+  *         @arg @ref LL_ADC_OVS_REG_DISCONT
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetOverSamplingDiscont(ADC_TypeDef *ADCx, uint32_t OverSamplingDiscont)
+{
+  MODIFY_REG(ADCx->CFGR2, ADC_CFGR2_TROVS, OverSamplingDiscont);
+}
+
+/**
+  * @brief  Get ADC oversampling discontinuous mode (triggered mode)
+  *         on the selected ADC group.
+  * @note   Number of oversampled conversions are done either in:
+  *         - continuous mode (all conversions of oversampling ratio
+  *           are done from 1 trigger)
+  *         - discontinuous mode (each conversion of oversampling ratio
+  *           needs a trigger)
+  * @rmtoll CFGR2    TROVS          LL_ADC_GetOverSamplingDiscont
+  * @param  ADCx ADC instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_OVS_REG_CONT
+  *         @arg @ref LL_ADC_OVS_REG_DISCONT
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingDiscont(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_TROVS));
+}
+
+/**
+  * @brief  Set ADC oversampling
+  *         (impacting both ADC groups regular and injected)
+  * @note   This function set the 2 items of oversampling configuration:
+  *         - ratio
+  *         - shift
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be disabled or enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CFGR2    OVSS           LL_ADC_ConfigOverSamplingRatioShift\n
+  *         CFGR2    OVSR           LL_ADC_ConfigOverSamplingRatioShift
+  * @param  ADCx ADC instance
+  * @param  Ratio This parameter can be in the range from 1 to 1024.
+  *         In the case of ADC3 can be one of the following values:
+  *         @arg @ref LL_ADC_OVS_RATIO_2
+  *         @arg @ref LL_ADC_OVS_RATIO_4
+  *         @arg @ref LL_ADC_OVS_RATIO_8
+  *         @arg @ref LL_ADC_OVS_RATIO_16
+  *         @arg @ref LL_ADC_OVS_RATIO_32
+  *         @arg @ref LL_ADC_OVS_RATIO_64
+  *         @arg @ref LL_ADC_OVS_RATIO_128
+  *         @arg @ref LL_ADC_OVS_RATIO_256
+  * @param  Shift This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OVS_SHIFT_NONE
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_1
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_2
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_3
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_4
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_5
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_6
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_7
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_8
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_9
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_10
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_11
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ConfigOverSamplingRatioShift(ADC_TypeDef *ADCx, uint32_t Ratio, uint32_t Shift)
+{
+#if defined(ADC_VER_V5_V90)
+  if(ADCx==ADC3)
+  {
+    MODIFY_REG(ADCx->CFGR2, (ADC_CFGR2_OVSS | ADC3_CFGR2_OVSR), (Shift | Ratio));
+  }
+  else
+  {
+    MODIFY_REG(ADCx->CFGR2, (ADC_CFGR2_OVSS | ADC_CFGR2_OVSR), (Shift | (((Ratio - 1UL) << ADC_CFGR2_OVSR_Pos))));
+  }
+#else
+
+  MODIFY_REG(ADCx->CFGR2, (ADC_CFGR2_OVSS | ADC_CFGR2_OVSR), (Shift | (((Ratio - 1UL) << ADC_CFGR2_OVSR_Pos))));
+
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Get ADC oversampling ratio
+  *        (impacting both ADC groups regular and injected)
+  * @rmtoll CFGR2    OVSR           LL_ADC_GetOverSamplingRatio
+  * @param  ADCx ADC instance
+  * @retval Ratio This parameter can be in the from 1 to 1024.
+  *         In the case of ADC3 can be one of the following values:
+  *         @arg @ref LL_ADC_OVS_RATIO_2
+  *         @arg @ref LL_ADC_OVS_RATIO_4
+  *         @arg @ref LL_ADC_OVS_RATIO_8
+  *         @arg @ref LL_ADC_OVS_RATIO_16
+  *         @arg @ref LL_ADC_OVS_RATIO_32
+  *         @arg @ref LL_ADC_OVS_RATIO_64
+  *         @arg @ref LL_ADC_OVS_RATIO_128
+  *         @arg @ref LL_ADC_OVS_RATIO_256
+*/
+__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingRatio(const ADC_TypeDef *ADCx)
+{
+#if defined(ADC_VER_V5_V90)
+  if(ADCx==ADC3)
+  {
+    return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC3_CFGR2_OVSR));
+  }
+  else
+  {
+    return (((uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSR)) + (1UL << ADC_CFGR2_OVSR_Pos)) >> ADC_CFGR2_OVSR_Pos);
+  }
+#else
+
+  return (((uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSR)) + (1UL << ADC_CFGR2_OVSR_Pos)) >> ADC_CFGR2_OVSR_Pos);
+
+#endif /* ADC_VER_V5_V90 */
+}
+
+/**
+  * @brief  Get ADC oversampling shift
+  *        (impacting both ADC groups regular and injected)
+  * @rmtoll CFGR2    OVSS           LL_ADC_GetOverSamplingShift
+  * @param  ADCx ADC instance
+  * @retval Shift This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_OVS_SHIFT_NONE
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_1
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_2
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_3
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_4
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_5
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_6
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_7
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_8
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_9
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_10
+  *         @arg @ref LL_ADC_OVS_SHIFT_RIGHT_11
+*/
+__STATIC_INLINE uint32_t LL_ADC_GetOverSamplingShift(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->CFGR2, ADC_CFGR2_OVSS));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Configuration_ADC_Multimode Configuration of ADC hierarchical scope: multimode
+  * @{
+  */
+/**
+  * @brief  Set ADC boost mode.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC boost must be configured, without calibration on going, without conversion
+  *         on going on group regular.
+  * @rmtoll CR  BOOST      LL_ADC_SetBoostMode
+  * @param  ADCx ADC instance
+  * @param  BoostMode This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_BOOST_MODE_6MHZ25
+  *         @arg @ref LL_ADC_BOOST_MODE_12MHZ5
+  *         @arg @ref LL_ADC_BOOST_MODE_20MHZ
+  *         @arg @ref LL_ADC_BOOST_MODE_25MHZ
+  *         @arg @ref LL_ADC_BOOST_MODE_50MHZ
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetBoostMode(ADC_TypeDef *ADCx, uint32_t BoostMode)
+{
+#if defined(ADC_VER_V5_V90)
+  if (ADCx != ADC3)
+  {
+    MODIFY_REG(ADCx->CR, ADC_CR_BOOST, (BoostMode & ADC_CR_BOOST));
+  }
+#else   /* ADC_VER_V5_V90 */
+  if ((DBGMCU->IDCODE & 0x30000000UL) == 0x10000000UL) /* Cut 1.x */
+  {
+    MODIFY_REG(ADCx->CR, ADC_CR_BOOST_0, (BoostMode >> 2UL));
+  }
+  else /* Cut 2.x */
+  {
+    MODIFY_REG(ADCx->CR, ADC_CR_BOOST, (BoostMode & ADC_CR_BOOST));
+  }
+#endif /* ADC_VER_V5_V90 */
+}
+
+
+/**
+  * @brief  Get ADC boost mode.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC boost must be configured, without calibration on going, without conversion
+  *         on going on group regular.
+  * @rmtoll CR  BOOST      LL_ADC_GetBoostMode
+  * @param  ADCx ADC instance
+  * @retval 0: Boost disabled 1: Boost enabled
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetBoostMode(const ADC_TypeDef *ADCx)
+{
+  if ((DBGMCU->IDCODE & 0x30000000UL) == 0x10000000UL) /* Cut 1.x */
+  {
+    return (uint32_t)READ_BIT(ADCx->CR, ADC_CR_BOOST_0);
+  }
+  else /* Cut 2.x */
+  {
+    return ((READ_BIT(ADCx->CR, ADC_CR_BOOST) == (ADC_CR_BOOST)) ? 1UL : 0UL);
+  }
+}
+
+/**
+  * @brief  Set ADC multimode configuration to operate in independent mode
+  *         or multimode (for devices with several ADC instances).
+  * @note   If multimode configuration: the selected ADC instance is
+  *         either master or slave depending on hardware.
+  *         Refer to reference manual.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled.
+  *         This check can be done with function @ref LL_ADC_IsEnabled() for each
+  *         ADC instance or by using helper macro
+  *         @ref __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE().
+  * @rmtoll CCR      DUAL           LL_ADC_SetMultimode
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  Multimode This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_INDEPENDENT
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_SIMULT
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_INTERL
+  *         @arg @ref LL_ADC_MULTI_DUAL_INJ_SIMULT
+  *         @arg @ref LL_ADC_MULTI_DUAL_INJ_ALTERN
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_SIM_INJ_SIM
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_SIM_INJ_ALT
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_INT_INJ_SIM
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetMultimode(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t Multimode)
+{
+  MODIFY_REG(ADCxy_COMMON->CCR, ADC_CCR_DUAL, Multimode);
+}
+
+/**
+  * @brief  Get ADC multimode configuration to operate in independent mode
+  *         or multimode (for devices with several ADC instances).
+  * @note   If multimode configuration: the selected ADC instance is
+  *         either master or slave depending on hardware.
+  *         Refer to reference manual.
+  * @rmtoll CCR      DUAL           LL_ADC_GetMultimode
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_INDEPENDENT
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_SIMULT
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_INTERL
+  *         @arg @ref LL_ADC_MULTI_DUAL_INJ_SIMULT
+  *         @arg @ref LL_ADC_MULTI_DUAL_INJ_ALTERN
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_SIM_INJ_SIM
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_SIM_INJ_ALT
+  *         @arg @ref LL_ADC_MULTI_DUAL_REG_INT_INJ_SIM
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetMultimode(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return (uint32_t)(READ_BIT(ADCxy_COMMON->CCR, ADC_CCR_DUAL));
+}
+
+/**
+  * @brief  Set ADC multimode conversion data transfer: no transfer
+  *         or transfer by DMA.
+  * @note   If ADC multimode transfer by DMA is not selected:
+  *         each ADC uses its own DMA channel, with its individual
+  *         DMA transfer settings.
+  *         If ADC multimode transfer by DMA is selected:
+  *         One DMA channel is used for both ADC (DMA of ADC master)
+  *         Specifies the DMA requests mode:
+  *         - Limited mode (One shot mode): DMA transfer requests are stopped
+  *           when number of DMA data transfers (number of
+  *           ADC conversions) is reached.
+  *           This ADC mode is intended to be used with DMA mode non-circular.
+  *         - Unlimited mode: DMA transfer requests are unlimited,
+  *           whatever number of DMA data transfers (number of
+  *           ADC conversions).
+  *           This ADC mode is intended to be used with DMA mode circular.
+  * @note   If ADC DMA requests mode is set to unlimited and DMA is set to
+  *         mode non-circular:
+  *         when DMA transfers size will be reached, DMA will stop transfers of
+  *         ADC conversions data ADC will raise an overrun error
+  *         (overrun flag and interruption if enabled).
+  * @note   How to retrieve multimode conversion data:
+  *         Whatever multimode transfer by DMA setting: using function
+  *         @ref LL_ADC_REG_ReadMultiConversionData32().
+  *         If ADC multimode transfer by DMA is selected: conversion data
+  *         is a raw data with ADC master and slave concatenated.
+  *         A macro is available to get the conversion data of
+  *         ADC master or ADC slave: see helper macro
+  *         @ref __LL_ADC_MULTI_CONV_DATA_MASTER_SLAVE().
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled
+  *         or enabled without conversion on going on group regular.
+  * @rmtoll CCR      DAMDF          LL_ADC_GetMultiDMATransfer\n
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  MultiDMATransfer This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_REG_DMA_EACH_ADC
+  *         @arg @ref LL_ADC_MULTI_REG_DMA_RES_32_10B
+  *         @arg @ref LL_ADC_MULTI_REG_DMA_RES_8B
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetMultiDMATransfer(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t MultiDMATransfer)
+{
+  MODIFY_REG(ADCxy_COMMON->CCR, ADC_CCR_DAMDF, MultiDMATransfer);
+}
+
+/**
+  * @brief  Get ADC multimode conversion data transfer: no transfer
+  *         or transfer by DMA.
+  * @note   If ADC multimode transfer by DMA is not selected:
+  *         each ADC uses its own DMA channel, with its individual
+  *         DMA transfer settings.
+  *         If ADC multimode transfer by DMA is selected:
+  *         One DMA channel is used for both ADC (DMA of ADC master)
+  *         Specifies the DMA requests mode:
+  *         - Limited mode (One shot mode): DMA transfer requests are stopped
+  *           when number of DMA data transfers (number of
+  *           ADC conversions) is reached.
+  *           This ADC mode is intended to be used with DMA mode non-circular.
+  *         - Unlimited mode: DMA transfer requests are unlimited,
+  *           whatever number of DMA data transfers (number of
+  *           ADC conversions).
+  *           This ADC mode is intended to be used with DMA mode circular.
+  * @note   If ADC DMA requests mode is set to unlimited and DMA is set to
+  *         mode non-circular:
+  *         when DMA transfers size will be reached, DMA will stop transfers of
+  *         ADC conversions data ADC will raise an overrun error
+  *         (overrun flag and interruption if enabled).
+  * @note   How to retrieve multimode conversion data:
+  *         Whatever multimode transfer by DMA setting: using function
+  *         @ref LL_ADC_REG_ReadMultiConversionData32().
+  *         If ADC multimode transfer by DMA is selected: conversion data
+  *         is a raw data with ADC master and slave concatenated.
+  *         A macro is available to get the conversion data of
+  *         ADC master or ADC slave: see helper macro
+  *         @ref __LL_ADC_MULTI_CONV_DATA_MASTER_SLAVE().
+  * @rmtoll CCR      DAMDF          LL_ADC_GetMultiDMATransfer\n
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_REG_DMA_EACH_ADC
+  *         @arg @ref LL_ADC_MULTI_REG_DMA_RES_32_10B
+  *         @arg @ref LL_ADC_MULTI_REG_DMA_RES_8B
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetMultiDMATransfer(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return (uint32_t)(READ_BIT(ADCxy_COMMON->CCR, ADC_CCR_DAMDF));
+}
+
+/**
+  * @brief  Set ADC multimode delay between 2 sampling phases.
+  * @note   The sampling delay range depends on ADC resolution:
+  *         - ADC resolution 12 bits can have maximum delay of 12 cycles.
+  *         - ADC resolution 10 bits can have maximum delay of 10 cycles.
+  *         - ADC resolution  8 bits can have maximum delay of  8 cycles.
+  *         - ADC resolution  6 bits can have maximum delay of  6 cycles.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         All ADC instances of the ADC common group must be disabled.
+  *         This check can be done with function @ref LL_ADC_IsEnabled() for each
+  *         ADC instance or by using helper macro helper macro
+  *         @ref __LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE().
+  * @rmtoll CCR      DELAY          LL_ADC_SetMultiTwoSamplingDelay
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  MultiTwoSamplingDelay This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_1CYCLE_5
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_2CYCLES_5
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_3CYCLES_5
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_4CYCLES_5 (1)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_4CYCLES_5_8_BITS
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_5CYCLES_5 (2)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_5CYCLES_5_10_BITS
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES  (3)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES_5 (4)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES_5_12_BITS
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_7CYCLES_5 (5)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_8CYCLES  (6)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_9CYCLES  (7)
+  *
+  *         (1) Parameter available only if ADC resolution is 16, 14, 12 or 10 bits.
+  *         (2) Parameter available only if ADC resolution is 16, 14 or 12  bits.
+  *         (3) Parameter available only if ADC resolution is 10 or 8 bits.
+  *         (4) Parameter available only if ADC resolution is 16 or 14 bits.
+  *         (5) Parameter available only if ADC resolution is 16 bits.
+  *         (6) Parameter available only if ADC resolution is 12 bits.
+  *         (7) Parameter available only if ADC resolution is 16 or 14 bits.
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_SetMultiTwoSamplingDelay(ADC_Common_TypeDef *ADCxy_COMMON, uint32_t MultiTwoSamplingDelay)
+{
+  MODIFY_REG(ADCxy_COMMON->CCR, ADC_CCR_DELAY, MultiTwoSamplingDelay);
+}
+
+/**
+  * @brief  Get ADC multimode delay between 2 sampling phases.
+  * @rmtoll CCR      DELAY          LL_ADC_GetMultiTwoSamplingDelay
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_1CYCLE_5
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_2CYCLES_5
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_3CYCLES_5
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_4CYCLES_5 (1)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_4CYCLES_5_8_BITS
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_5CYCLES_5 (2)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_5CYCLES_5_10_BITS
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES  (3)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES_5 (4)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_6CYCLES_5_12_BITS
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_7CYCLES_5 (5)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_8CYCLES  (6)
+  *         @arg @ref LL_ADC_MULTI_TWOSMP_DELAY_9CYCLES  (7)
+  *
+  *         (1) Parameter available only if ADC resolution is 16, 14, 12 or 10 bits.
+  *         (2) Parameter available only if ADC resolution is 16, 14 or 12  bits.
+  *         (3) Parameter available only if ADC resolution is 10 or 8 bits.
+  *         (4) Parameter available only if ADC resolution is 16 or 14 bits.
+  *         (5) Parameter available only if ADC resolution is 16 bits.
+  *         (6) Parameter available only if ADC resolution is 12 bits.
+  *         (7) Parameter available only if ADC resolution is 16 or 14 bits.
+  */
+__STATIC_INLINE uint32_t LL_ADC_GetMultiTwoSamplingDelay(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return (uint32_t)(READ_BIT(ADCxy_COMMON->CCR, ADC_CCR_DELAY));
+}
+
+/**
+  * @}
+  */
+/** @defgroup ADC_LL_EF_Operation_ADC_Instance Operation on ADC hierarchical scope: ADC instance
+  * @{
+  */
+
+/**
+  * @brief  Put ADC instance in deep power down state.
+  * @note   In case of ADC calibration necessary: When ADC is in deep-power-down
+  *         state, the internal analog calibration is lost. After exiting from
+  *         deep power down, calibration must be relaunched or calibration factor
+  *         (preliminarily saved) must be set back into calibration register.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be ADC disabled.
+  * @rmtoll CR       DEEPPWD        LL_ADC_EnableDeepPowerDown
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableDeepPowerDown(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_DEEPPWD);
+}
+
+/**
+  * @brief  Disable ADC deep power down mode.
+  * @note   In case of ADC calibration necessary: When ADC is in deep-power-down
+  *         state, the internal analog calibration is lost. After exiting from
+  *         deep power down, calibration must be relaunched or calibration factor
+  *         (preliminarily saved) must be set back into calibration register.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be ADC disabled.
+  * @rmtoll CR       DEEPPWD        LL_ADC_DisableDeepPowerDown
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableDeepPowerDown(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  CLEAR_BIT(ADCx->CR, (ADC_CR_DEEPPWD | ADC_CR_BITS_PROPERTY_RS));
+}
+
+/**
+  * @brief  Get the selected ADC instance deep power down state.
+  * @rmtoll CR       DEEPPWD        LL_ADC_IsDeepPowerDownEnabled
+  * @param  ADCx ADC instance
+  * @retval 0: deep power down is disabled, 1: deep power down is enabled.
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsDeepPowerDownEnabled(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_DEEPPWD) == (ADC_CR_DEEPPWD)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Enable ADC instance internal voltage regulator.
+  * @note   On this STM32 series, after ADC internal voltage regulator enable,
+  *         a delay for ADC internal voltage regulator stabilization
+  *         is required before performing a ADC calibration or ADC enable.
+  *         Refer to device datasheet, parameter tADCVREG_STUP.
+  *         Refer to literal @ref LL_ADC_DELAY_INTERNAL_REGUL_STAB_US.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be ADC disabled.
+  * @rmtoll CR       ADVREGEN       LL_ADC_EnableInternalRegulator
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableInternalRegulator(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_ADVREGEN);
+}
+
+/**
+  * @brief  Disable ADC internal voltage regulator.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be ADC disabled.
+  * @rmtoll CR       ADVREGEN       LL_ADC_DisableInternalRegulator
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableInternalRegulator(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->CR, (ADC_CR_ADVREGEN | ADC_CR_BITS_PROPERTY_RS));
+}
+
+/**
+  * @brief  Get the selected ADC instance internal voltage regulator state.
+  * @rmtoll CR       ADVREGEN       LL_ADC_IsInternalRegulatorEnabled
+  * @param  ADCx ADC instance
+  * @retval 0: internal regulator is disabled, 1: internal regulator is enabled.
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsInternalRegulatorEnabled(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_ADVREGEN) == (ADC_CR_ADVREGEN)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Enable the selected ADC instance.
+  * @note   On this STM32 series, after ADC enable, a delay for
+  *         ADC internal analog stabilization is required before performing a
+  *         ADC conversion start.
+  *         Refer to device datasheet, parameter tSTAB.
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  *         is enabled and when conversion clock is active.
+  *         (not only core clock: this ADC has a dual clock domain)
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be ADC disabled and ADC internal voltage regulator enabled.
+  * @rmtoll CR       ADEN           LL_ADC_Enable
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_Enable(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_ADEN);
+}
+
+/**
+  * @brief  Disable the selected ADC instance.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be not disabled. Must be enabled without conversion on going
+  *         on either groups regular or injected.
+  * @rmtoll CR       ADDIS          LL_ADC_Disable
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_Disable(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_ADDIS);
+}
+
+/**
+  * @brief  Get the selected ADC instance enable state.
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  *         is enabled and when conversion clock is active.
+  *         (not only core clock: this ADC has a dual clock domain)
+  * @rmtoll CR       ADEN           LL_ADC_IsEnabled
+  * @param  ADCx ADC instance
+  * @retval 0: ADC is disabled, 1: ADC is enabled.
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabled(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_ADEN) == (ADC_CR_ADEN)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get the selected ADC instance disable state.
+  * @rmtoll CR       ADDIS          LL_ADC_IsDisableOngoing
+  * @param  ADCx ADC instance
+  * @retval 0: no ADC disable command on going.
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsDisableOngoing(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_ADDIS) == (ADC_CR_ADDIS)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Start ADC calibration in the mode single-ended
+  *         or differential (for devices with differential mode available).
+  * @note   On this STM32 series, a minimum number of ADC clock cycles
+  *         are required between ADC end of calibration and ADC enable.
+  *         Refer to literal @ref LL_ADC_DELAY_CALIB_ENABLE_ADC_CYCLES.
+  * @note   Calibration duration:
+  *         - Calibration of offset: 520 ADC clock cycles
+  *         - Calibration of linearity: 131072 ADC clock cycles
+  * @note   For devices with differential mode available:
+  *         Calibration of offset is specific to each of
+  *         single-ended and differential modes
+  *         (calibration run must be performed for each of these
+  *         differential modes, if used afterwards and if the application
+  *         requires their calibration).
+  *         Calibration of linearity is common to both
+  *         single-ended and differential modes
+  *         (calibration run can be performed only once).
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be ADC disabled.
+  * @rmtoll CR       ADCAL          LL_ADC_StartCalibration\n
+  *         CR       ADCALDIF       LL_ADC_StartCalibration\n
+  *         CR       ADCALLIN       LL_ADC_StartCalibration
+  * @param  ADCx ADC instance
+  * @param  CalibrationMode This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_CALIB_OFFSET
+  *         @arg @ref LL_ADC_CALIB_OFFSET_LINEARITY
+  * @param  SingleDiff This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_SINGLE_ENDED
+  *         @arg @ref LL_ADC_DIFFERENTIAL_ENDED
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_StartCalibration(ADC_TypeDef *ADCx, uint32_t CalibrationMode, uint32_t SingleDiff)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_ADCALLIN | ADC_CR_ADCALDIF | ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_ADCAL | (CalibrationMode & ADC_CALIB_MODE_MASK) | (SingleDiff & ADC_SINGLEDIFF_CALIB_START_MASK));
+}
+
+/**
+  * @brief  Get ADC calibration state.
+  * @rmtoll CR       ADCAL          LL_ADC_IsCalibrationOnGoing
+  * @param  ADCx ADC instance
+  * @retval 0: calibration complete, 1: calibration in progress.
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsCalibrationOnGoing(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_ADCAL) == (ADC_CR_ADCAL)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Operation_ADC_Group_Regular Operation on ADC hierarchical scope: group regular
+  * @{
+  */
+
+/**
+  * @brief  Start ADC group regular conversion.
+  * @note   On this STM32 series, this function is relevant for both
+  *         internal trigger (SW start) and external trigger:
+  *         - If ADC trigger has been set to software start, ADC conversion
+  *           starts immediately.
+  *         - If ADC trigger has been set to external trigger, ADC conversion
+  *           will start at next trigger event (on the selected trigger edge)
+  *           following the ADC start conversion command.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be enabled without conversion on going on group regular,
+  *         without conversion stop command on going on group regular,
+  *         without ADC disable command on going.
+  * @rmtoll CR       ADSTART        LL_ADC_REG_StartConversion
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_StartConversion(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_ADSTART);
+}
+
+/**
+  * @brief  Stop ADC group regular conversion.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be enabled with conversion on going on group regular,
+  *         without ADC disable command on going.
+  * @rmtoll CR       ADSTP          LL_ADC_REG_StopConversion
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_REG_StopConversion(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_ADSTP);
+}
+
+/**
+  * @brief  Get ADC group regular conversion state.
+  * @rmtoll CR       ADSTART        LL_ADC_REG_IsConversionOngoing
+  * @param  ADCx ADC instance
+  * @retval 0: no conversion is on going on ADC group regular.
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_IsConversionOngoing(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_ADSTART) == (ADC_CR_ADSTART)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get ADC group regular command of conversion stop state
+  * @rmtoll CR       ADSTP          LL_ADC_REG_IsStopConversionOngoing
+  * @param  ADCx ADC instance
+  * @retval 0: no command of conversion stop is on going on ADC group regular.
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_IsStopConversionOngoing(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_ADSTP) == (ADC_CR_ADSTP)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get ADC group regular conversion data, range fit for
+  *         all ADC configurations: all ADC resolutions and
+  *         all oversampling increased data width (for devices
+  *         with feature oversampling).
+  * @rmtoll DR       RDATA          LL_ADC_REG_ReadConversionData32
+  * @param  ADCx ADC instance
+  * @retval Value between Min_Data=0x00000000 and Max_Data=0xFFFFFFFF
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_ReadConversionData32(const ADC_TypeDef *ADCx)
+{
+  return (uint32_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
+}
+
+/**
+  * @brief  Get ADC group regular conversion data, range fit for
+  *         ADC resolution 16 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_REG_ReadConversionData32.
+  * @rmtoll DR       RDATA          LL_ADC_REG_ReadConversionData16
+  * @param  ADCx ADC instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0xFFFF
+  */
+__STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData16(const ADC_TypeDef *ADCx)
+{
+  return (uint16_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
+}
+
+/**
+  * @brief  Get ADC group regular conversion data, range fit for
+  *         ADC resolution 14 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_REG_ReadConversionData32.
+  * @rmtoll DR       RDATA          LL_ADC_REG_ReadConversionData14
+  * @param  ADCx ADC instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x3FF
+  */
+__STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData14(const ADC_TypeDef *ADCx)
+{
+  return (uint16_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
+}
+
+/**
+  * @brief  Get ADC group regular conversion data, range fit for
+  *         ADC resolution 12 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_REG_ReadConversionData32.
+  * @rmtoll DR       RDATA          LL_ADC_REG_ReadConversionData12
+  * @param  ADCx ADC instance
+  * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
+  */
+__STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData12(const ADC_TypeDef *ADCx)
+{
+  return (uint16_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
+}
+
+/**
+  * @brief  Get ADC group regular conversion data, range fit for
+  *         ADC resolution 10 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_REG_ReadConversionData32.
+  * @rmtoll DR       RDATA          LL_ADC_REG_ReadConversionData10
+  * @param  ADCx ADC instance
+  * @retval Value between Min_Data=0x000 and Max_Data=0x3FF
+  */
+__STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData10(const ADC_TypeDef *ADCx)
+{
+  return (uint16_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
+}
+
+/**
+  * @brief  Get ADC group regular conversion data, range fit for
+  *         ADC resolution 8 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_REG_ReadConversionData32.
+  * @rmtoll DR       RDATA          LL_ADC_REG_ReadConversionData8
+  * @param  ADCx ADC instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0xFF
+  */
+__STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData8(const ADC_TypeDef *ADCx)
+{
+  return (uint8_t)(READ_BIT(ADCx->DR, ADC_DR_RDATA));
+}
+/**
+  * @brief  Get ADC multimode conversion data of ADC master, ADC slave
+  *         or raw data with ADC master and slave concatenated.
+  * @note   If raw data with ADC master and slave concatenated is retrieved,
+  *         a macro is available to get the conversion data of
+  *         ADC master or ADC slave: see helper macro
+  *         @ref __LL_ADC_MULTI_CONV_DATA_MASTER_SLAVE().
+  *         (however this macro is mainly intended for multimode
+  *         transfer by DMA, because this function can do the same
+  *         by getting multimode conversion data of ADC master or ADC slave
+  *         separately).
+  * @rmtoll CDR      RDATA_MST      LL_ADC_REG_ReadMultiConversionData32\n
+  *         CDR      RDATA_SLV      LL_ADC_REG_ReadMultiConversionData32
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @param  ConversionData This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_MULTI_MASTER
+  *         @arg @ref LL_ADC_MULTI_SLAVE
+  *         @arg @ref LL_ADC_MULTI_MASTER_SLAVE
+  * @retval Value between Min_Data=0x00000000 and Max_Data=0xFFFFFFFF
+  */
+__STATIC_INLINE uint32_t LL_ADC_REG_ReadMultiConversionData32(const ADC_Common_TypeDef *ADCxy_COMMON, uint32_t ConversionData)
+{
+  return (uint32_t)(READ_BIT(ADCxy_COMMON->CDR,
+                             ConversionData)
+                    >> (POSITION_VAL(ConversionData) & 0x1FUL)
+                   );
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_Operation_ADC_Group_Injected Operation on ADC hierarchical scope: group injected
+  * @{
+  */
+
+/**
+  * @brief  Start ADC group injected conversion.
+  * @note   On this STM32 series, this function is relevant for both
+  *         internal trigger (SW start) and external trigger:
+  *         - If ADC trigger has been set to software start, ADC conversion
+  *           starts immediately.
+  *         - If ADC trigger has been set to external trigger, ADC conversion
+  *           will start at next trigger event (on the selected trigger edge)
+  *           following the ADC start conversion command.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be enabled without conversion on going on group injected,
+  *         without conversion stop command on going on group injected,
+  *         without ADC disable command on going.
+  * @rmtoll CR       JADSTART       LL_ADC_INJ_StartConversion
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_StartConversion(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_JADSTART);
+}
+
+/**
+  * @brief  Stop ADC group injected conversion.
+  * @note   On this STM32 series, setting of this feature is conditioned to
+  *         ADC state:
+  *         ADC must be enabled with conversion on going on group injected,
+  *         without ADC disable command on going.
+  * @rmtoll CR       JADSTP         LL_ADC_INJ_StopConversion
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_INJ_StopConversion(ADC_TypeDef *ADCx)
+{
+  /* Note: Write register with some additional bits forced to state reset     */
+  /*       instead of modifying only the selected bit for this function,      */
+  /*       to not interfere with bits with HW property "rs".                  */
+  MODIFY_REG(ADCx->CR,
+             ADC_CR_BITS_PROPERTY_RS,
+             ADC_CR_JADSTP);
+}
+
+/**
+  * @brief  Get ADC group injected conversion state.
+  * @rmtoll CR       JADSTART       LL_ADC_INJ_IsConversionOngoing
+  * @param  ADCx ADC instance
+  * @retval 0: no conversion is on going on ADC group injected.
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_IsConversionOngoing(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_JADSTART) == (ADC_CR_JADSTART)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get ADC group injected command of conversion stop state
+  * @rmtoll CR       JADSTP         LL_ADC_INJ_IsStopConversionOngoing
+  * @param  ADCx ADC instance
+  * @retval 0: no command of conversion stop is on going on ADC group injected.
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_IsStopConversionOngoing(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->CR, ADC_CR_JADSTP) == (ADC_CR_JADSTP)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get ADC group injected conversion data, range fit for
+  *         all ADC configurations: all ADC resolutions and
+  *         all oversampling increased data width (for devices
+  *         with feature oversampling).
+  * @rmtoll JDR1     JDATA          LL_ADC_INJ_ReadConversionData32\n
+  *         JDR2     JDATA          LL_ADC_INJ_ReadConversionData32\n
+  *         JDR3     JDATA          LL_ADC_INJ_ReadConversionData32\n
+  *         JDR4     JDATA          LL_ADC_INJ_ReadConversionData32
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_RANK_1
+  *         @arg @ref LL_ADC_INJ_RANK_2
+  *         @arg @ref LL_ADC_INJ_RANK_3
+  *         @arg @ref LL_ADC_INJ_RANK_4
+  * @retval Value between Min_Data=0x00000000 and Max_Data=0xFFFFFFFF
+  */
+__STATIC_INLINE uint32_t LL_ADC_INJ_ReadConversionData32(const ADC_TypeDef *ADCx, uint32_t Rank)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
+
+  return (uint32_t)(READ_BIT(*preg,
+                             ADC_JDR1_JDATA)
+                   );
+}
+
+/**
+  * @brief  Get ADC group injected conversion data, range fit for
+  *         ADC resolution 16 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_INJ_ReadConversionData32.
+  * @rmtoll JDR1     JDATA          LL_ADC_INJ_ReadConversionData16\n
+  *         JDR2     JDATA          LL_ADC_INJ_ReadConversionData16\n
+  *         JDR3     JDATA          LL_ADC_INJ_ReadConversionData16\n
+  *         JDR4     JDATA          LL_ADC_INJ_ReadConversionData16
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_RANK_1
+  *         @arg @ref LL_ADC_INJ_RANK_2
+  *         @arg @ref LL_ADC_INJ_RANK_3
+  *         @arg @ref LL_ADC_INJ_RANK_4
+  * @retval Value between Min_Data=0x000 and Max_Data=0xFFFF
+  */
+__STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData16(const ADC_TypeDef *ADCx, uint32_t Rank)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
+
+  return (uint16_t)(READ_BIT(*preg,
+                             ADC_JDR1_JDATA)
+                   );
+}
+
+/**
+  * @brief  Get ADC group injected conversion data, range fit for
+  *         ADC resolution 14 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_INJ_ReadConversionData32.
+  * @rmtoll JDR1     JDATA          LL_ADC_INJ_ReadConversionData14\n
+  *         JDR2     JDATA          LL_ADC_INJ_ReadConversionData14\n
+  *         JDR3     JDATA          LL_ADC_INJ_ReadConversionData14\n
+  *         JDR4     JDATA          LL_ADC_INJ_ReadConversionData14
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_RANK_1
+  *         @arg @ref LL_ADC_INJ_RANK_2
+  *         @arg @ref LL_ADC_INJ_RANK_3
+  *         @arg @ref LL_ADC_INJ_RANK_4
+  * @retval Value between Min_Data=0x000 and Max_Data=0x3FFF
+  */
+__STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData14(const ADC_TypeDef *ADCx, uint32_t Rank)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
+
+  return (uint16_t)(READ_BIT(*preg,
+                             ADC_JDR1_JDATA)
+                   );
+}
+
+/**
+  * @brief  Get ADC group injected conversion data, range fit for
+  *         ADC resolution 12 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_INJ_ReadConversionData32.
+  * @rmtoll JDR1     JDATA          LL_ADC_INJ_ReadConversionData12\n
+  *         JDR2     JDATA          LL_ADC_INJ_ReadConversionData12\n
+  *         JDR3     JDATA          LL_ADC_INJ_ReadConversionData12\n
+  *         JDR4     JDATA          LL_ADC_INJ_ReadConversionData12
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_RANK_1
+  *         @arg @ref LL_ADC_INJ_RANK_2
+  *         @arg @ref LL_ADC_INJ_RANK_3
+  *         @arg @ref LL_ADC_INJ_RANK_4
+  * @retval Value between Min_Data=0x000 and Max_Data=0xFFF
+  */
+__STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData12(const ADC_TypeDef *ADCx, uint32_t Rank)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
+
+  return (uint16_t)(READ_BIT(*preg,
+                             ADC_JDR1_JDATA)
+                   );
+}
+
+/**
+  * @brief  Get ADC group injected conversion data, range fit for
+  *         ADC resolution 10 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_INJ_ReadConversionData32.
+  * @rmtoll JDR1     JDATA          LL_ADC_INJ_ReadConversionData10\n
+  *         JDR2     JDATA          LL_ADC_INJ_ReadConversionData10\n
+  *         JDR3     JDATA          LL_ADC_INJ_ReadConversionData10\n
+  *         JDR4     JDATA          LL_ADC_INJ_ReadConversionData10
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_RANK_1
+  *         @arg @ref LL_ADC_INJ_RANK_2
+  *         @arg @ref LL_ADC_INJ_RANK_3
+  *         @arg @ref LL_ADC_INJ_RANK_4
+  * @retval Value between Min_Data=0x000 and Max_Data=0x3FF
+  */
+__STATIC_INLINE uint16_t LL_ADC_INJ_ReadConversionData10(const ADC_TypeDef *ADCx, uint32_t Rank)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
+
+  return (uint16_t)(READ_BIT(*preg,
+                             ADC_JDR1_JDATA)
+                   );
+}
+
+/**
+  * @brief  Get ADC group injected conversion data, range fit for
+  *         ADC resolution 8 bits.
+  * @note   For devices with feature oversampling: Oversampling
+  *         can increase data width, function for extended range
+  *         may be needed: @ref LL_ADC_INJ_ReadConversionData32.
+  * @rmtoll JDR1     JDATA          LL_ADC_INJ_ReadConversionData8\n
+  *         JDR2     JDATA          LL_ADC_INJ_ReadConversionData8\n
+  *         JDR3     JDATA          LL_ADC_INJ_ReadConversionData8\n
+  *         JDR4     JDATA          LL_ADC_INJ_ReadConversionData8
+  * @param  ADCx ADC instance
+  * @param  Rank This parameter can be one of the following values:
+  *         @arg @ref LL_ADC_INJ_RANK_1
+  *         @arg @ref LL_ADC_INJ_RANK_2
+  *         @arg @ref LL_ADC_INJ_RANK_3
+  *         @arg @ref LL_ADC_INJ_RANK_4
+  * @retval Value between Min_Data=0x00 and Max_Data=0xFF
+  */
+__STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData8(const ADC_TypeDef *ADCx, uint32_t Rank)
+{
+  const __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, ((Rank & ADC_INJ_JDRX_REGOFFSET_MASK) >> ADC_JDRX_REGOFFSET_POS));
+
+  return (uint8_t)(READ_BIT(*preg,
+                            ADC_JDR1_JDATA)
+                  );
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_FLAG_Management ADC flag management
+  * @{
+  */
+
+/**
+  * @brief  Get flag ADC ready.
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  *         is enabled and when conversion clock is active.
+  *         (not only core clock: this ADC has a dual clock domain)
+  * @rmtoll ISR      ADRDY          LL_ADC_IsActiveFlag_ADRDY
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_ADRDY(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_ADRDY) == (LL_ADC_FLAG_ADRDY)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC group regular end of unitary conversion.
+  * @rmtoll ISR      EOC            LL_ADC_IsActiveFlag_EOC
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOC(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, ADC_ISR_EOC) == (ADC_ISR_EOC)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC group regular end of sequence conversions.
+  * @rmtoll ISR      EOS            LL_ADC_IsActiveFlag_EOS
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOS(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_EOS) == (LL_ADC_FLAG_EOS)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC group regular overrun.
+  * @rmtoll ISR      OVR            LL_ADC_IsActiveFlag_OVR
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_OVR(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_OVR) == (LL_ADC_FLAG_OVR)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC group regular end of sampling phase.
+  * @rmtoll ISR      EOSMP          LL_ADC_IsActiveFlag_EOSMP
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_EOSMP(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_EOSMP) == (LL_ADC_FLAG_EOSMP)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC group injected end of unitary conversion.
+  * @rmtoll ISR      JEOC           LL_ADC_IsActiveFlag_JEOC
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JEOC(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_JEOC) == (LL_ADC_FLAG_JEOC)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC group injected end of sequence conversions.
+  * @rmtoll ISR      JEOS           LL_ADC_IsActiveFlag_JEOS
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JEOS(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_JEOS) == (LL_ADC_FLAG_JEOS)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC group injected contexts queue overflow.
+  * @rmtoll ISR      JQOVF          LL_ADC_IsActiveFlag_JQOVF
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_JQOVF(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_JQOVF) == (LL_ADC_FLAG_JQOVF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC LDO output voltage ready bit.
+  * @rmtoll ISR      LDORDY          LL_ADC_IsActiveFlag_LDORDY
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_LDORDY(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_LDORDY) == (LL_ADC_FLAG_LDORDY)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC analog watchdog 1 flag
+  * @rmtoll ISR      AWD1           LL_ADC_IsActiveFlag_AWD1
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD1(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_AWD1) == (LL_ADC_FLAG_AWD1)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC analog watchdog 2.
+  * @rmtoll ISR      AWD2           LL_ADC_IsActiveFlag_AWD2
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD2(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_AWD2) == (LL_ADC_FLAG_AWD2)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag ADC analog watchdog 3.
+  * @rmtoll ISR      AWD3           LL_ADC_IsActiveFlag_AWD3
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_AWD3(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->ISR, LL_ADC_FLAG_AWD3) == (LL_ADC_FLAG_AWD3)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Clear flag ADC ready.
+  * @note   On this STM32 series, flag LL_ADC_FLAG_ADRDY is raised when the ADC
+  *         is enabled and when conversion clock is active.
+  *         (not only core clock: this ADC has a dual clock domain)
+  * @rmtoll ISR      ADRDY          LL_ADC_ClearFlag_ADRDY
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_ADRDY(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_ADRDY);
+}
+
+/**
+  * @brief  Clear flag ADC group regular end of unitary conversion.
+  * @rmtoll ISR      EOC            LL_ADC_ClearFlag_EOC
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_EOC(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_EOC);
+}
+
+/**
+  * @brief  Clear flag ADC group regular end of sequence conversions.
+  * @rmtoll ISR      EOS            LL_ADC_ClearFlag_EOS
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_EOS(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_EOS);
+}
+
+/**
+  * @brief  Clear flag ADC group regular overrun.
+  * @rmtoll ISR      OVR            LL_ADC_ClearFlag_OVR
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_OVR(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_OVR);
+}
+
+/**
+  * @brief  Clear flag ADC group regular end of sampling phase.
+  * @rmtoll ISR      EOSMP          LL_ADC_ClearFlag_EOSMP
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_EOSMP(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_EOSMP);
+}
+
+/**
+  * @brief  Clear flag ADC group injected end of unitary conversion.
+  * @rmtoll ISR      JEOC           LL_ADC_ClearFlag_JEOC
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_JEOC(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_JEOC);
+}
+
+/**
+  * @brief  Clear flag ADC group injected end of sequence conversions.
+  * @rmtoll ISR      JEOS           LL_ADC_ClearFlag_JEOS
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_JEOS(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_JEOS);
+}
+
+/**
+  * @brief  Clear flag ADC group injected contexts queue overflow.
+  * @rmtoll ISR      JQOVF          LL_ADC_ClearFlag_JQOVF
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_JQOVF(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_JQOVF);
+}
+
+/**
+  * @brief  Clear flag ADC analog watchdog 1.
+  * @rmtoll ISR      AWD1           LL_ADC_ClearFlag_AWD1
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_AWD1(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_AWD1);
+}
+
+/**
+  * @brief  Clear flag ADC analog watchdog 2.
+  * @rmtoll ISR      AWD2           LL_ADC_ClearFlag_AWD2
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_AWD2(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_AWD2);
+}
+
+/**
+  * @brief  Clear flag ADC analog watchdog 3.
+  * @rmtoll ISR      AWD3           LL_ADC_ClearFlag_AWD3
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_ClearFlag_AWD3(ADC_TypeDef *ADCx)
+{
+  WRITE_REG(ADCx->ISR, LL_ADC_FLAG_AWD3);
+}
+
+/**
+  * @brief  Get flag multimode ADC ready of the ADC master.
+  * @rmtoll CSR      ADRDY_MST      LL_ADC_IsActiveFlag_MST_ADRDY
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_ADRDY(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_ADRDY_MST) == (LL_ADC_FLAG_ADRDY_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC ready of the ADC slave.
+  * @rmtoll CSR      ADRDY_SLV      LL_ADC_IsActiveFlag_SLV_ADRDY
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_ADRDY(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_ADRDY_SLV) == (LL_ADC_FLAG_ADRDY_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group regular end of unitary conversion of the ADC master.
+  * @rmtoll CSR      EOC_MST        LL_ADC_IsActiveFlag_MST_EOC
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_EOC(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_EOC_SLV) == (LL_ADC_FLAG_EOC_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group regular end of unitary conversion of the ADC slave.
+  * @rmtoll CSR      EOC_SLV        LL_ADC_IsActiveFlag_SLV_EOC
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_EOC(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_EOC_SLV) == (LL_ADC_FLAG_EOC_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group regular end of sequence conversions of the ADC master.
+  * @rmtoll CSR      EOS_MST        LL_ADC_IsActiveFlag_MST_EOS
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_EOS(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_EOS_MST) == (LL_ADC_FLAG_EOS_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group regular end of sequence conversions of the ADC slave.
+  * @rmtoll CSR      EOS_SLV        LL_ADC_IsActiveFlag_SLV_EOS
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_EOS(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_EOS_SLV) == (LL_ADC_FLAG_EOS_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group regular overrun of the ADC master.
+  * @rmtoll CSR      OVR_MST        LL_ADC_IsActiveFlag_MST_OVR
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_OVR(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_OVR_MST) == (LL_ADC_FLAG_OVR_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group regular overrun of the ADC slave.
+  * @rmtoll CSR      OVR_SLV        LL_ADC_IsActiveFlag_SLV_OVR
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_OVR(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_OVR_SLV) == (LL_ADC_FLAG_OVR_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group regular end of sampling of the ADC master.
+  * @rmtoll CSR      EOSMP_MST      LL_ADC_IsActiveFlag_MST_EOSMP
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_EOSMP(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_EOSMP_MST) == (LL_ADC_FLAG_EOSMP_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group regular end of sampling of the ADC slave.
+  * @rmtoll CSR      EOSMP_SLV      LL_ADC_IsActiveFlag_SLV_EOSMP
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_EOSMP(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_EOSMP_SLV) == (LL_ADC_FLAG_EOSMP_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group injected end of unitary conversion of the ADC master.
+  * @rmtoll CSR      JEOC_MST       LL_ADC_IsActiveFlag_MST_JEOC
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_JEOC(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_JEOC_MST) == (LL_ADC_FLAG_JEOC_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group injected end of unitary conversion of the ADC slave.
+  * @rmtoll CSR      JEOC_SLV       LL_ADC_IsActiveFlag_SLV_JEOC
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_JEOC(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_JEOC_SLV) == (LL_ADC_FLAG_JEOC_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group injected end of sequence conversions of the ADC master.
+  * @rmtoll CSR      JEOS_MST       LL_ADC_IsActiveFlag_MST_JEOS
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_JEOS(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_JEOS_MST) == (LL_ADC_FLAG_JEOS_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group injected end of sequence conversions of the ADC slave.
+  * @rmtoll CSR      JEOS_SLV       LL_ADC_IsActiveFlag_SLV_JEOS
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_JEOS(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_JEOS_SLV) == (LL_ADC_FLAG_JEOS_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group injected context queue overflow of the ADC master.
+  * @rmtoll CSR      JQOVF_MST      LL_ADC_IsActiveFlag_MST_JQOVF
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_JQOVF(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_JQOVF_MST) == (LL_ADC_FLAG_JQOVF_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC group injected context queue overflow of the ADC slave.
+  * @rmtoll CSR      JQOVF_SLV      LL_ADC_IsActiveFlag_SLV_JQOVF
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_JQOVF(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_JQOVF_SLV) == (LL_ADC_FLAG_JQOVF_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC analog watchdog 1 of the ADC master.
+  * @rmtoll CSR      AWD1_MST       LL_ADC_IsActiveFlag_MST_AWD1
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_AWD1(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_AWD1_MST) == (LL_ADC_FLAG_AWD1_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode analog watchdog 1 of the ADC slave.
+  * @rmtoll CSR      AWD1_SLV       LL_ADC_IsActiveFlag_SLV_AWD1
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_AWD1(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_AWD1_SLV) == (LL_ADC_FLAG_AWD1_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC analog watchdog 2 of the ADC master.
+  * @rmtoll CSR      AWD2_MST       LL_ADC_IsActiveFlag_MST_AWD2
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_AWD2(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_AWD2_MST) == (LL_ADC_FLAG_AWD2_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC analog watchdog 2 of the ADC slave.
+  * @rmtoll CSR      AWD2_SLV       LL_ADC_IsActiveFlag_SLV_AWD2
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_AWD2(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_AWD2_SLV) == (LL_ADC_FLAG_AWD2_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC analog watchdog 3 of the ADC master.
+  * @rmtoll CSR      AWD3_MST       LL_ADC_IsActiveFlag_MST_AWD3
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_MST_AWD3(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_AWD3_MST) == (LL_ADC_FLAG_AWD3_MST)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get flag multimode ADC analog watchdog 3 of the ADC slave.
+  * @rmtoll CSR      AWD3_SLV       LL_ADC_IsActiveFlag_SLV_AWD3
+  * @param  ADCxy_COMMON ADC common instance
+  *         (can be set directly from CMSIS definition or by using helper macro @ref __LL_ADC_COMMON_INSTANCE() )
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsActiveFlag_SLV_AWD3(const ADC_Common_TypeDef *ADCxy_COMMON)
+{
+  return ((READ_BIT(ADCxy_COMMON->CSR, LL_ADC_FLAG_AWD3_SLV) == (LL_ADC_FLAG_AWD3_SLV)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_LL_EF_IT_Management ADC IT management
+  * @{
+  */
+
+/**
+  * @brief  Enable ADC ready.
+  * @rmtoll IER      ADRDYIE        LL_ADC_EnableIT_ADRDY
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_ADRDY(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_ADRDY);
+}
+
+/**
+  * @brief  Enable interruption ADC group regular end of unitary conversion.
+  * @rmtoll IER      EOCIE          LL_ADC_EnableIT_EOC
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_EOC(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_EOC);
+}
+
+/**
+  * @brief  Enable interruption ADC group regular end of sequence conversions.
+  * @rmtoll IER      EOSIE          LL_ADC_EnableIT_EOS
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_EOS(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_EOS);
+}
+
+/**
+  * @brief  Enable ADC group regular interruption overrun.
+  * @rmtoll IER      OVRIE          LL_ADC_EnableIT_OVR
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_OVR(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_OVR);
+}
+
+/**
+  * @brief  Enable interruption ADC group regular end of sampling.
+  * @rmtoll IER      EOSMPIE        LL_ADC_EnableIT_EOSMP
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_EOSMP(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_EOSMP);
+}
+
+/**
+  * @brief  Enable interruption ADC group injected end of unitary conversion.
+  * @rmtoll IER      JEOCIE         LL_ADC_EnableIT_JEOC
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_JEOC(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_JEOC);
+}
+
+/**
+  * @brief  Enable interruption ADC group injected end of sequence conversions.
+  * @rmtoll IER      JEOSIE         LL_ADC_EnableIT_JEOS
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_JEOS(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_JEOS);
+}
+
+/**
+  * @brief  Enable interruption ADC group injected context queue overflow.
+  * @rmtoll IER      JQOVFIE        LL_ADC_EnableIT_JQOVF
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_JQOVF(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_JQOVF);
+}
+
+/**
+  * @brief  Enable interruption ADC analog watchdog 1.
+  * @rmtoll IER      AWD1IE         LL_ADC_EnableIT_AWD1
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_AWD1(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_AWD1);
+}
+
+/**
+  * @brief  Enable interruption ADC analog watchdog 2.
+  * @rmtoll IER      AWD2IE         LL_ADC_EnableIT_AWD2
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_AWD2(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_AWD2);
+}
+
+/**
+  * @brief  Enable interruption ADC analog watchdog 3.
+  * @rmtoll IER      AWD3IE         LL_ADC_EnableIT_AWD3
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_EnableIT_AWD3(ADC_TypeDef *ADCx)
+{
+  SET_BIT(ADCx->IER, LL_ADC_IT_AWD3);
+}
+
+/**
+  * @brief  Disable interruption ADC ready.
+  * @rmtoll IER      ADRDYIE        LL_ADC_DisableIT_ADRDY
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_ADRDY(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_ADRDY);
+}
+
+/**
+  * @brief  Disable interruption ADC group regular end of unitary conversion.
+  * @rmtoll IER      EOCIE          LL_ADC_DisableIT_EOC
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_EOC(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_EOC);
+}
+
+/**
+  * @brief  Disable interruption ADC group regular end of sequence conversions.
+  * @rmtoll IER      EOSIE          LL_ADC_DisableIT_EOS
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_EOS(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_EOS);
+}
+
+/**
+  * @brief  Disable interruption ADC group regular overrun.
+  * @rmtoll IER      OVRIE          LL_ADC_DisableIT_OVR
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_OVR(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_OVR);
+}
+
+/**
+  * @brief  Disable interruption ADC group regular end of sampling.
+  * @rmtoll IER      EOSMPIE        LL_ADC_DisableIT_EOSMP
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_EOSMP(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_EOSMP);
+}
+
+/**
+  * @brief  Disable interruption ADC group regular end of unitary conversion.
+  * @rmtoll IER      JEOCIE         LL_ADC_DisableIT_JEOC
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_JEOC(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_JEOC);
+}
+
+/**
+  * @brief  Disable interruption ADC group injected end of sequence conversions.
+  * @rmtoll IER      JEOSIE         LL_ADC_DisableIT_JEOS
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_JEOS(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_JEOS);
+}
+
+/**
+  * @brief  Disable interruption ADC group injected context queue overflow.
+  * @rmtoll IER      JQOVFIE        LL_ADC_DisableIT_JQOVF
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_JQOVF(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_JQOVF);
+}
+
+/**
+  * @brief  Disable interruption ADC analog watchdog 1.
+  * @rmtoll IER      AWD1IE         LL_ADC_DisableIT_AWD1
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_AWD1(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_AWD1);
+}
+
+/**
+  * @brief  Disable interruption ADC analog watchdog 2.
+  * @rmtoll IER      AWD2IE         LL_ADC_DisableIT_AWD2
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_AWD2(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_AWD2);
+}
+
+/**
+  * @brief  Disable interruption ADC analog watchdog 3.
+  * @rmtoll IER      AWD3IE         LL_ADC_DisableIT_AWD3
+  * @param  ADCx ADC instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_ADC_DisableIT_AWD3(ADC_TypeDef *ADCx)
+{
+  CLEAR_BIT(ADCx->IER, LL_ADC_IT_AWD3);
+}
+
+/**
+  * @brief  Get state of interruption ADC ready
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      ADRDYIE        LL_ADC_IsEnabledIT_ADRDY
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_ADRDY(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_ADRDY) == (LL_ADC_IT_ADRDY)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption ADC group regular end of unitary conversion
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      EOCIE          LL_ADC_IsEnabledIT_EOC
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOC(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_EOC) == (LL_ADC_IT_EOC)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption ADC group regular end of sequence conversions
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      EOSIE          LL_ADC_IsEnabledIT_EOS
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOS(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_EOS) == (LL_ADC_IT_EOS)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption ADC group regular overrun
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      OVRIE          LL_ADC_IsEnabledIT_OVR
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_OVR(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_OVR) == (LL_ADC_IT_OVR)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption ADC group regular end of sampling
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      EOSMPIE        LL_ADC_IsEnabledIT_EOSMP
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_EOSMP(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_EOSMP) == (LL_ADC_IT_EOSMP)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption ADC group injected end of unitary conversion
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      JEOCIE         LL_ADC_IsEnabledIT_JEOC
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JEOC(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_JEOC) == (LL_ADC_IT_JEOC)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption ADC group injected end of sequence conversions
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      JEOSIE         LL_ADC_IsEnabledIT_JEOS
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JEOS(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_JEOS) == (LL_ADC_IT_JEOS)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption ADC group injected context queue overflow interrupt state
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      JQOVFIE        LL_ADC_IsEnabledIT_JQOVF
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_JQOVF(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_JQOVF) == (LL_ADC_IT_JQOVF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption ADC analog watchdog 1
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      AWD1IE         LL_ADC_IsEnabledIT_AWD1
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD1(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_AWD1) == (LL_ADC_IT_AWD1)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption Get ADC analog watchdog 2
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      AWD2IE         LL_ADC_IsEnabledIT_AWD2
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD2(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_AWD2) == (LL_ADC_IT_AWD2)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get state of interruption Get ADC analog watchdog 3
+  *         (0: interrupt disabled, 1: interrupt enabled).
+  * @rmtoll IER      AWD3IE         LL_ADC_IsEnabledIT_AWD3
+  * @param  ADCx ADC instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_ADC_IsEnabledIT_AWD3(const ADC_TypeDef *ADCx)
+{
+  return ((READ_BIT(ADCx->IER, LL_ADC_IT_AWD3) == (LL_ADC_IT_AWD3)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup ADC_LL_EF_Init Initialization and de-initialization functions
+  * @{
+  */
+
+/* Initialization of some features of ADC common parameters and multimode */
+ErrorStatus LL_ADC_CommonDeInit(const ADC_Common_TypeDef *ADCxy_COMMON);
+ErrorStatus LL_ADC_CommonInit(ADC_Common_TypeDef *ADCxy_COMMON, LL_ADC_CommonInitTypeDef *ADC_CommonInitStruct);
+void        LL_ADC_CommonStructInit(LL_ADC_CommonInitTypeDef *ADC_CommonInitStruct);
+
+/* De-initialization of ADC instance, ADC group regular and ADC group injected */
+/* (availability of ADC group injected depends on STM32 families) */
+ErrorStatus LL_ADC_DeInit(ADC_TypeDef *ADCx);
+
+/* Initialization of some features of ADC instance */
+ErrorStatus LL_ADC_Init(ADC_TypeDef *ADCx, LL_ADC_InitTypeDef *ADC_InitStruct);
+void        LL_ADC_StructInit(LL_ADC_InitTypeDef *ADC_InitStruct);
+
+/* Initialization of some features of ADC instance and ADC group regular */
+ErrorStatus LL_ADC_REG_Init(ADC_TypeDef *ADCx, LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct);
+void        LL_ADC_REG_StructInit(LL_ADC_REG_InitTypeDef *ADC_REG_InitStruct);
+
+/* Initialization of some features of ADC instance and ADC group injected */
+ErrorStatus LL_ADC_INJ_Init(ADC_TypeDef *ADCx, LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct);
+void        LL_ADC_INJ_StructInit(LL_ADC_INJ_InitTypeDef *ADC_INJ_InitStruct);
+
+/**
+  * @}
+  */
+#endif /* USE_FULL_LL_DRIVER */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* ADC1 || ADC2 || ADC3 */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32H7xx_LL_ADC_H */
+

--- a/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_adc.c
+++ b/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_adc.c
@@ -1,0 +1,4057 @@
+/**
+  ******************************************************************************
+  * @file    stm32h7xx_hal_adc.c
+  * @author  MCD Application Team
+  * @brief   This file provides firmware functions to manage the following
+  *          functionalities of the Analog to Digital Converter (ADC)
+  *          peripheral:
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *          Other functions (extended functions) are available in file
+  *          "stm32h7xx_hal_adc_ex.c".
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  @verbatim
+  ==============================================================================
+                     ##### ADC peripheral features #####
+  ==============================================================================
+  [..]
+  (+) 16-bit, 14-bit, 12-bit, 10-bit or 8-bit configurable resolution.
+       Note: On devices STM32H72xx and STM32H73xx, these resolution are applicable to instances ADC1 and ADC2.
+       ADC3 is featuring resolutions 12-bit, 10-bit, 8-bit, 6-bit.
+
+  (+) Interrupt generation at the end of regular conversion and in case of
+      analog watchdog or overrun events.
+
+  (+) Single and continuous conversion modes.
+
+  (+) Scan mode for conversion of several channels sequentially.
+
+  (+) Data alignment with in-built data coherency.
+
+  (+) Programmable sampling time (channel wise)
+
+  (+) External trigger (timer or EXTI) with configurable polarity
+
+  (+) DMA request generation for transfer of conversions data of regular group.
+
+  (+) Configurable delay between conversions in Dual interleaved mode.
+
+  (+) ADC channels selectable single/differential input.
+
+  (+) ADC offset shared on 4 offset instances.
+  (+) ADC calibration
+
+  (+) ADC conversion of regular group.
+
+  (+) ADC supply requirements: 1.62 V to 3.6 V.
+
+  (+) ADC input range: from Vref- (connected to Vssa) to Vref+ (connected to
+      Vdda or to an external voltage reference).
+
+
+                     ##### How to use this driver #####
+  ==============================================================================
+    [..]
+
+     *** Configuration of top level parameters related to ADC ***
+     ============================================================
+     [..]
+
+    (#) Enable the ADC interface
+        (++) As prerequisite, ADC clock must be configured at RCC top level.
+
+        (++) Two clock settings are mandatory:
+             (+++) ADC clock (core clock, also possibly conversion clock).
+
+             (+++) ADC clock (conversions clock).
+                   Two possible clock sources: synchronous clock derived from AHB clock
+                   or asynchronous clock derived from system clock, the PLL2 or the PLL3 running up to 400MHz.
+
+             (+++) Example:
+                   Into HAL_ADC_MspInit() (recommended code location) or with
+                   other device clock parameters configuration:
+               (+++) __HAL_RCC_ADC_CLK_ENABLE();                  (mandatory)
+
+               RCC_ADCCLKSOURCE_PLL2 enable:                   (optional: if asynchronous clock selected)
+               (+++) RCC_PeriphClkInitTypeDef   RCC_PeriphClkInit;
+               (+++) PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC;
+               (+++) PeriphClkInit.AdcClockSelection    = RCC_ADCCLKSOURCE_PLL2;
+               (+++) HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
+
+        (++) ADC clock source and clock prescaler are configured at ADC level with
+             parameter "ClockPrescaler" using function HAL_ADC_Init().
+
+    (#) ADC pins configuration
+         (++) Enable the clock for the ADC GPIOs
+              using macro __HAL_RCC_GPIOx_CLK_ENABLE()
+         (++) Configure these ADC pins in analog mode
+              using function HAL_GPIO_Init()
+
+    (#) Optionally, in case of usage of ADC with interruptions:
+         (++) Configure the NVIC for ADC
+              using function HAL_NVIC_EnableIRQ(ADCx_IRQn)
+         (++) Insert the ADC interruption handler function HAL_ADC_IRQHandler()
+              into the function of corresponding ADC interruption vector
+              ADCx_IRQHandler().
+
+    (#) Optionally, in case of usage of DMA:
+         (++) Configure the DMA (DMA channel, mode normal or circular, ...)
+              using function HAL_DMA_Init().
+         (++) Configure the NVIC for DMA
+              using function HAL_NVIC_EnableIRQ(DMAx_Channelx_IRQn)
+         (++) Insert the ADC interruption handler function HAL_ADC_IRQHandler()
+              into the function of corresponding DMA interruption vector
+              DMAx_Channelx_IRQHandler().
+
+     *** Configuration of ADC, group regular, channels parameters ***
+     ================================================================
+     [..]
+
+    (#) Configure the ADC parameters (resolution, data alignment, ...)
+        and regular group parameters (conversion trigger, sequencer, ...)
+        using function HAL_ADC_Init().
+
+    (#) Configure the channels for regular group parameters (channel number,
+        channel rank into sequencer, ..., into regular group)
+        using function HAL_ADC_ConfigChannel().
+
+    (#) Optionally, configure the analog watchdog parameters (channels
+        monitored, thresholds, ...)
+        using function HAL_ADC_AnalogWDGConfig().
+
+     *** Execution of ADC conversions ***
+     ====================================
+     [..]
+
+    (#) Optionally, perform an automatic ADC calibration to improve the
+        conversion accuracy
+        using function HAL_ADCEx_Calibration_Start().
+
+    (#) ADC driver can be used among three modes: polling, interruption,
+        transfer by DMA.
+
+        (++) ADC conversion by polling:
+          (+++) Activate the ADC peripheral and start conversions
+                using function HAL_ADC_Start()
+          (+++) Wait for ADC conversion completion
+                using function HAL_ADC_PollForConversion()
+          (+++) Retrieve conversion results
+                using function HAL_ADC_GetValue()
+          (+++) Stop conversion and disable the ADC peripheral
+                using function HAL_ADC_Stop()
+
+        (++) ADC conversion by interruption:
+          (+++) Activate the ADC peripheral and start conversions
+                using function HAL_ADC_Start_IT()
+          (+++) Wait for ADC conversion completion by call of function
+                HAL_ADC_ConvCpltCallback()
+                (this function must be implemented in user program)
+          (+++) Retrieve conversion results
+                using function HAL_ADC_GetValue()
+          (+++) Stop conversion and disable the ADC peripheral
+                using function HAL_ADC_Stop_IT()
+
+        (++) ADC conversion with transfer by DMA:
+          (+++) Activate the ADC peripheral and start conversions
+                using function HAL_ADC_Start_DMA()
+          (+++) Wait for ADC conversion completion by call of function
+                HAL_ADC_ConvCpltCallback() or HAL_ADC_ConvHalfCpltCallback()
+                (these functions must be implemented in user program)
+          (+++) Conversion results are automatically transferred by DMA into
+                destination variable address.
+          (+++) Stop conversion and disable the ADC peripheral
+                using function HAL_ADC_Stop_DMA()
+
+     [..]
+
+    (@) Callback functions must be implemented in user program:
+      (+@) HAL_ADC_ErrorCallback()
+      (+@) HAL_ADC_LevelOutOfWindowCallback() (callback of analog watchdog)
+      (+@) HAL_ADC_ConvCpltCallback()
+      (+@) HAL_ADC_ConvHalfCpltCallback
+
+     *** Deinitialization of ADC ***
+     ============================================================
+     [..]
+
+    (#) Disable the ADC interface
+      (++) ADC clock can be hard reset and disabled at RCC top level.
+        (++) Hard reset of ADC peripherals
+             using macro __HAL_RCC_ADCx_FORCE_RESET(), __HAL_RCC_ADCx_RELEASE_RESET().
+        (++) ADC clock disable
+             using the equivalent macro/functions as configuration step.
+             (+++) Example:
+                   Into HAL_ADC_MspDeInit() (recommended code location) or with
+                   other device clock parameters configuration:
+               (+++) __HAL_RCC_ADC_CLK_DISABLE();                  (if not used anymore)
+               RCC_ADCCLKSOURCE_CLKP restore:                      (optional)
+               (+++) RCC_PeriphClkInitTypeDef   RCC_PeriphClkInit;
+               (+++) PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_ADC;
+               (+++) PeriphClkInit.AdcClockSelection    = RCC_ADCCLKSOURCE_CLKP;
+               (+++) HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
+
+    (#) ADC pins configuration
+         (++) Disable the clock for the ADC GPIOs
+              using macro __HAL_RCC_GPIOx_CLK_DISABLE()
+
+    (#) Optionally, in case of usage of ADC with interruptions:
+         (++) Disable the NVIC for ADC
+              using function HAL_NVIC_EnableIRQ(ADCx_IRQn)
+
+    (#) Optionally, in case of usage of DMA:
+         (++) Deinitialize the DMA
+              using function HAL_DMA_Init().
+         (++) Disable the NVIC for DMA
+              using function HAL_NVIC_EnableIRQ(DMAx_Channelx_IRQn)
+
+    [..]
+
+    *** Callback registration ***
+    =============================================
+    [..]
+
+     The compilation flag USE_HAL_ADC_REGISTER_CALLBACKS, when set to 1,
+     allows the user to configure dynamically the driver callbacks.
+     Use Functions HAL_ADC_RegisterCallback()
+     to register an interrupt callback.
+    [..]
+
+     Function HAL_ADC_RegisterCallback() allows to register following callbacks:
+       (+) ConvCpltCallback               : ADC conversion complete callback
+       (+) ConvHalfCpltCallback           : ADC conversion DMA half-transfer callback
+       (+) LevelOutOfWindowCallback       : ADC analog watchdog 1 callback
+       (+) ErrorCallback                  : ADC error callback
+       (+) InjectedConvCpltCallback       : ADC group injected conversion complete callback
+       (+) InjectedQueueOverflowCallback  : ADC group injected context queue overflow callback
+       (+) LevelOutOfWindow2Callback      : ADC analog watchdog 2 callback
+       (+) LevelOutOfWindow3Callback      : ADC analog watchdog 3 callback
+       (+) EndOfSamplingCallback          : ADC end of sampling callback
+       (+) MspInitCallback                : ADC Msp Init callback
+       (+) MspDeInitCallback              : ADC Msp DeInit callback
+     This function takes as parameters the HAL peripheral handle, the Callback ID
+     and a pointer to the user callback function.
+    [..]
+
+     Use function HAL_ADC_UnRegisterCallback to reset a callback to the default
+     weak function.
+    [..]
+
+     HAL_ADC_UnRegisterCallback takes as parameters the HAL peripheral handle,
+     and the Callback ID.
+     This function allows to reset following callbacks:
+       (+) ConvCpltCallback               : ADC conversion complete callback
+       (+) ConvHalfCpltCallback           : ADC conversion DMA half-transfer callback
+       (+) LevelOutOfWindowCallback       : ADC analog watchdog 1 callback
+       (+) ErrorCallback                  : ADC error callback
+       (+) InjectedConvCpltCallback       : ADC group injected conversion complete callback
+       (+) InjectedQueueOverflowCallback  : ADC group injected context queue overflow callback
+       (+) LevelOutOfWindow2Callback      : ADC analog watchdog 2 callback
+       (+) LevelOutOfWindow3Callback      : ADC analog watchdog 3 callback
+       (+) EndOfSamplingCallback          : ADC end of sampling callback
+       (+) MspInitCallback                : ADC Msp Init callback
+       (+) MspDeInitCallback              : ADC Msp DeInit callback
+     [..]
+
+     By default, after the HAL_ADC_Init() and when the state is HAL_ADC_STATE_RESET
+     all callbacks are set to the corresponding weak functions:
+     examples HAL_ADC_ConvCpltCallback(), HAL_ADC_ErrorCallback().
+     Exception done for MspInit and MspDeInit functions that are
+     reset to the legacy weak functions in the HAL_ADC_Init()/ HAL_ADC_DeInit() only when
+     these callbacks are null (not registered beforehand).
+    [..]
+
+     If MspInit or MspDeInit are not null, the HAL_ADC_Init()/ HAL_ADC_DeInit()
+     keep and use the user MspInit/MspDeInit callbacks (registered beforehand) whatever the state.
+     [..]
+
+     Callbacks can be registered/unregistered in HAL_ADC_STATE_READY state only.
+     Exception done MspInit/MspDeInit functions that can be registered/unregistered
+     in HAL_ADC_STATE_READY or HAL_ADC_STATE_RESET state,
+     thus registered (user) MspInit/DeInit callbacks can be used during the Init/DeInit.
+    [..]
+
+     Then, the user first registers the MspInit/MspDeInit user callbacks
+     using HAL_ADC_RegisterCallback() before calling HAL_ADC_DeInit()
+     or HAL_ADC_Init() function.
+     [..]
+
+     When the compilation flag USE_HAL_ADC_REGISTER_CALLBACKS is set to 0 or
+     not defined, the callback registration feature is not available and all callbacks
+     are set to the corresponding weak functions.
+
+  @endverbatim
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32h7xx_hal.h"
+
+/** @addtogroup STM32H7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ADC ADC
+  * @brief ADC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+
+/** @defgroup ADC_Private_Constants ADC Private Constants
+  * @{
+  */
+#define ADC_CFGR_FIELDS_1  ((uint32_t)(ADC_CFGR_RES    |\
+                                       ADC_CFGR_CONT   | ADC_CFGR_OVRMOD  |\
+                                       ADC_CFGR_DISCEN | ADC_CFGR_DISCNUM |\
+                                       ADC_CFGR_EXTEN  | ADC_CFGR_EXTSEL)) /*!< ADC_CFGR fields of parameters that can be updated
+                                                                                  when no regular conversion is on-going */
+
+#if defined(ADC_VER_V5_V90)
+#define ADC3_CFGR_FIELDS_1  ((ADC3_CFGR_RES    | ADC3_CFGR_ALIGN   |\
+                             ADC_CFGR_CONT   | ADC_CFGR_OVRMOD  |\
+                             ADC_CFGR_DISCEN | ADC_CFGR_DISCNUM |\
+                             ADC_CFGR_EXTEN  | ADC_CFGR_EXTSEL))   /*!< ADC_CFGR fields of parameters that can be updated
+                                                                        when no regular conversion is on-going */
+#endif
+
+#define ADC_CFGR2_FIELDS  ((uint32_t)(ADC_CFGR2_ROVSE | ADC_CFGR2_OVSR  |\
+                                       ADC_CFGR2_OVSS | ADC_CFGR2_TROVS |\
+                                       ADC_CFGR2_ROVSM))                     /*!< ADC_CFGR2 fields of parameters that can be updated when no conversion
+                                                                                 (neither regular nor injected) is on-going  */
+
+/* Timeout values for ADC operations (enable settling time,                   */
+/*   disable settling time, ...).                                             */
+/*   Values defined to be higher than worst cases: low clock frequency,       */
+/*   maximum prescalers.                                                      */
+#define ADC_ENABLE_TIMEOUT              (2UL)    /*!< ADC enable time-out value  */
+#define ADC_DISABLE_TIMEOUT             (2UL)    /*!< ADC disable time-out value */
+
+/* Timeout to wait for current conversion on going to be completed.           */
+/* Timeout fixed to worst case, for 1 channel.                                */
+/*   - maximum sampling time (830.5 adc_clk)                                  */
+/*   - ADC resolution (Tsar 16 bits= 16.5 adc_clk)                            */
+/*   - ADC clock with prescaler 256                                           */
+/*     823 * 256 = 210688 clock cycles max                                    */
+/* Unit: cycles of CPU clock.                                                 */
+#define ADC_CONVERSION_TIME_MAX_CPU_CYCLES (210688UL)  /*!< ADC conversion completion time-out value */
+
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup ADC_Exported_Functions ADC Exported Functions
+  * @{
+  */
+
+/** @defgroup ADC_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @brief    ADC Initialization and Configuration functions
+  *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Initialize and configure the ADC.
+      (+) De-initialize the ADC.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initialize the ADC peripheral and regular group according to
+  *         parameters specified in structure "ADC_InitTypeDef".
+  * @note   As prerequisite, ADC clock must be configured at RCC top level
+  *         (refer to description of RCC configuration for ADC
+  *         in header of this file).
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes the ADC MSP (HAL_ADC_MspInit()) only when
+  *         coming from ADC state reset. Following calls to this function can
+  *         be used to reconfigure some parameters of ADC_InitTypeDef
+  *         structure on the fly, without modifying MSP configuration. If ADC
+  *         MSP has to be modified again, HAL_ADC_DeInit() must be called
+  *         before HAL_ADC_Init().
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure
+  *         "ADC_InitTypeDef".
+  * @note   This function configures the ADC within 2 scopes: scope of entire
+  *         ADC and scope of regular group. For parameters details, see comments
+  *         of structure "ADC_InitTypeDef".
+  * @note   Parameters related to common ADC registers (ADC clock mode) are set
+  *         only if all ADCs are disabled.
+  *         If this is not the case, these common parameters setting are
+  *         bypassed without error reporting: it can be the intended behaviour in
+  *         case of update of a parameter of ADC_InitTypeDef on the fly,
+  *         without  disabling the other ADCs.
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Init(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tmpCFGR;
+  uint32_t tmp_adc_reg_is_conversion_on_going;
+  __IO uint32_t wait_loop_index = 0UL;
+  uint32_t tmp_adc_is_conversion_on_going_regular;
+  uint32_t tmp_adc_is_conversion_on_going_injected;
+
+  /* Check ADC handle */
+  if (hadc == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CLOCKPRESCALER(hadc->Init.ClockPrescaler));
+  assert_param(IS_ADC_RESOLUTION(hadc->Init.Resolution));
+  assert_param(IS_ADC_SCAN_MODE(hadc->Init.ScanConvMode));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXTTRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+  assert_param(IS_ADC_EXTTRIG(hadc->Init.ExternalTrigConv));
+  assert_param(IS_ADC_CONVERSIONDATAMGT(hadc->Init.ConversionDataManagement));
+  assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
+  assert_param(IS_ADC_OVERRUN(hadc->Init.Overrun));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.LowPowerAutoWait));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.OversamplingMode));
+
+  if (hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  {
+    assert_param(IS_ADC_REGULAR_NB_CONV(hadc->Init.NbrOfConversion));
+    assert_param(IS_FUNCTIONAL_STATE(hadc->Init.DiscontinuousConvMode));
+
+    if (hadc->Init.DiscontinuousConvMode == ENABLE)
+    {
+      assert_param(IS_ADC_REGULAR_DISCONT_NUMBER(hadc->Init.NbrOfDiscConversion));
+    }
+  }
+
+  /* DISCEN and CONT bits cannot be set at the same time */
+  assert_param(!((hadc->Init.DiscontinuousConvMode == ENABLE) && (hadc->Init.ContinuousConvMode == ENABLE)));
+
+  /* Actions performed only if ADC is coming from state reset:                */
+  /* - Initialization of ADC MSP                                              */
+  if (hadc->State == HAL_ADC_STATE_RESET)
+  {
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    /* Init the ADC Callback settings */
+    hadc->ConvCpltCallback              = HAL_ADC_ConvCpltCallback;                 /* Legacy weak callback */
+    hadc->ConvHalfCpltCallback          = HAL_ADC_ConvHalfCpltCallback;             /* Legacy weak callback */
+    hadc->LevelOutOfWindowCallback      = HAL_ADC_LevelOutOfWindowCallback;         /* Legacy weak callback */
+    hadc->ErrorCallback                 = HAL_ADC_ErrorCallback;                    /* Legacy weak callback */
+    hadc->InjectedConvCpltCallback      = HAL_ADCEx_InjectedConvCpltCallback;       /* Legacy weak callback */
+    hadc->InjectedQueueOverflowCallback = HAL_ADCEx_InjectedQueueOverflowCallback;  /* Legacy weak callback */
+    hadc->LevelOutOfWindow2Callback     = HAL_ADCEx_LevelOutOfWindow2Callback;      /* Legacy weak callback */
+    hadc->LevelOutOfWindow3Callback     = HAL_ADCEx_LevelOutOfWindow3Callback;      /* Legacy weak callback */
+    hadc->EndOfSamplingCallback         = HAL_ADCEx_EndOfSamplingCallback;          /* Legacy weak callback */
+
+    if (hadc->MspInitCallback == NULL)
+    {
+      hadc->MspInitCallback = HAL_ADC_MspInit; /* Legacy weak MspInit  */
+    }
+
+    /* Init the low level hardware */
+    hadc->MspInitCallback(hadc);
+#else
+    /* Init the low level hardware */
+    HAL_ADC_MspInit(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+    /* Set ADC error code to none */
+    ADC_CLEAR_ERRORCODE(hadc);
+
+    /* Initialize Lock */
+    hadc->Lock = HAL_UNLOCKED;
+  }
+
+  /* - Exit from deep-power-down mode and ADC voltage regulator enable        */
+  if (LL_ADC_IsDeepPowerDownEnabled(hadc->Instance) != 0UL)
+  {
+    /* Disable ADC deep power down mode */
+    LL_ADC_DisableDeepPowerDown(hadc->Instance);
+
+    /* System was in deep power down mode, calibration must
+     be relaunched or a previously saved calibration factor
+     re-applied once the ADC voltage regulator is enabled */
+  }
+
+  if (LL_ADC_IsInternalRegulatorEnabled(hadc->Instance) == 0UL)
+  {
+    /* Enable ADC internal voltage regulator */
+    LL_ADC_EnableInternalRegulator(hadc->Instance);
+
+    /* Note: Variable divided by 2 to compensate partially              */
+    /*       CPU processing cycles, scaling in us split to not          */
+    /*       exceed 32 bits register capacity and handle low frequency. */
+    wait_loop_index = ((LL_ADC_DELAY_INTERNAL_REGUL_STAB_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
+    while (wait_loop_index != 0UL)
+    {
+      wait_loop_index--;
+    }
+  }
+
+  /* Verification that ADC voltage regulator is correctly enabled, whether    */
+  /* or not ADC is coming from state reset (if any potential problem of       */
+  /* clocking, voltage regulator would not be enabled).                       */
+  if (LL_ADC_IsInternalRegulatorEnabled(hadc->Instance) == 0UL)
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+    /* Set ADC error code to ADC peripheral internal error */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  /* Configuration of ADC parameters if previous preliminary actions are      */
+  /* correctly completed and if there is no conversion on going on regular    */
+  /* group (ADC may already be enabled at this point if HAL_ADC_Init() is     */
+  /* called to update a parameter on the fly).                                */
+  tmp_adc_reg_is_conversion_on_going = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+
+  if (((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) == 0UL)
+      && (tmp_adc_reg_is_conversion_on_going == 0UL)
+     )
+  {
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY,
+                      HAL_ADC_STATE_BUSY_INTERNAL);
+
+    /* Configuration of common ADC parameters                                 */
+
+    /* Parameters update conditioned to ADC state:                            */
+    /* Parameters that can be updated only when ADC is disabled:              */
+    /*  - clock configuration                                                 */
+    if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+    {
+      if (__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) == 0UL)
+      {
+        /* Reset configuration of ADC common register CCR:                      */
+        /*                                                                      */
+        /*   - ADC clock mode and ACC prescaler (CKMODE and PRESC bits)are set  */
+        /*     according to adc->Init.ClockPrescaler. It selects the clock      */
+        /*    source and sets the clock division factor.                        */
+        /*                                                                      */
+        /* Some parameters of this register are not reset, since they are set   */
+        /* by other functions and must be kept in case of usage of this         */
+        /* function on the fly (update of a parameter of ADC_InitTypeDef        */
+        /* without needing to reconfigure all other ADC groups/channels         */
+        /* parameters):                                                         */
+        /*   - when multimode feature is available, multimode-related           */
+        /*     parameters: MDMA, DMACFG, DELAY, DUAL (set by API                */
+        /*     HAL_ADCEx_MultiModeConfigChannel() )                             */
+        /*   - internal measurement paths: Vbat, temperature sensor, Vref       */
+        /*     (set into HAL_ADC_ConfigChannel() or                             */
+        /*     HAL_ADCEx_InjectedConfigChannel() )                              */
+        LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(hadc->Instance), hadc->Init.ClockPrescaler);
+      }
+    }
+
+    /* Configuration of ADC:                                                  */
+    /*  - resolution                               Init.Resolution            */
+    /*  - external trigger to start conversion     Init.ExternalTrigConv      */
+    /*  - external trigger polarity                Init.ExternalTrigConvEdge  */
+    /*  - continuous conversion mode               Init.ContinuousConvMode    */
+    /*  - overrun                                  Init.Overrun               */
+    /*  - discontinuous mode                       Init.DiscontinuousConvMode */
+    /*  - discontinuous mode channel count         Init.NbrOfDiscConversion   */
+#if defined(ADC_VER_V5_3)
+
+    tmpCFGR  = (ADC_CFGR_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode)           |
+                hadc->Init.Overrun                                                    |
+                hadc->Init.Resolution                                                 |
+                ADC_CFGR_REG_DISCONTINUOUS((uint32_t)hadc->Init.DiscontinuousConvMode));
+
+#elif defined(ADC_VER_V5_V90)
+    if (hadc->Instance == ADC3)
+    {
+      tmpCFGR  = (ADC_CFGR_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode)         |
+                  hadc->Init.Overrun                                                     |
+                  hadc->Init.DataAlign                                                   |
+                  ((__LL_ADC12_RESOLUTION_TO_ADC3(hadc->Init.Resolution)  & (ADC_CFGR_RES_1 | ADC_CFGR_RES_0)) << 1UL)                                                   |
+                  ADC_CFGR_REG_DISCONTINUOUS((uint32_t)hadc->Init.DiscontinuousConvMode));
+    }
+    else
+    {
+      tmpCFGR  = (ADC_CFGR_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode)          |
+                  hadc->Init.Overrun                                                    |
+                  hadc->Init.Resolution                                                 |
+                  ADC_CFGR_REG_DISCONTINUOUS((uint32_t)hadc->Init.DiscontinuousConvMode));
+    }
+
+#else
+
+    if ((HAL_GetREVID() > REV_ID_Y) && (ADC_RESOLUTION_8B == hadc->Init.Resolution))
+    {
+      /* for STM32H7 silicon rev.B and above , ADC_CFGR_RES value for 8bits resolution is : b111 */
+      tmpCFGR  = (ADC_CFGR_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode)          |
+                  hadc->Init.Overrun                                                    |
+                  hadc->Init.Resolution | (ADC_CFGR_RES_1 | ADC_CFGR_RES_0)                |
+                  ADC_CFGR_REG_DISCONTINUOUS((uint32_t)hadc->Init.DiscontinuousConvMode));
+    }
+    else
+    {
+
+      tmpCFGR  = (ADC_CFGR_CONTINUOUS((uint32_t)hadc->Init.ContinuousConvMode)          |
+                  hadc->Init.Overrun                                                    |
+                  hadc->Init.Resolution                                                 |
+                  ADC_CFGR_REG_DISCONTINUOUS((uint32_t)hadc->Init.DiscontinuousConvMode));
+    }
+
+#endif /* ADC_VER_V5_3 */
+
+    if (hadc->Init.DiscontinuousConvMode == ENABLE)
+    {
+      tmpCFGR |= ADC_CFGR_DISCONTINUOUS_NUM(hadc->Init.NbrOfDiscConversion);
+    }
+
+    /* Enable external trigger if trigger selection is different of software  */
+    /* start.                                                                 */
+    /* Note: This configuration keeps the hardware feature of parameter       */
+    /*       ExternalTrigConvEdge "trigger edge none" equivalent to           */
+    /*       software start.                                                  */
+    if (hadc->Init.ExternalTrigConv != ADC_SOFTWARE_START)
+    {
+      tmpCFGR |= ((hadc->Init.ExternalTrigConv & ADC_CFGR_EXTSEL)
+                  | hadc->Init.ExternalTrigConvEdge
+                 );
+    }
+
+
+#if defined(ADC_VER_V5_V90)
+    if (hadc->Instance == ADC3)
+    {
+      /* Update Configuration Register CFGR */
+      MODIFY_REG(hadc->Instance->CFGR, ADC3_CFGR_FIELDS_1, tmpCFGR);
+      /* Configuration of sampling mode */
+      MODIFY_REG(hadc->Instance->CFGR2, ADC3_CFGR2_BULB | ADC3_CFGR2_SMPTRIG, hadc->Init.SamplingMode);
+    }
+    else
+    {
+      /* Update Configuration Register CFGR */
+      MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_FIELDS_1, tmpCFGR);
+    }
+#else
+    /* Update Configuration Register CFGR */
+    MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_FIELDS_1, tmpCFGR);
+#endif
+
+    /* Parameters update conditioned to ADC state:                            */
+    /* Parameters that can be updated when ADC is disabled or enabled without */
+    /* conversion on going on regular and injected groups:                    */
+    /*  - Conversion data management      Init.ConversionDataManagement       */
+    /*  - LowPowerAutoWait feature        Init.LowPowerAutoWait               */
+    /*  - Oversampling parameters         Init.Oversampling                   */
+    tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+    tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
+    if ((tmp_adc_is_conversion_on_going_regular == 0UL)
+        && (tmp_adc_is_conversion_on_going_injected == 0UL)
+       )
+    {
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance == ADC3)
+      {
+        tmpCFGR = (
+                    ADC_CFGR_AUTOWAIT((uint32_t)hadc->Init.LowPowerAutoWait)        |
+                    ADC3_CFGR_DMACONTREQ((uint32_t)hadc->Init.DMAContinuousRequests));
+      }
+      else
+      {
+        tmpCFGR = (
+                    ADC_CFGR_AUTOWAIT((uint32_t)hadc->Init.LowPowerAutoWait)        |
+                    ADC_CFGR_DMACONTREQ((uint32_t)hadc->Init.ConversionDataManagement));
+      }
+#else
+      tmpCFGR = (
+                  ADC_CFGR_AUTOWAIT((uint32_t)hadc->Init.LowPowerAutoWait)        |
+                  ADC_CFGR_DMACONTREQ((uint32_t)hadc->Init.ConversionDataManagement));
+#endif
+
+      MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_FIELDS_2, tmpCFGR);
+
+      if (hadc->Init.OversamplingMode == ENABLE)
+      {
+#if defined(ADC_VER_V5_V90)
+        if (hadc->Instance == ADC3)
+        {
+          assert_param(IS_ADC_OVERSAMPLING_RATIO_ADC3(hadc->Init.Oversampling.Ratio));
+        }
+        else
+        {
+          assert_param(IS_ADC_OVERSAMPLING_RATIO(hadc->Init.Oversampling.Ratio));
+        }
+#else
+        assert_param(IS_ADC_OVERSAMPLING_RATIO(hadc->Init.Oversampling.Ratio));
+#endif
+        assert_param(IS_ADC_RIGHT_BIT_SHIFT(hadc->Init.Oversampling.RightBitShift));
+        assert_param(IS_ADC_TRIGGERED_OVERSAMPLING_MODE(hadc->Init.Oversampling.TriggeredMode));
+        assert_param(IS_ADC_REGOVERSAMPLING_MODE(hadc->Init.Oversampling.OversamplingStopReset));
+
+        if ((hadc->Init.ExternalTrigConv == ADC_SOFTWARE_START)
+            || (hadc->Init.ExternalTrigConvEdge == ADC_EXTERNALTRIGCONVEDGE_NONE))
+        {
+          /* Multi trigger is not applicable to software-triggered conversions */
+          assert_param((hadc->Init.Oversampling.TriggeredMode == ADC_TRIGGEREDMODE_SINGLE_TRIGGER));
+        }
+
+#if defined(ADC_VER_V5_V90)
+        if (hadc->Instance == ADC3)
+        {
+          /* Configuration of Oversampler:                                      */
+          /*  - Oversampling Ratio                                              */
+          /*  - Right bit shift                                                 */
+          /*  - Triggered mode                                                  */
+          /*  - Oversampling mode (continued/resumed)                           */
+          MODIFY_REG(hadc->Instance->CFGR2,
+                     ADC_CFGR2_OVSR  |
+                     ADC_CFGR2_OVSS  |
+                     ADC_CFGR2_TROVS |
+                     ADC_CFGR2_ROVSM,
+                     ADC_CFGR2_ROVSE                       |
+                     hadc->Init.Oversampling.Ratio         |
+                     hadc->Init.Oversampling.RightBitShift |
+                     hadc->Init.Oversampling.TriggeredMode |
+                     hadc->Init.Oversampling.OversamplingStopReset
+                    );
+        }
+        else
+        {
+
+          /* Configuration of Oversampler:                                       */
+          /*  - Oversampling Ratio                                               */
+          /*  - Right bit shift                                                  */
+          /*  - Left bit shift                                                   */
+          /*  - Triggered mode                                                   */
+          /*  - Oversampling mode (continued/resumed)                            */
+          MODIFY_REG(hadc->Instance->CFGR2, ADC_CFGR2_FIELDS,
+                     ADC_CFGR2_ROVSE                       |
+                     ((hadc->Init.Oversampling.Ratio - 1UL)  << ADC_CFGR2_OVSR_Pos) |
+                     hadc->Init.Oversampling.RightBitShift |
+                     hadc->Init.Oversampling.TriggeredMode |
+                     hadc->Init.Oversampling.OversamplingStopReset);
+        }
+#else
+        /* Configuration of Oversampler:                                       */
+        /*  - Oversampling Ratio                                               */
+        /*  - Right bit shift                                                  */
+        /*  - Left bit shift                                                   */
+        /*  - Triggered mode                                                   */
+        /*  - Oversampling mode (continued/resumed)                            */
+        MODIFY_REG(hadc->Instance->CFGR2, ADC_CFGR2_FIELDS,
+                   ADC_CFGR2_ROVSE                       |
+                   ((hadc->Init.Oversampling.Ratio - 1UL) << ADC_CFGR2_OVSR_Pos) |
+                   hadc->Init.Oversampling.RightBitShift |
+                   hadc->Init.Oversampling.TriggeredMode |
+                   hadc->Init.Oversampling.OversamplingStopReset);
+#endif
+
+      }
+      else
+      {
+        /* Disable ADC oversampling scope on ADC group regular */
+        CLEAR_BIT(hadc->Instance->CFGR2, ADC_CFGR2_ROVSE);
+      }
+
+      /* Set the LeftShift parameter: it is applied to the final result with or without oversampling */
+      MODIFY_REG(hadc->Instance->CFGR2, ADC_CFGR2_LSHIFT, hadc->Init.LeftBitShift);
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance != ADC3)
+      {
+        /* Configure the BOOST Mode */
+        ADC_ConfigureBoostMode(hadc);
+      }
+#else
+      /* Configure the BOOST Mode */
+      ADC_ConfigureBoostMode(hadc);
+#endif
+    }
+
+    /* Configuration of regular group sequencer:                              */
+    /* - if scan mode is disabled, regular channels sequence length is set to */
+    /*   0x00: 1 channel converted (channel on regular rank 1)                */
+    /*   Parameter "NbrOfConversion" is discarded.                            */
+    /*   Note: Scan mode is not present by hardware on this device, but       */
+    /*   emulated by software for alignment over all STM32 devices.           */
+    /* - if scan mode is enabled, regular channels sequence length is set to  */
+    /*   parameter "NbrOfConversion".                                         */
+
+    if (hadc->Init.ScanConvMode == ADC_SCAN_ENABLE)
+    {
+      /* Set number of ranks in regular group sequencer */
+      MODIFY_REG(hadc->Instance->SQR1, ADC_SQR1_L, (hadc->Init.NbrOfConversion - (uint8_t)1));
+    }
+    else
+    {
+      CLEAR_BIT(hadc->Instance->SQR1, ADC_SQR1_L);
+    }
+
+    /* Initialize the ADC state */
+    /* Clear HAL_ADC_STATE_BUSY_INTERNAL bit, set HAL_ADC_STATE_READY bit */
+    ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL, HAL_ADC_STATE_READY);
+  }
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Deinitialize the ADC peripheral registers to their default reset
+  *         values, with deinitialization of the ADC MSP.
+  * @note   For devices with several ADCs: reset of ADC common registers is done
+  *         only if all ADCs sharing the same common group are disabled.
+  *         (function "HAL_ADC_MspDeInit()" is also called under the same conditions:
+  *         all ADC instances use the same core clock at RCC level, disabling
+  *         the core clock reset all ADC instances).
+  *         If this is not the case, reset of these common parameters reset is
+  *         bypassed without error reporting: it can be the intended behavior in
+  *         case of reset of a single ADC while the other ADCs sharing the same
+  *         common group is still running.
+  * @note   By default, HAL_ADC_DeInit() set ADC in mode deep power-down:
+  *         this saves more power by reducing leakage currents
+  *         and is particularly interesting before entering MCU low-power modes.
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_DeInit(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check ADC handle */
+  if (hadc == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Set ADC state */
+  SET_BIT(hadc->State, HAL_ADC_STATE_BUSY_INTERNAL);
+
+  /* Stop potential conversion on going */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped            */
+  /* Flush register JSQR: reset the queue sequencer when injected             */
+  /* queue sequencer is enabled and ADC disabled.                             */
+  /* The software and hardware triggers of the injected sequence are both     */
+  /* internally disabled just after the completion of the last valid          */
+  /* injected sequence.                                                       */
+  SET_BIT(hadc->Instance->CFGR, ADC_CFGR_JQM);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Disable the ADC peripheral */
+    tmp_hal_status = ADC_Disable(hadc);
+
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Change ADC state */
+      hadc->State = HAL_ADC_STATE_READY;
+    }
+  }
+
+  /* Note: HAL ADC deInit is done independently of ADC conversion stop        */
+  /*       and disable return status. In case of status fail, attempt to      */
+  /*       perform deinitialization anyway and it is up user code in          */
+  /*       in HAL_ADC_MspDeInit() to reset the ADC peripheral using           */
+  /*       system RCC hard reset.                                             */
+
+  /* ========== Reset ADC registers ========== */
+  /* Reset register IER */
+  __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_AWD3  | ADC_IT_AWD2 | ADC_IT_AWD1 |
+                              ADC_IT_JQOVF | ADC_IT_OVR  |
+                              ADC_IT_JEOS  | ADC_IT_JEOC |
+                              ADC_IT_EOS   | ADC_IT_EOC  |
+                              ADC_IT_EOSMP | ADC_IT_RDY));
+
+  /* Reset register ISR */
+  __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_AWD3  | ADC_FLAG_AWD2 | ADC_FLAG_AWD1 |
+                              ADC_FLAG_JQOVF | ADC_FLAG_OVR  |
+                              ADC_FLAG_JEOS  | ADC_FLAG_JEOC |
+                              ADC_FLAG_EOS   | ADC_FLAG_EOC  |
+                              ADC_FLAG_EOSMP | ADC_FLAG_RDY));
+
+  /* Reset register CR */
+  /* Bits ADC_CR_JADSTP, ADC_CR_ADSTP, ADC_CR_JADSTART, ADC_CR_ADSTART,
+     ADC_CR_ADCAL, ADC_CR_ADDIS and ADC_CR_ADEN are in access mode "read-set":
+     no direct reset applicable.
+     Update CR register to reset value where doable by software */
+  CLEAR_BIT(hadc->Instance->CR, ADC_CR_ADVREGEN | ADC_CR_ADCALDIF);
+  SET_BIT(hadc->Instance->CR, ADC_CR_DEEPPWD);
+
+  /* Reset register CFGR */
+  CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_AWD1CH  | ADC_CFGR_JAUTO   | ADC_CFGR_JAWD1EN |
+            ADC_CFGR_AWD1EN  | ADC_CFGR_AWD1SGL | ADC_CFGR_JQM     |
+            ADC_CFGR_JDISCEN | ADC_CFGR_DISCNUM | ADC_CFGR_DISCEN  |
+            ADC_CFGR_AUTDLY  | ADC_CFGR_CONT    | ADC_CFGR_OVRMOD  |
+            ADC_CFGR_EXTEN   | ADC_CFGR_EXTSEL  |
+            ADC_CFGR_RES     | ADC_CFGR_DMNGT);
+  SET_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS);
+
+  /* Reset register CFGR2 */
+  CLEAR_BIT(hadc->Instance->CFGR2, ADC_CFGR2_ROVSM  | ADC_CFGR2_TROVS   | ADC_CFGR2_OVSS |
+            ADC_CFGR2_OVSR  | ADC_CFGR2_JOVSE | ADC_CFGR2_ROVSE);
+
+  /* Reset register SMPR1 */
+  CLEAR_BIT(hadc->Instance->SMPR1, ADC_SMPR1_FIELDS);
+
+  /* Reset register SMPR2 */
+  CLEAR_BIT(hadc->Instance->SMPR2, ADC_SMPR2_SMP18 | ADC_SMPR2_SMP17 | ADC_SMPR2_SMP16 |
+            ADC_SMPR2_SMP15 | ADC_SMPR2_SMP14 | ADC_SMPR2_SMP13 |
+            ADC_SMPR2_SMP12 | ADC_SMPR2_SMP11 | ADC_SMPR2_SMP10);
+
+#if defined(ADC_VER_V5_V90)
+  if (hadc->Instance == ADC3)
+  {
+    /* Reset register LTR1 and HTR1 */
+    CLEAR_BIT(hadc->Instance->LTR1_TR1, ADC3_TR1_HT1 | ADC3_TR1_LT1);
+    CLEAR_BIT(hadc->Instance->HTR1_TR2, ADC3_TR2_HT2 | ADC3_TR2_LT2);
+
+    /* Reset register LTR3 and HTR3 */
+    CLEAR_BIT(hadc->Instance->RES1_TR3, ADC3_TR3_HT3 | ADC3_TR3_LT3);
+  }
+  else
+  {
+    CLEAR_BIT(hadc->Instance->LTR1_TR1, ADC_LTR_LT);
+    CLEAR_BIT(hadc->Instance->HTR1_TR2, ADC_HTR_HT);
+
+    /* Reset register LTR2 and HTR2*/
+    CLEAR_BIT(hadc->Instance->LTR2_DIFSEL, ADC_LTR_LT);
+    CLEAR_BIT(hadc->Instance->HTR2_CALFACT, ADC_HTR_HT);
+
+    /* Reset register LTR3 and HTR3 */
+    CLEAR_BIT(hadc->Instance->LTR3_RES10, ADC_LTR_LT);
+    CLEAR_BIT(hadc->Instance->HTR3_RES11, ADC_HTR_HT);
+  }
+#else
+  /* Reset register LTR1 and HTR1 */
+  CLEAR_BIT(hadc->Instance->LTR1, ADC_LTR_LT);
+  CLEAR_BIT(hadc->Instance->HTR1, ADC_HTR_HT);
+
+  /* Reset register LTR2 and HTR2*/
+  CLEAR_BIT(hadc->Instance->LTR2, ADC_LTR_LT);
+  CLEAR_BIT(hadc->Instance->HTR2, ADC_HTR_HT);
+
+  /* Reset register LTR3 and HTR3 */
+  CLEAR_BIT(hadc->Instance->LTR3, ADC_LTR_LT);
+  CLEAR_BIT(hadc->Instance->HTR3, ADC_HTR_HT);
+#endif /* ADC_VER_V5_V90 */
+
+
+  /* Reset register SQR1 */
+  CLEAR_BIT(hadc->Instance->SQR1, ADC_SQR1_SQ4 | ADC_SQR1_SQ3 | ADC_SQR1_SQ2 |
+            ADC_SQR1_SQ1 | ADC_SQR1_L);
+
+  /* Reset register SQR2 */
+  CLEAR_BIT(hadc->Instance->SQR2, ADC_SQR2_SQ9 | ADC_SQR2_SQ8 | ADC_SQR2_SQ7 |
+            ADC_SQR2_SQ6 | ADC_SQR2_SQ5);
+
+  /* Reset register SQR3 */
+  CLEAR_BIT(hadc->Instance->SQR3, ADC_SQR3_SQ14 | ADC_SQR3_SQ13 | ADC_SQR3_SQ12 |
+            ADC_SQR3_SQ11 | ADC_SQR3_SQ10);
+
+  /* Reset register SQR4 */
+  CLEAR_BIT(hadc->Instance->SQR4, ADC_SQR4_SQ16 | ADC_SQR4_SQ15);
+
+  /* Register JSQR was reset when the ADC was disabled */
+
+  /* Reset register DR */
+  /* bits in access mode read only, no direct reset applicable*/
+
+  /* Reset register OFR1 */
+  CLEAR_BIT(hadc->Instance->OFR1, ADC_OFR1_SSATE | ADC_OFR1_OFFSET1_CH | ADC_OFR1_OFFSET1);
+  /* Reset register OFR2 */
+  CLEAR_BIT(hadc->Instance->OFR2, ADC_OFR2_SSATE | ADC_OFR2_OFFSET2_CH | ADC_OFR2_OFFSET2);
+  /* Reset register OFR3 */
+  CLEAR_BIT(hadc->Instance->OFR3, ADC_OFR3_SSATE | ADC_OFR3_OFFSET3_CH | ADC_OFR3_OFFSET3);
+  /* Reset register OFR4 */
+  CLEAR_BIT(hadc->Instance->OFR4, ADC_OFR4_SSATE | ADC_OFR4_OFFSET4_CH | ADC_OFR4_OFFSET4);
+
+  /* Reset registers JDR1, JDR2, JDR3, JDR4 */
+  /* bits in access mode read only, no direct reset applicable*/
+
+  /* Reset register AWD2CR */
+  CLEAR_BIT(hadc->Instance->AWD2CR, ADC_AWD2CR_AWD2CH);
+
+  /* Reset register AWD3CR */
+  CLEAR_BIT(hadc->Instance->AWD3CR, ADC_AWD3CR_AWD3CH);
+
+#if defined(ADC_VER_V5_V90)
+  if (hadc->Instance == ADC3)
+  {
+  /* Reset register DIFSEL */
+  CLEAR_BIT(hadc->Instance->LTR2_DIFSEL, ADC_DIFSEL_DIFSEL);
+
+  /* Reset register CALFACT */
+  CLEAR_BIT(hadc->Instance->HTR2_CALFACT, ADC_CALFACT_CALFACT_D | ADC_CALFACT_CALFACT_S);
+  }
+  else
+  {
+    /* Reset register DIFSEL */
+    CLEAR_BIT(hadc->Instance->DIFSEL_RES12, ADC_DIFSEL_DIFSEL);
+
+    /* Reset register CALFACT */
+    CLEAR_BIT(hadc->Instance->CALFACT_RES13, ADC_CALFACT_CALFACT_D | ADC_CALFACT_CALFACT_S);
+  }
+#else
+  /* Reset register DIFSEL */
+  CLEAR_BIT(hadc->Instance->DIFSEL, ADC_DIFSEL_DIFSEL);
+
+  /* Reset register CALFACT */
+  CLEAR_BIT(hadc->Instance->CALFACT, ADC_CALFACT_CALFACT_D | ADC_CALFACT_CALFACT_S);
+#endif /* ADC_VER_V5_V90 */
+
+  /* ========== Reset common ADC registers ========== */
+
+  /* Software is allowed to change common parameters only when all the other
+     ADCs are disabled.   */
+  if (__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) == 0UL)
+  {
+    /* Reset configuration of ADC common register CCR:
+      - clock mode: CKMODE, PRESCEN
+      - multimode related parameters(when this feature is available): DELAY, DUAL
+       (set into  HAL_ADCEx_MultiModeConfigChannel() API)
+      - internal measurement paths: Vbat, temperature sensor, Vref (set into
+        HAL_ADC_ConfigChannel() or HAL_ADCEx_InjectedConfigChannel() )
+    */
+    ADC_CLEAR_COMMON_CONTROL_REGISTER(hadc);
+
+    /* ========== Hard reset ADC peripheral ========== */
+    /* Performs a global reset of the entire ADC peripherals instances        */
+    /* sharing the same common ADC instance: ADC state is forced to           */
+    /* a similar state as after device power-on.                              */
+    /* Note: A possible implementation is to add RCC bus reset of ADC         */
+    /* (for example, using macro                                              */
+    /*  __HAL_RCC_ADC..._FORCE_RESET()/..._RELEASE_RESET()/..._CLK_DISABLE()) */
+    /* in function "void HAL_ADC_MspDeInit(ADC_HandleTypeDef *hadc)":         */
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    if (hadc->MspDeInitCallback == NULL)
+    {
+      hadc->MspDeInitCallback = HAL_ADC_MspDeInit; /* Legacy weak MspDeInit  */
+    }
+
+    /* DeInit the low level hardware: RCC clock, NVIC */
+    hadc->MspDeInitCallback(hadc);
+#else
+    /* DeInit the low level hardware: RCC clock, NVIC */
+    HAL_ADC_MspDeInit(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+  }
+
+  /* Set ADC error code to none */
+  ADC_CLEAR_ERRORCODE(hadc);
+
+  /* Reset injected channel configuration parameters */
+  hadc->InjectionConfig.ContextQueue = 0;
+  hadc->InjectionConfig.ChannelCount = 0;
+
+  /* Set ADC state */
+  hadc->State = HAL_ADC_STATE_RESET;
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Initialize the ADC MSP.
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_MspInit(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_MspInit must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  DeInitialize the ADC MSP.
+  * @param hadc ADC handle
+  * @note   All ADC instances use the same core clock at RCC level, disabling
+  *         the core clock reset all ADC instances).
+  * @retval None
+  */
+__weak void HAL_ADC_MspDeInit(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_MspDeInit must be implemented in the user file.
+   */
+}
+
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+/**
+  * @brief  Register a User ADC Callback
+  *         To be used instead of the weak predefined callback
+  * @param  hadc Pointer to a ADC_HandleTypeDef structure that contains
+  *                the configuration information for the specified ADC.
+  * @param  CallbackID ID of the callback to be registered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_ADC_CONVERSION_COMPLETE_CB_ID      ADC conversion complete callback ID
+  *          @arg @ref HAL_ADC_CONVERSION_HALF_CB_ID          ADC conversion DMA half-transfer callback ID
+  *          @arg @ref HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID    ADC analog watchdog 1 callback ID
+  *          @arg @ref HAL_ADC_ERROR_CB_ID                    ADC error callback ID
+  *          @arg @ref HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID  ADC group injected conversion complete callback ID
+  *          @arg @ref HAL_ADC_INJ_QUEUE_OVEFLOW_CB_ID        ADC group injected context queue overflow callback ID
+  *          @arg @ref HAL_ADC_LEVEL_OUT_OF_WINDOW_2_CB_ID    ADC analog watchdog 2 callback ID
+  *          @arg @ref HAL_ADC_LEVEL_OUT_OF_WINDOW_3_CB_ID    ADC analog watchdog 3 callback ID
+  *          @arg @ref HAL_ADC_END_OF_SAMPLING_CB_ID          ADC end of sampling callback ID
+  *          @arg @ref HAL_ADC_MSPINIT_CB_ID                  ADC Msp Init callback ID
+  *          @arg @ref HAL_ADC_MSPDEINIT_CB_ID                ADC Msp DeInit callback ID
+  * @param  pCallback pointer to the Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_RegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID, pADC_CallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    /* Update the error code */
+    hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+    return HAL_ERROR;
+  }
+
+  if ((hadc->State & HAL_ADC_STATE_READY) != 0UL)
+  {
+    switch (CallbackID)
+    {
+      case HAL_ADC_CONVERSION_COMPLETE_CB_ID :
+        hadc->ConvCpltCallback = pCallback;
+        break;
+
+      case HAL_ADC_CONVERSION_HALF_CB_ID :
+        hadc->ConvHalfCpltCallback = pCallback;
+        break;
+
+      case HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID :
+        hadc->LevelOutOfWindowCallback = pCallback;
+        break;
+
+      case HAL_ADC_ERROR_CB_ID :
+        hadc->ErrorCallback = pCallback;
+        break;
+
+      case HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID :
+        hadc->InjectedConvCpltCallback = pCallback;
+        break;
+
+      case HAL_ADC_INJ_QUEUE_OVEFLOW_CB_ID :
+        hadc->InjectedQueueOverflowCallback = pCallback;
+        break;
+
+      case HAL_ADC_LEVEL_OUT_OF_WINDOW_2_CB_ID :
+        hadc->LevelOutOfWindow2Callback = pCallback;
+        break;
+
+      case HAL_ADC_LEVEL_OUT_OF_WINDOW_3_CB_ID :
+        hadc->LevelOutOfWindow3Callback = pCallback;
+        break;
+
+      case HAL_ADC_END_OF_SAMPLING_CB_ID :
+        hadc->EndOfSamplingCallback = pCallback;
+        break;
+
+      case HAL_ADC_MSPINIT_CB_ID :
+        hadc->MspInitCallback = pCallback;
+        break;
+
+      case HAL_ADC_MSPDEINIT_CB_ID :
+        hadc->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status = HAL_ERROR;
+        break;
+    }
+  }
+  else if (HAL_ADC_STATE_RESET == hadc->State)
+  {
+    switch (CallbackID)
+    {
+      case HAL_ADC_MSPINIT_CB_ID :
+        hadc->MspInitCallback = pCallback;
+        break;
+
+      case HAL_ADC_MSPDEINIT_CB_ID :
+        hadc->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Update the error code */
+        hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status = HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Unregister a ADC Callback
+  *         ADC callback is redirected to the weak predefined callback
+  * @param  hadc Pointer to a ADC_HandleTypeDef structure that contains
+  *                the configuration information for the specified ADC.
+  * @param  CallbackID ID of the callback to be unregistered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_ADC_CONVERSION_COMPLETE_CB_ID      ADC conversion complete callback ID
+  *          @arg @ref HAL_ADC_CONVERSION_HALF_CB_ID          ADC conversion DMA half-transfer callback ID
+  *          @arg @ref HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID    ADC analog watchdog 1 callback ID
+  *          @arg @ref HAL_ADC_ERROR_CB_ID                    ADC error callback ID
+  *          @arg @ref HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID  ADC group injected conversion complete callback ID
+  *          @arg @ref HAL_ADC_INJ_QUEUE_OVEFLOW_CB_ID        ADC group injected context queue overflow callback ID
+  *          @arg @ref HAL_ADC_LEVEL_OUT_OF_WINDOW_2_CB_ID    ADC analog watchdog 2 callback ID
+  *          @arg @ref HAL_ADC_LEVEL_OUT_OF_WINDOW_3_CB_ID    ADC analog watchdog 3 callback ID
+  *          @arg @ref HAL_ADC_END_OF_SAMPLING_CB_ID          ADC end of sampling callback ID
+  *          @arg @ref HAL_ADC_MSPINIT_CB_ID                  ADC Msp Init callback ID
+  *          @arg @ref HAL_ADC_MSPDEINIT_CB_ID                ADC Msp DeInit callback ID
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_UnRegisterCallback(ADC_HandleTypeDef *hadc, HAL_ADC_CallbackIDTypeDef CallbackID)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if ((hadc->State & HAL_ADC_STATE_READY) != 0UL)
+  {
+    switch (CallbackID)
+    {
+      case HAL_ADC_CONVERSION_COMPLETE_CB_ID :
+        hadc->ConvCpltCallback = HAL_ADC_ConvCpltCallback;
+        break;
+
+      case HAL_ADC_CONVERSION_HALF_CB_ID :
+        hadc->ConvHalfCpltCallback = HAL_ADC_ConvHalfCpltCallback;
+        break;
+
+      case HAL_ADC_LEVEL_OUT_OF_WINDOW_1_CB_ID :
+        hadc->LevelOutOfWindowCallback = HAL_ADC_LevelOutOfWindowCallback;
+        break;
+
+      case HAL_ADC_ERROR_CB_ID :
+        hadc->ErrorCallback = HAL_ADC_ErrorCallback;
+        break;
+
+      case HAL_ADC_INJ_CONVERSION_COMPLETE_CB_ID :
+        hadc->InjectedConvCpltCallback = HAL_ADCEx_InjectedConvCpltCallback;
+        break;
+
+      case HAL_ADC_INJ_QUEUE_OVEFLOW_CB_ID :
+        hadc->InjectedQueueOverflowCallback = HAL_ADCEx_InjectedQueueOverflowCallback;
+        break;
+
+      case HAL_ADC_LEVEL_OUT_OF_WINDOW_2_CB_ID :
+        hadc->LevelOutOfWindow2Callback = HAL_ADCEx_LevelOutOfWindow2Callback;
+        break;
+
+      case HAL_ADC_LEVEL_OUT_OF_WINDOW_3_CB_ID :
+        hadc->LevelOutOfWindow3Callback = HAL_ADCEx_LevelOutOfWindow3Callback;
+        break;
+
+      case HAL_ADC_END_OF_SAMPLING_CB_ID :
+        hadc->EndOfSamplingCallback = HAL_ADCEx_EndOfSamplingCallback;
+        break;
+
+      case HAL_ADC_MSPINIT_CB_ID :
+        hadc->MspInitCallback = HAL_ADC_MspInit; /* Legacy weak MspInit              */
+        break;
+
+      case HAL_ADC_MSPDEINIT_CB_ID :
+        hadc->MspDeInitCallback = HAL_ADC_MspDeInit; /* Legacy weak MspDeInit            */
+        break;
+
+      default :
+        /* Update the error code */
+        hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (HAL_ADC_STATE_RESET == hadc->State)
+  {
+    switch (CallbackID)
+    {
+      case HAL_ADC_MSPINIT_CB_ID :
+        hadc->MspInitCallback = HAL_ADC_MspInit;                   /* Legacy weak MspInit              */
+        break;
+
+      case HAL_ADC_MSPDEINIT_CB_ID :
+        hadc->MspDeInitCallback = HAL_ADC_MspDeInit;               /* Legacy weak MspDeInit            */
+        break;
+
+      default :
+        /* Update the error code */
+        hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Update the error code */
+    hadc->ErrorCode |= HAL_ADC_ERROR_INVALID_CALLBACK;
+
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  return status;
+}
+
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group2 ADC Input and Output operation functions
+  * @brief    ADC IO operation functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Start conversion of regular group.
+      (+) Stop conversion of regular group.
+      (+) Poll for conversion complete on regular group.
+      (+) Poll for conversion event.
+      (+) Get result of regular channel conversion.
+      (+) Start conversion of regular group and enable interruptions.
+      (+) Stop conversion of regular group and disable interruptions.
+      (+) Handle ADC interrupt request
+      (+) Start conversion of regular group and enable DMA transfer.
+      (+) Stop conversion of regular group and disable ADC DMA transfer.
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Enable ADC, start conversion of regular group.
+  * @note   Interruptions enabled in this function: None.
+  * @note   Case of multimode enabled (when multimode feature is available):
+  *           if ADC is Slave, ADC is enabled but conversion is not started,
+  *           if ADC is master, ADC is enabled and multimode conversion is started.
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  const ADC_TypeDef *tmpADC_Master;
+  uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+
+    /* Enable the ADC peripheral */
+    tmp_hal_status = ADC_Enable(hadc);
+
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state                                                        */
+      /* - Clear state bitfield related to regular group conversion results   */
+      /* - Set state bitfield related to regular operation                    */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP,
+                        HAL_ADC_STATE_REG_BUSY);
+
+      /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - if ADC instance is master or if multimode feature is not available
+        - if multimode setting is disabled (ADC instance slave in independent mode) */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+         )
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+
+      /* Set ADC error code */
+      /* Check if a conversion is on going on ADC group injected */
+      if (HAL_IS_BIT_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY))
+      {
+        /* Reset ADC error code fields related to regular conversions only */
+        CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));
+      }
+      else
+      {
+        /* Reset all ADC error code fields */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+
+      /* Clear ADC group regular conversion flag and overrun flag               */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+
+      /* Enable conversion of regular group.                                  */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion will start at next */
+      /* trigger event.                                                       */
+      /* Case of multimode enabled (when multimode feature is available):     */
+      /*  - if ADC is slave and dual regular conversions are enabled, ADC is  */
+      /*    enabled only (conversion is not started),                         */
+      /*  - if ADC is master, ADC is enabled and conversion is started.       */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_SIMULT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_ALTERN)
+         )
+      {
+        /* ADC instance is not a multimode slave instance with multimode regular conversions enabled */
+        if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != 0UL)
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+        }
+
+        /* Start ADC group regular conversion */
+        LL_ADC_REG_StartConversion(hadc->Instance);
+      }
+      else
+      {
+        /* ADC instance is a multimode slave instance with multimode regular conversions enabled */
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        /* if Master ADC JAUTO bit is set, update Slave State in setting
+           HAL_ADC_STATE_INJ_BUSY bit and in resetting HAL_ADC_STATE_INJ_EOC bit */
+        tmpADC_Master = __LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance);
+        if (READ_BIT(tmpADC_Master->CFGR, ADC_CFGR_JAUTO) != 0UL)
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+        }
+
+      }
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular group (and injected channels in
+  *         case of auto_injection mode), disable ADC peripheral.
+  * @note:  ADC peripheral disable is forcing stop of potential
+  *         conversion on injected group. If injected group is under use, it
+  *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
+  * @param hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* 1. Stop potential conversion on going, on ADC groups regular and injected */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* 2. Disable the ADC peripheral */
+    tmp_hal_status = ADC_Disable(hadc);
+
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Wait for regular group conversion to be completed.
+  * @note   ADC conversion flags EOS (end of sequence) and EOC (end of
+  *         conversion) are cleared by this function, with an exception:
+  *         if low power feature "LowPowerAutoWait" is enabled, flags are
+  *         not cleared to not interfere with this feature until data register
+  *         is read using function HAL_ADC_GetValue().
+  * @note   This function cannot be used in a particular setup: ADC configured
+  *         in DMA mode and polling for end of each conversion (ADC init
+  *         parameter "EOCSelection" set to ADC_EOC_SINGLE_CONV).
+  *         In this case, DMA resets the flag EOC and polling cannot be
+  *         performed on each conversion. Nevertheless, polling can still
+  *         be performed on the complete sequence (ADC init
+  *         parameter "EOCSelection" set to ADC_EOC_SEQ_CONV).
+  * @param hadc ADC handle
+  * @param Timeout Timeout value in millisecond.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForConversion(ADC_HandleTypeDef *hadc, uint32_t Timeout)
+{
+  uint32_t tickstart;
+  uint32_t tmp_Flag_End;
+  uint32_t tmp_cfgr;
+  const ADC_TypeDef *tmpADC_Master;
+  uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* If end of conversion selected to end of sequence conversions */
+  if (hadc->Init.EOCSelection == ADC_EOC_SEQ_CONV)
+  {
+    tmp_Flag_End = ADC_FLAG_EOS;
+  }
+  /* If end of conversion selected to end of unitary conversion */
+  else /* ADC_EOC_SINGLE_CONV */
+  {
+    /* Verification that ADC configuration is compliant with polling for      */
+    /* each conversion:                                                       */
+    /* Particular case is ADC configured in DMA mode and ADC sequencer with   */
+    /* several ranks and polling for end of each conversion.                  */
+    /* For code simplicity sake, this particular case is generalized to       */
+    /* ADC configured in DMA mode and and polling for end of each conversion. */
+    if ((tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+        || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_SIMULT)
+        || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_ALTERN)
+       )
+    {
+      /* Check DMNGT bit in handle ADC CFGR register */
+      if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_DMNGT_0) != 0UL)
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        return HAL_ERROR;
+      }
+      else
+      {
+        tmp_Flag_End = (ADC_FLAG_EOC);
+      }
+    }
+    else
+    {
+      /* Check ADC DMA mode in multimode on ADC group regular */
+      if (LL_ADC_GetMultiDMATransfer(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) != LL_ADC_MULTI_REG_DMA_EACH_ADC)
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+        return HAL_ERROR;
+      }
+      else
+      {
+        tmp_Flag_End = (ADC_FLAG_EOC);
+      }
+    }
+  }
+
+  /* Get tick count */
+  tickstart = HAL_GetTick();
+
+  /* Wait until End of unitary conversion or sequence conversions flag is raised */
+  while ((hadc->Instance->ISR & tmp_Flag_End) == 0UL)
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
+      {
+        /* New check to avoid false timeout detection in case of preemption */
+        if((hadc->Instance->ISR & tmp_Flag_End) == 0UL)
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+
+  /* Determine whether any further conversion upcoming on group regular       */
+  /* by external trigger, continuous mode or scan sequence on going.          */
+  if ((LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
+      && (hadc->Init.ContinuousConvMode == DISABLE)
+     )
+  {
+    /* Check whether end of sequence is reached */
+    if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS))
+    {
+      /* Set ADC state */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+
+      if ((hadc->State & HAL_ADC_STATE_INJ_BUSY) == 0UL)
+      {
+        SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+      }
+    }
+  }
+
+  /* Get relevant register CFGR in ADC instance of ADC master or slave        */
+  /* in function of multimode state (for devices with multimode               */
+  /* available).                                                              */
+  if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+      || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+      || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_SIMULT)
+      || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_ALTERN)
+     )
+  {
+    /* Retrieve handle ADC CFGR register */
+    tmp_cfgr = READ_REG(hadc->Instance->CFGR);
+  }
+  else
+  {
+    /* Retrieve Master ADC CFGR register */
+    tmpADC_Master = __LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance);
+    tmp_cfgr = READ_REG(tmpADC_Master->CFGR);
+  }
+
+  /* Clear polled flag */
+  if (tmp_Flag_End == ADC_FLAG_EOS)
+  {
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOS);
+  }
+  else
+  {
+    /* Clear end of conversion EOC flag of regular group if low power feature */
+    /* "LowPowerAutoWait " is disabled, to not interfere with this feature    */
+    /* until data register is read using function HAL_ADC_GetValue().         */
+    if (READ_BIT(tmp_cfgr, ADC_CFGR_AUTDLY) == 0UL)
+    {
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS));
+    }
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Poll for ADC event.
+  * @param hadc ADC handle
+  * @param EventType the ADC event type.
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_EOSMP_EVENT  ADC End of Sampling event
+  *            @arg @ref ADC_AWD1_EVENT   ADC Analog watchdog 1 event (main analog watchdog, present on all STM32 devices)
+  *            @arg @ref ADC_AWD2_EVENT   ADC Analog watchdog 2 event (additional analog watchdog, not present on all STM32 families)
+  *            @arg @ref ADC_AWD3_EVENT   ADC Analog watchdog 3 event (additional analog watchdog, not present on all STM32 families)
+  *            @arg @ref ADC_OVR_EVENT    ADC Overrun event
+  *            @arg @ref ADC_JQOVF_EVENT  ADC Injected context queue overflow event
+  * @param Timeout Timeout value in millisecond.
+  * @note   The relevant flag is cleared if found to be set, except for ADC_FLAG_OVR.
+  *         Indeed, the latter is reset only if hadc->Init.Overrun field is set
+  *         to ADC_OVR_DATA_OVERWRITTEN. Otherwise, data register may be potentially overwritten
+  *         by a new converted data as soon as OVR is cleared.
+  *         To reset OVR flag once the preserved data is retrieved, the user can resort
+  *         to macro __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_PollForEvent(ADC_HandleTypeDef *hadc, uint32_t EventType, uint32_t Timeout)
+{
+  uint32_t tickstart;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_EVENT_TYPE(EventType));
+
+  /* Get tick count */
+  tickstart = HAL_GetTick();
+
+  /* Check selected event flag */
+  while (__HAL_ADC_GET_FLAG(hadc, EventType) == 0UL)
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
+      {
+        /* New check to avoid false timeout detection in case of preemption */
+        if(__HAL_ADC_GET_FLAG(hadc, EventType) == 0UL)
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+
+  switch (EventType)
+  {
+    /* End Of Sampling event */
+    case ADC_EOSMP_EVENT:
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOSMP);
+
+      /* Clear the End Of Sampling flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP);
+
+      break;
+
+    /* Analog watchdog (level out of window) event */
+    /* Note: In case of several analog watchdog enabled, if needed to know      */
+    /* which one triggered and on which ADCx, test ADC state of analog watchdog */
+    /* flags HAL_ADC_STATE_AWD1/2/3 using function "HAL_ADC_GetState()".        */
+    /* For example:                                                             */
+    /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD1) != 0UL) "          */
+    /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD2) != 0UL) "          */
+    /*  " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD3) != 0UL) "          */
+
+    /* Check analog watchdog 1 flag */
+    case ADC_AWD_EVENT:
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+
+      /* Clear ADC analog watchdog flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD1);
+
+      break;
+
+    /* Check analog watchdog 2 flag */
+    case ADC_AWD2_EVENT:
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+
+      /* Clear ADC analog watchdog flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD2);
+
+      break;
+
+    /* Check analog watchdog 3 flag */
+    case ADC_AWD3_EVENT:
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+
+      /* Clear ADC analog watchdog flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD3);
+
+      break;
+
+    /* Injected context queue overflow event */
+    case ADC_JQOVF_EVENT:
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_JQOVF);
+
+      /* Set ADC error code to Injected context queue overflow */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);
+
+      /* Clear ADC Injected context queue overflow flag */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JQOVF);
+
+      break;
+
+    /* Overrun event */
+    default: /* Case ADC_OVR_EVENT */
+      /* If overrun is set to overwrite previous data, overrun event is not     */
+      /* considered as an error.                                                */
+      /* (cf ref manual "Managing conversions without using the DMA and without */
+      /* overrun ")                                                             */
+      if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+      {
+        /* Set ADC state */
+        SET_BIT(hadc->State, HAL_ADC_STATE_REG_OVR);
+
+        /* Set ADC error code to overrun */
+        SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_OVR);
+      }
+      else
+      {
+        /* Clear ADC Overrun flag only if Overrun is set to ADC_OVR_DATA_OVERWRITTEN
+           otherwise, data register is potentially overwritten by new converted data as soon
+           as OVR is cleared. */
+        __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+      }
+      break;
+  }
+
+  /* Return function status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enable ADC, start conversion of regular group with interruption.
+  * @note   Interruptions enabled in this function according to initialization
+  *         setting : EOC (end of conversion), EOS (end of sequence),
+  *         OVR overrun.
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   Case of multimode enabled (when multimode feature is available):
+  *         HAL_ADC_Start_IT() must be called for ADC Slave first, then for
+  *         ADC Master.
+  *         For ADC Slave, ADC is enabled only (conversion is not started).
+  *         For ADC Master, ADC is enabled and multimode conversion is started.
+  * @note   To guarantee a proper reset of all interruptions once all the needed
+  *         conversions are obtained, HAL_ADC_Stop_IT() must be called to ensure
+  *         a correct stop of the IT-based conversions.
+  * @note   By default, HAL_ADC_Start_IT() does not enable the End Of Sampling
+  *         interruption. If required (e.g. in case of oversampling with trigger
+  *         mode), the user must:
+  *          1. first clear the EOSMP flag if set with macro __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP)
+  *          2. then enable the EOSMP interrupt with macro __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOSMP)
+  *          before calling HAL_ADC_Start_IT().
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_Start_IT(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  const ADC_TypeDef *tmpADC_Master;
+  uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+
+    /* Enable the ADC peripheral */
+    tmp_hal_status = ADC_Enable(hadc);
+
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state                                                        */
+      /* - Clear state bitfield related to regular group conversion results   */
+      /* - Set state bitfield related to regular operation                    */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP,
+                        HAL_ADC_STATE_REG_BUSY);
+
+      /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - if ADC instance is master or if multimode feature is not available
+        - if multimode setting is disabled (ADC instance slave in independent mode) */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+         )
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+
+      /* Set ADC error code */
+      /* Check if a conversion is on going on ADC group injected */
+      if ((hadc->State & HAL_ADC_STATE_INJ_BUSY) != 0UL)
+      {
+        /* Reset ADC error code fields related to regular conversions only */
+        CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));
+      }
+      else
+      {
+        /* Reset all ADC error code fields */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+
+      /* Clear ADC group regular conversion flag and overrun flag               */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+
+      /* Disable all interruptions before enabling the desired ones */
+      __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+
+      /* Enable ADC end of conversion interrupt */
+      switch (hadc->Init.EOCSelection)
+      {
+        case ADC_EOC_SEQ_CONV:
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOS);
+          break;
+        /* case ADC_EOC_SINGLE_CONV */
+        default:
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_EOC);
+          break;
+      }
+
+      /* Enable ADC overrun interrupt */
+      /* If hadc->Init.Overrun is set to ADC_OVR_DATA_PRESERVED, only then is
+         ADC_IT_OVR enabled; otherwise data overwrite is considered as normal
+         behavior and no CPU time is lost for a non-processed interruption */
+      if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+      {
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+      }
+
+      /* Enable conversion of regular group.                                  */
+      /* If software start has been selected, conversion starts immediately.  */
+      /* If external trigger has been selected, conversion will start at next */
+      /* trigger event.                                                       */
+      /* Case of multimode enabled (when multimode feature is available):     */
+      /*  - if ADC is slave and dual regular conversions are enabled, ADC is  */
+      /*    enabled only (conversion is not started),                         */
+      /*  - if ADC is master, ADC is enabled and conversion is started.       */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_SIMULT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_ALTERN)
+         )
+      {
+        /* ADC instance is not a multimode slave instance with multimode regular conversions enabled */
+        if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO) != 0UL)
+        {
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+
+          /* Enable as well injected interruptions in case
+           HAL_ADCEx_InjectedStart_IT() has not been called beforehand. This
+           allows to start regular and injected conversions when JAUTO is
+           set with a single call to HAL_ADC_Start_IT() */
+          switch (hadc->Init.EOCSelection)
+          {
+            case ADC_EOC_SEQ_CONV:
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+              __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOS);
+              break;
+            /* case ADC_EOC_SINGLE_CONV */
+            default:
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOS);
+              __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC);
+              break;
+          }
+        }
+
+        /* Start ADC group regular conversion */
+        LL_ADC_REG_StartConversion(hadc->Instance);
+      }
+      else
+      {
+        /* ADC instance is a multimode slave instance with multimode regular conversions enabled */
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        /* if Master ADC JAUTO bit is set, Slave injected interruptions
+           are enabled nevertheless (for same reason as above) */
+        tmpADC_Master = __LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance);
+        if (READ_BIT(tmpADC_Master->CFGR, ADC_CFGR_JAUTO) != 0UL)
+        {
+          /* First, update Slave State in setting HAL_ADC_STATE_INJ_BUSY bit
+             and in resetting HAL_ADC_STATE_INJ_EOC bit */
+          ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_EOC, HAL_ADC_STATE_INJ_BUSY);
+          /* Next, set Slave injected interruptions */
+          switch (hadc->Init.EOCSelection)
+          {
+            case ADC_EOC_SEQ_CONV:
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+              __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOS);
+              break;
+            /* case ADC_EOC_SINGLE_CONV */
+            default:
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOS);
+              __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC);
+              break;
+          }
+        }
+      }
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular group (and injected group in
+  *         case of auto_injection mode), disable interrution of
+  *         end-of-conversion, disable ADC peripheral.
+  * @param hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_IT(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* 1. Stop potential conversion on going, on ADC groups regular and injected */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Disable ADC end of conversion interrupt for regular group */
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+
+    /* 2. Disable the ADC peripheral */
+    tmp_hal_status = ADC_Disable(hadc);
+
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Enable ADC, start conversion of regular group and transfer result through DMA.
+  * @note   Interruptions enabled in this function:
+  *         overrun (if applicable), DMA half transfer, DMA transfer complete.
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   Case of multimode enabled (when multimode feature is available): HAL_ADC_Start_DMA()
+  *         is designed for single-ADC mode only. For multimode, the dedicated
+  *         HAL_ADCEx_MultiModeStart_DMA() function must be used.
+  * @param hadc ADC handle
+  * @param pData Destination Buffer address.
+  * @param Length Number of data to be transferred from ADC peripheral to memory
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Start_DMA(ADC_HandleTypeDef *hadc, uint32_t *pData, uint32_t Length)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Perform ADC enable and conversion start if no conversion is on going */
+  if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+
+    /* Ensure that multimode regular conversions are not enabled.   */
+    /* Otherwise, dedicated API HAL_ADCEx_MultiModeStart_DMA() must be used.  */
+    if ((tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+        || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_SIMULT)
+        || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_ALTERN)
+       )
+    {
+      /* Enable the ADC peripheral */
+      tmp_hal_status = ADC_Enable(hadc);
+
+      /* Start conversion if ADC is effectively enabled */
+      if (tmp_hal_status == HAL_OK)
+      {
+        /* Set ADC state                                                        */
+        /* - Clear state bitfield related to regular group conversion results   */
+        /* - Set state bitfield related to regular operation                    */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP,
+                          HAL_ADC_STATE_REG_BUSY);
+
+        /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+          - if ADC instance is master or if multimode feature is not available
+          - if multimode setting is disabled (ADC instance slave in independent mode) */
+        if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+            || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+           )
+        {
+          CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+        }
+
+        /* Check if a conversion is on going on ADC group injected */
+        if ((hadc->State & HAL_ADC_STATE_INJ_BUSY) != 0UL)
+        {
+          /* Reset ADC error code fields related to regular conversions only */
+          CLEAR_BIT(hadc->ErrorCode, (HAL_ADC_ERROR_OVR | HAL_ADC_ERROR_DMA));
+        }
+        else
+        {
+          /* Reset all ADC error code fields */
+          ADC_CLEAR_ERRORCODE(hadc);
+        }
+
+        /* Set the DMA transfer complete callback */
+        hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+
+        /* Set the DMA half transfer complete callback */
+        hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+
+        /* Set the DMA error callback */
+        hadc->DMA_Handle->XferErrorCallback = ADC_DMAError;
+
+
+        /* Manage ADC and DMA start: ADC overrun interruption, DMA start,     */
+        /* ADC start (in case of SW start):                                   */
+
+        /* Clear regular group conversion flag and overrun flag               */
+        /* (To ensure of no unknown state from potential previous ADC         */
+        /* operations)                                                        */
+        __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+
+        /* Process unlocked */
+        /* Unlock before starting ADC conversions: in case of potential         */
+        /* interruption, to let the process to ADC IRQ Handler.                 */
+        __HAL_UNLOCK(hadc);
+
+        /* With DMA, overrun event is always considered as an error even if
+           hadc->Init.Overrun is set to ADC_OVR_DATA_OVERWRITTEN. Therefore,
+           ADC_IT_OVR is enabled. */
+        __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+
+        /* Enable ADC DMA  mode*/
+#if defined(ADC_VER_V5_V90)
+        if (hadc->Instance == ADC3)
+        {
+          LL_ADC_REG_SetDMATransferMode(hadc->Instance, ADC3_CFGR_DMACONTREQ((uint32_t)hadc->Init.DMAContinuousRequests));
+          LL_ADC_EnableDMAReq(hadc->Instance);
+        }
+        else
+        {
+          LL_ADC_REG_SetDataTransferMode(hadc->Instance, ADC_CFGR_DMACONTREQ((uint32_t)hadc->Init.ConversionDataManagement));
+        }
+
+#else
+        LL_ADC_REG_SetDataTransferMode(hadc->Instance, (uint32_t)hadc->Init.ConversionDataManagement);
+#endif
+
+
+        /* Start the DMA channel */
+        tmp_hal_status = HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&hadc->Instance->DR, (uint32_t)pData, Length);
+
+        /* Enable conversion of regular group.                                  */
+        /* If software start has been selected, conversion starts immediately.  */
+        /* If external trigger has been selected, conversion will start at next */
+        /* trigger event.                                                       */
+        /* Start ADC group regular conversion */
+        LL_ADC_REG_StartConversion(hadc->Instance);
+      }
+      else
+      {
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+      }
+
+    }
+    else
+    {
+      tmp_hal_status = HAL_ERROR;
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+  }
+  else
+  {
+    tmp_hal_status = HAL_BUSY;
+  }
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular group (and injected group in
+  *         case of auto_injection mode), disable ADC DMA transfer, disable
+  *         ADC peripheral.
+  * @note:  ADC peripheral disable is forcing stop of potential
+  *         conversion on ADC group injected. If ADC group injected is under use, it
+  *         should be preliminarily stopped using HAL_ADCEx_InjectedStop function.
+  * @note   Case of multimode enabled (when multimode feature is available):
+  *         HAL_ADC_Stop_DMA() function is dedicated to single-ADC mode only.
+  *         For multimode, the dedicated HAL_ADCEx_MultiModeStop_DMA() API must be used.
+  * @param hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADC_Stop_DMA(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* 1. Stop potential ADC group regular conversion on going */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Disable ADC DMA (ADC DMA configuration of continuous requests is kept) */
+    MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_DMNGT_0 | ADC_CFGR_DMNGT_1, 0UL);
+
+    /* Disable the DMA channel (in case of DMA in circular mode or stop       */
+    /* while DMA transfer is on going)                                        */
+    if (hadc->DMA_Handle->State == HAL_DMA_STATE_BUSY)
+    {
+      tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
+
+      /* Check if DMA channel effectively disabled */
+      if (tmp_hal_status != HAL_OK)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+      }
+    }
+
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+
+    /* 2. Disable the ADC peripheral */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed,          */
+    /* to keep in memory a potential failing status.                          */
+    if (tmp_hal_status == HAL_OK)
+    {
+      tmp_hal_status = ADC_Disable(hadc);
+    }
+    else
+    {
+      (void)ADC_Disable(hadc);
+    }
+
+    /* Check if ADC is effectively disabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                        HAL_ADC_STATE_READY);
+    }
+
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Get ADC regular group conversion result.
+  * @note   Reading register DR automatically clears ADC flag EOC
+  *         (ADC group regular end of unitary conversion).
+  * @note   This function does not clear ADC flag EOS
+  *         (ADC group regular end of sequence conversion).
+  *         Occurrence of flag EOS rising:
+  *          - If sequencer is composed of 1 rank, flag EOS is equivalent
+  *            to flag EOC.
+  *          - If sequencer is composed of several ranks, during the scan
+  *            sequence flag EOC only is raised, at the end of the scan sequence
+  *            both flags EOC and EOS are raised.
+  *         To clear this flag, either use function:
+  *         in programming model IT: @ref HAL_ADC_IRQHandler(), in programming
+  *         model polling: @ref HAL_ADC_PollForConversion()
+  *         or @ref __HAL_ADC_CLEAR_FLAG(&hadc, ADC_FLAG_EOS).
+  * @param hadc ADC handle
+  * @retval ADC group regular conversion data
+  */
+uint32_t HAL_ADC_GetValue(const ADC_HandleTypeDef *hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Note: EOC flag is not cleared here by software because automatically     */
+  /*       cleared by hardware when reading register DR.                      */
+
+  /* Return ADC converted value */
+  return hadc->Instance->DR;
+}
+
+/**
+  * @brief  Handle ADC interrupt request.
+  * @param hadc ADC handle
+  * @retval None
+  */
+void HAL_ADC_IRQHandler(ADC_HandleTypeDef *hadc)
+{
+  uint32_t overrun_error = 0UL; /* flag set if overrun occurrence has to be considered as an error */
+  uint32_t tmp_isr = hadc->Instance->ISR;
+  uint32_t tmp_ier = hadc->Instance->IER;
+  uint32_t tmp_adc_inj_is_trigger_source_sw_start;
+  uint32_t tmp_adc_reg_is_trigger_source_sw_start;
+  uint32_t tmp_cfgr;
+  const ADC_TypeDef *tmpADC_Master;
+  uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_EOC_SELECTION(hadc->Init.EOCSelection));
+
+  /* ========== Check End of Sampling flag for ADC group regular ========== */
+  if (((tmp_isr & ADC_FLAG_EOSMP) == ADC_FLAG_EOSMP) && ((tmp_ier & ADC_IT_EOSMP) == ADC_IT_EOSMP))
+  {
+    /* Update state machine on end of sampling status if not in error state */
+    if ((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) == 0UL)
+    {
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOSMP);
+    }
+
+    /* End Of Sampling callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->EndOfSamplingCallback(hadc);
+#else
+    HAL_ADCEx_EndOfSamplingCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+    /* Clear regular group conversion flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_EOSMP);
+  }
+
+  /* ====== Check ADC group regular end of unitary conversion sequence conversions ===== */
+  if ((((tmp_isr & ADC_FLAG_EOC) == ADC_FLAG_EOC) && ((tmp_ier & ADC_IT_EOC) == ADC_IT_EOC)) ||
+      (((tmp_isr & ADC_FLAG_EOS) == ADC_FLAG_EOS) && ((tmp_ier & ADC_IT_EOS) == ADC_IT_EOS)))
+  {
+    /* Update state machine on conversion status if not in error state */
+    if ((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) == 0UL)
+    {
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+    }
+
+    /* Determine whether any further conversion upcoming on group regular     */
+    /* by external trigger, continuous mode or scan sequence on going         */
+    /* to disable interruption.                                               */
+    if (LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
+    {
+      /* Get relevant register CFGR in ADC instance of ADC master or slave    */
+      /* in function of multimode state (for devices with multimode           */
+      /* available).                                                          */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_SIMULT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_INJ_ALTERN)
+         )
+      {
+        /* check CONT bit directly in handle ADC CFGR register */
+        tmp_cfgr = READ_REG(hadc->Instance->CFGR);
+      }
+      else
+      {
+        /* else need to check Master ADC CONT bit */
+        tmpADC_Master = __LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance);
+        tmp_cfgr = READ_REG(tmpADC_Master->CFGR);
+      }
+
+      /* Carry on if continuous mode is disabled */
+      if (READ_BIT(tmp_cfgr, ADC_CFGR_CONT) != ADC_CFGR_CONT)
+      {
+        /* If End of Sequence is reached, disable interrupts */
+        if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_EOS))
+        {
+          /* Allowed to modify bits ADC_IT_EOC/ADC_IT_EOS only if bit         */
+          /* ADSTART==0 (no conversion on going)                              */
+          if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
+          {
+            /* Disable ADC end of sequence conversion interrupt */
+            /* Note: Overrun interrupt was enabled with EOC interrupt in      */
+            /* HAL_Start_IT(), but is not disabled here because can be used   */
+            /* by overrun IRQ process below.                                  */
+            __HAL_ADC_DISABLE_IT(hadc, ADC_IT_EOC | ADC_IT_EOS);
+
+            /* Set ADC state */
+            CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+
+            if ((hadc->State & HAL_ADC_STATE_INJ_BUSY) == 0UL)
+            {
+              SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+            }
+          }
+          else
+          {
+            /* Change ADC state to error state */
+            SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+            /* Set ADC error code to ADC peripheral internal error */
+            SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+          }
+        }
+      }
+    }
+
+    /* Conversion complete callback */
+    /* Note: Into callback function "HAL_ADC_ConvCpltCallback()",             */
+    /*       to determine if conversion has been triggered from EOC or EOS,   */
+    /*       possibility to use:                                              */
+    /*        " if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_EOS)) "                */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->ConvCpltCallback(hadc);
+#else
+    HAL_ADC_ConvCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+    /* Clear regular group conversion flag */
+    /* Note: in case of overrun set to ADC_OVR_DATA_PRESERVED, end of         */
+    /*       conversion flags clear induces the release of the preserved data.*/
+    /*       Therefore, if the preserved data value is needed, it must be     */
+    /*       read preliminarily into HAL_ADC_ConvCpltCallback().              */
+    __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS));
+  }
+
+  /* ====== Check ADC group injected end of unitary conversion sequence conversions ===== */
+  if ((((tmp_isr & ADC_FLAG_JEOC) == ADC_FLAG_JEOC) && ((tmp_ier & ADC_IT_JEOC) == ADC_IT_JEOC)) ||
+      (((tmp_isr & ADC_FLAG_JEOS) == ADC_FLAG_JEOS) && ((tmp_ier & ADC_IT_JEOS) == ADC_IT_JEOS)))
+  {
+    /* Update state machine on conversion status if not in error state */
+    if ((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) == 0UL)
+    {
+      /* Set ADC state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_EOC);
+    }
+
+    /* Retrieve ADC configuration */
+    tmp_adc_inj_is_trigger_source_sw_start = LL_ADC_INJ_IsTriggerSourceSWStart(hadc->Instance);
+    tmp_adc_reg_is_trigger_source_sw_start = LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance);
+    /* Get relevant register CFGR in ADC instance of ADC master or slave  */
+    /* in function of multimode state (for devices with multimode         */
+    /* available).                                                        */
+    if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+        || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+        || (tmp_multimode_config == LL_ADC_MULTI_DUAL_REG_SIMULT)
+        || (tmp_multimode_config == LL_ADC_MULTI_DUAL_REG_INTERL)
+       )
+    {
+      tmp_cfgr = READ_REG(hadc->Instance->CFGR);
+    }
+    else
+    {
+      tmpADC_Master = __LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance);
+      tmp_cfgr = READ_REG(tmpADC_Master->CFGR);
+    }
+
+    /* Disable interruption if no further conversion upcoming by injected     */
+    /* external trigger or by automatic injected conversion with regular      */
+    /* group having no further conversion upcoming (same conditions as        */
+    /* regular group interruption disabling above),                           */
+    /* and if injected scan sequence is completed.                            */
+    if (tmp_adc_inj_is_trigger_source_sw_start != 0UL)
+    {
+      if ((READ_BIT(tmp_cfgr, ADC_CFGR_JAUTO) == 0UL) ||
+          ((tmp_adc_reg_is_trigger_source_sw_start != 0UL) &&
+           (READ_BIT(tmp_cfgr, ADC_CFGR_CONT) == 0UL)))
+      {
+        /* If End of Sequence is reached, disable interrupts */
+        if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS))
+        {
+          /* Particular case if injected contexts queue is enabled:             */
+          /* when the last context has been fully processed, JSQR is reset      */
+          /* by the hardware. Even if no injected conversion is planned to come */
+          /* (queue empty, triggers are ignored), it can start again            */
+          /* immediately after setting a new context (JADSTART is still set).   */
+          /* Therefore, state of HAL ADC injected group is kept to busy.        */
+          if (READ_BIT(tmp_cfgr, ADC_CFGR_JQM) == 0UL)
+          {
+            /* Allowed to modify bits ADC_IT_JEOC/ADC_IT_JEOS only if bit       */
+            /* JADSTART==0 (no conversion on going)                             */
+            if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) == 0UL)
+            {
+              /* Disable ADC end of sequence conversion interrupt  */
+              __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC | ADC_IT_JEOS);
+
+              /* Set ADC state */
+              CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+
+              if ((hadc->State & HAL_ADC_STATE_REG_BUSY) == 0UL)
+              {
+                SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+              }
+            }
+            else
+            {
+              /* Update ADC state machine to error */
+              SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+              /* Set ADC error code to ADC peripheral internal error */
+              SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+            }
+          }
+        }
+      }
+    }
+
+    /* Injected Conversion complete callback */
+    /* Note:  HAL_ADCEx_InjectedConvCpltCallback can resort to
+              if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_JEOS)) or
+              if( __HAL_ADC_GET_FLAG(&hadc, ADC_FLAG_JEOC)) to determine whether
+              interruption has been triggered by end of conversion or end of
+              sequence.    */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->InjectedConvCpltCallback(hadc);
+#else
+    HAL_ADCEx_InjectedConvCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+    /* Clear injected group conversion flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOC | ADC_FLAG_JEOS);
+  }
+
+  /* ========== Check Analog watchdog 1 flag ========== */
+  if (((tmp_isr & ADC_FLAG_AWD1) == ADC_FLAG_AWD1) && ((tmp_ier & ADC_IT_AWD1) == ADC_IT_AWD1))
+  {
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+
+    /* Level out of window 1 callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->LevelOutOfWindowCallback(hadc);
+#else
+    HAL_ADC_LevelOutOfWindowCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD1);
+  }
+
+  /* ========== Check analog watchdog 2 flag ========== */
+  if (((tmp_isr & ADC_FLAG_AWD2) == ADC_FLAG_AWD2) && ((tmp_ier & ADC_IT_AWD2) == ADC_IT_AWD2))
+  {
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+
+    /* Level out of window 2 callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->LevelOutOfWindow2Callback(hadc);
+#else
+    HAL_ADCEx_LevelOutOfWindow2Callback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD2);
+  }
+
+  /* ========== Check analog watchdog 3 flag ========== */
+  if (((tmp_isr & ADC_FLAG_AWD3) == ADC_FLAG_AWD3) && ((tmp_ier & ADC_IT_AWD3) == ADC_IT_AWD3))
+  {
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+
+    /* Level out of window 3 callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->LevelOutOfWindow3Callback(hadc);
+#else
+    HAL_ADCEx_LevelOutOfWindow3Callback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+
+    /* Clear ADC analog watchdog flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_AWD3);
+  }
+
+  /* ========== Check Overrun flag ========== */
+  if (((tmp_isr & ADC_FLAG_OVR) == ADC_FLAG_OVR) && ((tmp_ier & ADC_IT_OVR) == ADC_IT_OVR))
+  {
+    /* If overrun is set to overwrite previous data (default setting),        */
+    /* overrun event is not considered as an error.                           */
+    /* (cf ref manual "Managing conversions without using the DMA and without */
+    /* overrun ")                                                             */
+    /* Exception for usage with DMA overrun event always considered as an     */
+    /* error.                                                                 */
+    if (hadc->Init.Overrun == ADC_OVR_DATA_PRESERVED)
+    {
+      overrun_error = 1UL;
+    }
+    else
+    {
+      /* Check DMA configuration */
+      if (tmp_multimode_config != LL_ADC_MULTI_INDEPENDENT)
+      {
+        /* Multimode (when feature is available) is enabled,
+           Common Control Register MDMA bits must be checked. */
+        if (LL_ADC_GetMultiDMATransfer(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) != LL_ADC_MULTI_REG_DMA_EACH_ADC)
+        {
+          overrun_error = 1UL;
+        }
+      }
+      else
+      {
+        /* Multimode not set or feature not available or ADC independent */
+        if ((hadc->Instance->CFGR & ADC_CFGR_DMNGT) != 0UL)
+        {
+          overrun_error = 1UL;
+        }
+      }
+    }
+
+    if (overrun_error == 1UL)
+    {
+      /* Change ADC state to error state */
+      SET_BIT(hadc->State, HAL_ADC_STATE_REG_OVR);
+
+      /* Set ADC error code to overrun */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_OVR);
+
+      /* Error callback */
+      /* Note: In case of overrun, ADC conversion data is preserved until     */
+      /*       flag OVR is reset.                                             */
+      /*       Therefore, old ADC conversion data can be retrieved in         */
+      /*       function "HAL_ADC_ErrorCallback()".                            */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->ErrorCallback(hadc);
+#else
+      HAL_ADC_ErrorCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+    }
+
+    /* Clear ADC overrun flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_OVR);
+  }
+
+  /* ========== Check Injected context queue overflow flag ========== */
+  if (((tmp_isr & ADC_FLAG_JQOVF) == ADC_FLAG_JQOVF) && ((tmp_ier & ADC_IT_JQOVF) == ADC_IT_JQOVF))
+  {
+    /* Change ADC state to overrun state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_INJ_JQOVF);
+
+    /* Set ADC error code to Injected context queue overflow */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);
+
+    /* Clear the Injected context queue overflow flag */
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JQOVF);
+
+    /* Injected context queue overflow callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->InjectedQueueOverflowCallback(hadc);
+#else
+    HAL_ADCEx_InjectedQueueOverflowCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+  }
+
+}
+
+/**
+  * @brief  Conversion complete callback in non-blocking mode.
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ConvCpltCallback must be implemented in the user file.
+   */
+}
+
+/**
+  * @brief  Conversion DMA half-transfer callback in non-blocking mode.
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ConvHalfCpltCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Analog watchdog 1 callback in non-blocking mode.
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_LevelOutOfWindowCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_LevelOutOfWindowCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  ADC error callback in non-blocking mode
+  *         (ADC conversion with interruption or transfer by DMA).
+  * @note   In case of error due to overrun when using ADC with DMA transfer
+  *         (HAL ADC handle parameter "ErrorCode" to state "HAL_ADC_ERROR_OVR"):
+  *         - Reinitialize the DMA using function "HAL_ADC_Stop_DMA()".
+  *         - If needed, restart a new ADC conversion using function
+  *           "HAL_ADC_Start_DMA()"
+  *           (this function is also clearing overrun flag)
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADC_ErrorCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADC_ErrorCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group3 Peripheral Control functions
+  * @brief    Peripheral Control functions
+  *
+@verbatim
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Configure channels on regular group
+      (+) Configure the analog watchdog
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configure a channel to be assigned to ADC group regular.
+  * @note   In case of usage of internal measurement channels:
+  *         Vbat/VrefInt/TempSensor.
+  *         These internal paths can be disabled using function
+  *         HAL_ADC_DeInit().
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes channel into ADC group regular,
+  *         following calls to this function can be used to reconfigure
+  *         some parameters of structure "ADC_ChannelConfTypeDef" on the fly,
+  *         without resetting the ADC.
+  *         The setting of these parameters is conditioned to ADC state:
+  *         Refer to comments of structure "ADC_ChannelConfTypeDef".
+  * @param hadc ADC handle
+  * @param sConfig Structure of ADC channel assigned to ADC group regular.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_ConfigChannel(ADC_HandleTypeDef *hadc, ADC_ChannelConfTypeDef *sConfig)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tmpOffsetShifted;
+  uint32_t tmp_config_internal_channel;
+  __IO uint32_t wait_loop_index = 0;
+  uint32_t tmp_adc_is_conversion_on_going_regular;
+  uint32_t tmp_adc_is_conversion_on_going_injected;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_REGULAR_RANK(sConfig->Rank));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfig->SamplingTime));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(sConfig->SingleDiff));
+  assert_param(IS_ADC_OFFSET_NUMBER(sConfig->OffsetNumber));
+  /* Check offset range according to oversampling setting */
+  if (hadc->Init.OversamplingMode == ENABLE)
+  {
+    assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfig->Offset / (hadc->Init.Oversampling.Ratio + 1U)));
+  }
+  else
+  {
+#if defined(ADC_VER_V5_V90)
+    if (hadc->Instance == ADC3)
+    {
+      assert_param(IS_ADC3_RANGE(ADC_GET_RESOLUTION(hadc), sConfig->Offset));
+    }
+    else
+#endif /* ADC_VER_V5_V90 */
+    {
+      assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfig->Offset));
+    }
+  }
+#if defined(ADC3)
+  /* ADC3 is not available on some STM32H7 products */
+  if (hadc->Instance == ADC3)
+  {
+  /* if ROVSE is set, the value of the OFFSETy_EN bit in ADCx_OFRy register is
+     ignored (considered as reset) */
+  assert_param(!((sConfig->OffsetNumber != ADC_OFFSET_NONE) && (hadc->Init.OversamplingMode == ENABLE)));
+  }
+#endif
+  /* Verification of channel number */
+  if (sConfig->SingleDiff != ADC_DIFFERENTIAL_ENDED)
+  {
+    assert_param(IS_ADC_CHANNEL(sConfig->Channel));
+  }
+  else
+  {
+    if (hadc->Instance == ADC1)
+    {
+      assert_param(IS_ADC1_DIFF_CHANNEL(sConfig->Channel));
+    }
+    if (hadc->Instance == ADC2)
+    {
+      assert_param(IS_ADC2_DIFF_CHANNEL(sConfig->Channel));
+    }
+#if defined(ADC3)
+    /* ADC3 is not available on some STM32H7 products */
+    if (hadc->Instance == ADC3)
+    {
+      assert_param(IS_ADC3_DIFF_CHANNEL(sConfig->Channel));
+    }
+#endif
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular group:                                    */
+  /*  - Channel number                                                        */
+  /*  - Channel rank                                                          */
+  if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
+  {
+    if (!(__LL_ADC_IS_CHANNEL_INTERNAL(sConfig->Channel)))
+    {
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance != ADC3)
+      {
+        /* ADC channels preselection */
+        hadc->Instance->PCSEL_RES0 |= (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB((uint32_t)sConfig->Channel) & 0x1FUL));
+      }
+#else
+      /* ADC channels preselection */
+      hadc->Instance->PCSEL |= (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB((uint32_t)sConfig->Channel) & 0x1FUL));
+#endif /* ADC_VER_V5_V90 */
+    }
+
+    /* Set ADC group regular sequence: channel on the selected scan sequence rank */
+    LL_ADC_REG_SetSequencerRanks(hadc->Instance, sConfig->Rank, sConfig->Channel);
+
+    /* Parameters update conditioned to ADC state:                              */
+    /* Parameters that can be updated when ADC is disabled or enabled without   */
+    /* conversion on going on regular group:                                    */
+    /*  - Channel sampling time                                                 */
+    /*  - Channel offset                                                        */
+    tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+    tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
+    if ((tmp_adc_is_conversion_on_going_regular == 0UL)
+        && (tmp_adc_is_conversion_on_going_injected == 0UL)
+       )
+    {
+      /* Set sampling time of the selected ADC channel */
+      LL_ADC_SetChannelSamplingTime(hadc->Instance, sConfig->Channel, sConfig->SamplingTime);
+
+      /* Configure the offset: offset enable/disable, channel, offset value */
+
+      /* Shift the offset with respect to the selected ADC resolution. */
+      /* Offset has to be left-aligned on bit 11, the LSB (right bits) are set to 0 */
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance == ADC3)
+      {
+        tmpOffsetShifted = ADC3_OFFSET_SHIFT_RESOLUTION(hadc, (uint32_t)sConfig->Offset);
+      }
+      else
+#endif /* ADC_VER_V5_V90 */
+      {
+        tmpOffsetShifted = ADC_OFFSET_SHIFT_RESOLUTION(hadc, (uint32_t)sConfig->Offset);
+      }
+
+      if (sConfig->OffsetNumber != ADC_OFFSET_NONE)
+      {
+        /* Set ADC selected offset number */
+        LL_ADC_SetOffset(hadc->Instance, sConfig->OffsetNumber, sConfig->Channel, tmpOffsetShifted);
+
+#if defined(ADC_VER_V5_V90)
+        if (hadc->Instance == ADC3)
+        {
+          assert_param(IS_ADC3_OFFSET_SIGN(sConfig->OffsetSign));
+          assert_param(IS_FUNCTIONAL_STATE(sConfig->OffsetSaturation));
+          /* Set ADC selected offset sign & saturation */
+          LL_ADC_SetOffsetSign(hadc->Instance, sConfig->OffsetNumber, sConfig->OffsetSign);
+          LL_ADC_SetOffsetSaturation(hadc->Instance, sConfig->OffsetNumber, (sConfig->OffsetSaturation == ENABLE) ? LL_ADC_OFFSET_SATURATION_ENABLE : LL_ADC_OFFSET_SATURATION_DISABLE);
+        }
+        else
+#endif /* ADC_VER_V5_V90 */
+        {
+          assert_param(IS_FUNCTIONAL_STATE(sConfig->OffsetSignedSaturation));
+          /* Set ADC selected offset signed saturation */
+          LL_ADC_SetOffsetSignedSaturation(hadc->Instance, sConfig->OffsetNumber, (sConfig->OffsetSignedSaturation == ENABLE) ? LL_ADC_OFFSET_SIGNED_SATURATION_ENABLE : LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE);
+
+          assert_param(IS_FUNCTIONAL_STATE(sConfig->OffsetRightShift));
+          /* Set ADC selected offset right shift */
+          LL_ADC_SetDataRightShift(hadc->Instance, sConfig->OffsetNumber, (sConfig->OffsetRightShift == ENABLE) ? LL_ADC_OFFSET_RSHIFT_ENABLE : LL_ADC_OFFSET_RSHIFT_DISABLE);
+        }
+
+      }
+      else
+      {
+        /* Scan OFR1, OFR2, OFR3, OFR4 to check if the selected channel is enabled.
+          If this is the case, offset OFRx is disabled since
+          sConfig->OffsetNumber = ADC_OFFSET_NONE. */
+#if defined(ADC_VER_V5_V90)
+        if (hadc->Instance == ADC3)
+        {
+          if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_1)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfig->Channel))
+          {
+            LL_ADC_SetOffsetState(hadc->Instance, LL_ADC_OFFSET_1, LL_ADC_OFFSET_DISABLE);
+          }
+          if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_2)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfig->Channel))
+          {
+            LL_ADC_SetOffsetState(hadc->Instance, LL_ADC_OFFSET_2, LL_ADC_OFFSET_DISABLE);
+          }
+          if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_3)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfig->Channel))
+          {
+            LL_ADC_SetOffsetState(hadc->Instance, LL_ADC_OFFSET_3, LL_ADC_OFFSET_DISABLE);
+          }
+          if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_4)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfig->Channel))
+          {
+            LL_ADC_SetOffsetState(hadc->Instance, LL_ADC_OFFSET_4, LL_ADC_OFFSET_DISABLE);
+          }
+        }
+        else
+#endif /* ADC_VER_V5_V90 */
+        {
+          if (((hadc->Instance->OFR1) & ADC_OFR1_OFFSET1_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+          {
+            CLEAR_BIT(hadc->Instance->OFR1, ADC_OFR1_SSATE);
+          }
+          if (((hadc->Instance->OFR2) & ADC_OFR2_OFFSET2_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+          {
+            CLEAR_BIT(hadc->Instance->OFR2, ADC_OFR2_SSATE);
+          }
+          if (((hadc->Instance->OFR3) & ADC_OFR3_OFFSET3_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+          {
+            CLEAR_BIT(hadc->Instance->OFR3, ADC_OFR3_SSATE);
+          }
+          if (((hadc->Instance->OFR4) & ADC_OFR4_OFFSET4_CH) == ADC_OFR_CHANNEL(sConfig->Channel))
+          {
+            CLEAR_BIT(hadc->Instance->OFR4, ADC_OFR4_SSATE);
+          }
+        }
+
+     }
+    }
+
+    /* Parameters update conditioned to ADC state:                              */
+    /* Parameters that can be updated only when ADC is disabled:                */
+    /*  - Single or differential mode                                           */
+    /*  - Internal measurement channels: Vbat/VrefInt/TempSensor                */
+    if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+    {
+      /* Set mode single-ended or differential input of the selected ADC channel */
+      LL_ADC_SetChannelSingleDiff(hadc->Instance, sConfig->Channel, sConfig->SingleDiff);
+
+      /* Configuration of differential mode */
+      if (sConfig->SingleDiff == ADC_DIFFERENTIAL_ENDED)
+      {
+        /* Set ADC channel preselection of corresponding negative channel */
+        LL_ADC_SetChannelPreselection(hadc->Instance, ADC_CHANNEL_DIFF_NEG_INPUT(hadc, sConfig->Channel));
+      }
+
+      /* Management of internal measurement channels: Vbat/VrefInt/TempSensor.  */
+      /* If internal channel selected, enable dedicated internal buffers and    */
+      /* paths.                                                                 */
+      /* Note: these internal measurement paths can be disabled using           */
+      /* HAL_ADC_DeInit().                                                      */
+
+      if (__LL_ADC_IS_CHANNEL_INTERNAL(sConfig->Channel))
+      {
+        /* Configuration of common ADC parameters                                 */
+
+        tmp_config_internal_channel = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+        /* Software is allowed to change common parameters only when all ADCs   */
+        /* of the common group are disabled.                                    */
+        if (__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) == 0UL)
+        {
+          /* If the requested internal measurement path has already been enabled, */
+          /* bypass the configuration processing.                                 */
+          if ((sConfig->Channel == ADC_CHANNEL_TEMPSENSOR) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_TEMPSENSOR) == 0UL))
+          {
+            if (ADC_TEMPERATURE_SENSOR_INSTANCE(hadc))
+            {
+              LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_TEMPSENSOR | tmp_config_internal_channel);
+
+              /* Delay for temperature sensor stabilization time */
+              /* Wait loop initialization and execution */
+              /* Note: Variable divided by 2 to compensate partially              */
+              /*       CPU processing cycles, scaling in us split to not          */
+              /*       exceed 32 bits register capacity and handle low frequency. */
+              wait_loop_index = ((LL_ADC_DELAY_TEMPSENSOR_STAB_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
+              while (wait_loop_index != 0UL)
+              {
+                wait_loop_index--;
+              }
+            }
+          }
+          else if ((sConfig->Channel == ADC_CHANNEL_VBAT) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_VBAT) == 0UL))
+          {
+            if (ADC_BATTERY_VOLTAGE_INSTANCE(hadc))
+            {
+              LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_VBAT | tmp_config_internal_channel);
+            }
+          }
+          else if ((sConfig->Channel == ADC_CHANNEL_VREFINT) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_VREFINT) == 0UL))
+          {
+            if (ADC_VREFINT_INSTANCE(hadc))
+            {
+              LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_VREFINT | tmp_config_internal_channel);
+            }
+          }
+          else
+          {
+            /* nothing to do */
+          }
+        }
+        /* If the requested internal measurement path has already been          */
+        /* enabled and other ADC of the common group are enabled, internal      */
+        /* measurement paths cannot be enabled.                                 */
+        else
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+          tmp_hal_status = HAL_ERROR;
+        }
+      }
+    }
+  }
+
+  /* If a conversion is on going on regular group, no update on regular       */
+  /* channel could be done on neither of the channel configuration structure  */
+  /* parameters.                                                              */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Configure the analog watchdog.
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes the selected analog watchdog, successive
+  *         calls to this function can be used to reconfigure some parameters
+  *         of structure "ADC_AnalogWDGConfTypeDef" on the fly, without resetting
+  *         the ADC.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure
+  *         "ADC_AnalogWDGConfTypeDef".
+  * @note   On this STM32 series, analog watchdog thresholds cannot be modified
+  *         while ADC conversion is on going.
+  * @param hadc ADC handle
+  * @param AnalogWDGConfig Structure of ADC analog watchdog configuration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADC_AnalogWDGConfig(ADC_HandleTypeDef *hadc, ADC_AnalogWDGConfTypeDef *AnalogWDGConfig)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tmpAWDHighThresholdShifted;
+  uint32_t tmpAWDLowThresholdShifted;
+  uint32_t tmp_adc_is_conversion_on_going_regular;
+  uint32_t tmp_adc_is_conversion_on_going_injected;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_ANALOG_WATCHDOG_NUMBER(AnalogWDGConfig->WatchdogNumber));
+  assert_param(IS_ADC_ANALOG_WATCHDOG_MODE(AnalogWDGConfig->WatchdogMode));
+  assert_param(IS_FUNCTIONAL_STATE(AnalogWDGConfig->ITMode));
+
+  if ((AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REG)     ||
+      (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_INJEC)   ||
+      (AnalogWDGConfig->WatchdogMode == ADC_ANALOGWATCHDOG_SINGLE_REGINJEC))
+  {
+    assert_param(IS_ADC_CHANNEL(AnalogWDGConfig->Channel));
+  }
+
+#if defined(ADC_VER_V5_V90)
+
+  if (hadc->Instance == ADC3)
+  {
+    /* Verify thresholds range */
+    if (hadc->Init.OversamplingMode == ENABLE)
+    {
+      /* Case of oversampling enabled: thresholds are compared to oversampling
+         intermediate computation (after ratio, before shift application) */
+      assert_param(IS_ADC3_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->HighThreshold / (hadc->Init.Oversampling.Ratio + 1UL)));
+      assert_param(IS_ADC3_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->LowThreshold / (hadc->Init.Oversampling.Ratio + 1UL)));
+    }
+    else
+    {
+      /* Verify if thresholds are within the selected ADC resolution */
+      assert_param(IS_ADC3_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->HighThreshold));
+      assert_param(IS_ADC3_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->LowThreshold));
+    }
+  }
+  else
+#endif /* ADC_VER_V5_V90 */
+  {
+    /* Verify thresholds range */
+    if (hadc->Init.OversamplingMode == ENABLE)
+    {
+      /* Case of oversampling enabled: thresholds are compared to oversampling
+         intermediate computation (after ratio, before shift application) */
+      assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->HighThreshold / (hadc->Init.Oversampling.Ratio + 1UL)));
+      assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->LowThreshold / (hadc->Init.Oversampling.Ratio + 1UL)));
+    }
+    else
+    {
+      /* Verify if thresholds are within the selected ADC resolution */
+      assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->HighThreshold));
+      assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), AnalogWDGConfig->LowThreshold));
+    }
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on ADC groups regular and injected:                  */
+  /*  - Analog watchdog channels                                              */
+  /*  - Analog watchdog thresholds                                            */
+  tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+  tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
+  if ((tmp_adc_is_conversion_on_going_regular == 0UL)
+      && (tmp_adc_is_conversion_on_going_injected == 0UL)
+     )
+  {
+    /* Analog watchdog configuration */
+    if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_1)
+    {
+      /* Configuration of analog watchdog:                                    */
+      /*  - Set the analog watchdog enable mode: one or overall group of      */
+      /*    channels, on groups regular and-or injected.                      */
+      switch (AnalogWDGConfig->WatchdogMode)
+      {
+        case ADC_ANALOGWATCHDOG_SINGLE_REG:
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, __LL_ADC_ANALOGWD_CHANNEL_GROUP(AnalogWDGConfig->Channel,
+                                          LL_ADC_GROUP_REGULAR));
+          break;
+
+        case ADC_ANALOGWATCHDOG_SINGLE_INJEC:
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, __LL_ADC_ANALOGWD_CHANNEL_GROUP(AnalogWDGConfig->Channel,
+                                          LL_ADC_GROUP_INJECTED));
+          break;
+
+        case ADC_ANALOGWATCHDOG_SINGLE_REGINJEC:
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, __LL_ADC_ANALOGWD_CHANNEL_GROUP(AnalogWDGConfig->Channel,
+                                          LL_ADC_GROUP_REGULAR_INJECTED));
+          break;
+
+        case ADC_ANALOGWATCHDOG_ALL_REG:
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, LL_ADC_AWD_ALL_CHANNELS_REG);
+          break;
+
+        case ADC_ANALOGWATCHDOG_ALL_INJEC:
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, LL_ADC_AWD_ALL_CHANNELS_INJ);
+          break;
+
+        case ADC_ANALOGWATCHDOG_ALL_REGINJEC:
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, LL_ADC_AWD_ALL_CHANNELS_REG_INJ);
+          break;
+
+        default: /* ADC_ANALOGWATCHDOG_NONE */
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, LL_ADC_AWD1, LL_ADC_AWD_DISABLE);
+          break;
+      }
+
+      /* Shift the offset in function of the selected ADC resolution:         */
+      /* Thresholds have to be left-aligned on bit 11, the LSB (right bits)   */
+      /* are set to 0                                                         */
+      tmpAWDHighThresholdShifted = ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->HighThreshold);
+      tmpAWDLowThresholdShifted  = ADC_AWD1THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->LowThreshold);
+
+      /* Set the high and low thresholds */
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance == ADC3)
+      {
+        MODIFY_REG(hadc->Instance->LTR1_TR1,
+                   ADC3_TR1_AWDFILT,
+                   AnalogWDGConfig->FilteringConfig);
+        MODIFY_REG(hadc->Instance->LTR1_TR1,  ADC3_TR1_LT1, tmpAWDLowThresholdShifted);
+        MODIFY_REG(hadc->Instance->LTR1_TR1,  ADC3_TR1_HT1, (tmpAWDHighThresholdShifted << ADC3_TR1_HT1_Pos));
+      }
+      else
+      {
+
+        MODIFY_REG(hadc->Instance->LTR1_TR1,  ADC_LTR_LT, tmpAWDLowThresholdShifted);
+        MODIFY_REG(hadc->Instance->HTR1_TR2,  ADC_HTR_HT, tmpAWDHighThresholdShifted);
+      }
+#else
+      MODIFY_REG(hadc->Instance->LTR1,  ADC_LTR_LT, tmpAWDLowThresholdShifted);
+      MODIFY_REG(hadc->Instance->HTR1,  ADC_HTR_HT, tmpAWDHighThresholdShifted);
+#endif
+
+      /* Update state, clear previous result related to AWD1 */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_AWD1);
+
+      /* Clear flag ADC analog watchdog */
+      /* Note: Flag cleared Clear the ADC Analog watchdog flag to be ready  */
+      /* to use for HAL_ADC_IRQHandler() or HAL_ADC_PollForEvent()          */
+      /* (in case left enabled by previous ADC operations).                 */
+      LL_ADC_ClearFlag_AWD1(hadc->Instance);
+
+      /* Configure ADC analog watchdog interrupt */
+      if (AnalogWDGConfig->ITMode == ENABLE)
+      {
+        LL_ADC_EnableIT_AWD1(hadc->Instance);
+      }
+      else
+      {
+        LL_ADC_DisableIT_AWD1(hadc->Instance);
+      }
+    }
+    /* Case of ADC_ANALOGWATCHDOG_2 or ADC_ANALOGWATCHDOG_3 */
+    else
+    {
+      switch (AnalogWDGConfig->WatchdogMode)
+      {
+        case ADC_ANALOGWATCHDOG_SINGLE_REG:
+        case ADC_ANALOGWATCHDOG_SINGLE_INJEC:
+        case ADC_ANALOGWATCHDOG_SINGLE_REGINJEC:
+          /* Update AWD by bitfield to keep the possibility to monitor        */
+          /* several channels by successive calls of this function.           */
+          if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_2)
+          {
+            SET_BIT(hadc->Instance->AWD2CR, (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(AnalogWDGConfig->Channel) & 0x1FUL)));
+          }
+          else
+          {
+            SET_BIT(hadc->Instance->AWD3CR, (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(AnalogWDGConfig->Channel) & 0x1FUL)));
+          }
+          break;
+
+        case ADC_ANALOGWATCHDOG_ALL_REG:
+        case ADC_ANALOGWATCHDOG_ALL_INJEC:
+        case ADC_ANALOGWATCHDOG_ALL_REGINJEC:
+
+#if defined(ADC_VER_V5_V90)
+          if (hadc->Instance == ADC3)
+          {
+
+            LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, AnalogWDGConfig->WatchdogNumber, LL_ADC_AWD_ALL_CHANNELS_REG_INJ);
+
+          }
+          else
+          {
+#endif  /*ADC_VER_V5_V90*/
+            /* Update AWD by bitfield to keep the possibility to monitor        */
+            /* several channels by successive calls of this function.           */
+            if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_2)
+            {
+              SET_BIT(hadc->Instance->AWD2CR, (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(AnalogWDGConfig->Channel) & 0x1FUL)));
+            }
+            else
+            {
+              SET_BIT(hadc->Instance->AWD3CR, (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(AnalogWDGConfig->Channel) & 0x1FUL)));
+            }
+#if defined(ADC_VER_V5_V90)
+          }
+#endif  /*ADC_VER_V5_V90*/
+          break;
+
+        default: /* ADC_ANALOGWATCHDOG_NONE */
+          LL_ADC_SetAnalogWDMonitChannels(hadc->Instance, AnalogWDGConfig->WatchdogNumber, LL_ADC_AWD_DISABLE);
+          break;
+      }
+
+      /* Shift the thresholds in function of the selected ADC resolution      */
+      /* have to be left-aligned on bit 15, the LSB (right bits) are set to 0 */
+      tmpAWDHighThresholdShifted = ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->HighThreshold);
+      tmpAWDLowThresholdShifted  = ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->LowThreshold);
+
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance == ADC3)
+      {
+
+        /* Analog watchdog thresholds configuration */
+        if (AnalogWDGConfig->WatchdogNumber != ADC_ANALOGWATCHDOG_1)
+        {
+          /* Shift the offset with respect to the selected ADC resolution:        */
+          /* Thresholds have to be left-aligned on bit 7, the LSB (right bits)    */
+          /* are set to 0.                                                        */
+          tmpAWDHighThresholdShifted = ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->HighThreshold);
+          tmpAWDLowThresholdShifted  = ADC_AWD23THRESHOLD_SHIFT_RESOLUTION(hadc, AnalogWDGConfig->LowThreshold);
+        }
+
+        /* Set ADC analog watchdog thresholds value of both thresholds high and low */
+        LL_ADC_ConfigAnalogWDThresholds(hadc->Instance, AnalogWDGConfig->WatchdogNumber, tmpAWDHighThresholdShifted, tmpAWDLowThresholdShifted);
+
+
+      }
+      else
+      {
+
+        if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_2)
+        {
+          /* Set ADC analog watchdog thresholds value of both thresholds high and low */
+          MODIFY_REG(hadc->Instance->LTR2_DIFSEL,  ADC_LTR_LT, tmpAWDLowThresholdShifted);
+          MODIFY_REG(hadc->Instance->HTR2_CALFACT,  ADC_HTR_HT, tmpAWDHighThresholdShifted);
+        }
+        else
+        {
+          /* Set ADC analog watchdog thresholds value of both thresholds high and low */
+          MODIFY_REG(hadc->Instance->LTR3_RES10,  ADC_LTR_LT, tmpAWDLowThresholdShifted);
+          MODIFY_REG(hadc->Instance->HTR3_RES11,  ADC_HTR_HT, tmpAWDHighThresholdShifted);
+        }
+      }
+#else
+      if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_2)
+      {
+        /* Set ADC analog watchdog thresholds value of both thresholds high and low */
+        MODIFY_REG(hadc->Instance->LTR2,  ADC_LTR_LT, tmpAWDLowThresholdShifted);
+        MODIFY_REG(hadc->Instance->HTR2,  ADC_HTR_HT, tmpAWDHighThresholdShifted);
+      }
+      else
+      {
+        /* Set ADC analog watchdog thresholds value of both thresholds high and low */
+        MODIFY_REG(hadc->Instance->LTR3,  ADC_LTR_LT, tmpAWDLowThresholdShifted);
+        MODIFY_REG(hadc->Instance->HTR3,  ADC_HTR_HT, tmpAWDHighThresholdShifted);
+      }
+
+#endif
+      if (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_2)
+      {
+        /* Update state, clear previous result related to AWD2 */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_AWD2);
+
+        /* Clear flag ADC analog watchdog */
+        /* Note: Flag cleared Clear the ADC Analog watchdog flag to be ready  */
+        /* to use for HAL_ADC_IRQHandler() or HAL_ADC_PollForEvent()          */
+        /* (in case left enabled by previous ADC operations).                 */
+        LL_ADC_ClearFlag_AWD2(hadc->Instance);
+
+        /* Configure ADC analog watchdog interrupt */
+        if (AnalogWDGConfig->ITMode == ENABLE)
+        {
+          LL_ADC_EnableIT_AWD2(hadc->Instance);
+        }
+        else
+        {
+          LL_ADC_DisableIT_AWD2(hadc->Instance);
+        }
+      }
+      /* (AnalogWDGConfig->WatchdogNumber == ADC_ANALOGWATCHDOG_3) */
+      else
+      {
+        /* Update state, clear previous result related to AWD3 */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_AWD3);
+
+        /* Clear flag ADC analog watchdog */
+        /* Note: Flag cleared Clear the ADC Analog watchdog flag to be ready  */
+        /* to use for HAL_ADC_IRQHandler() or HAL_ADC_PollForEvent()          */
+        /* (in case left enabled by previous ADC operations).                 */
+        LL_ADC_ClearFlag_AWD3(hadc->Instance);
+
+        /* Configure ADC analog watchdog interrupt */
+        if (AnalogWDGConfig->ITMode == ENABLE)
+        {
+          LL_ADC_EnableIT_AWD3(hadc->Instance);
+        }
+        else
+        {
+          LL_ADC_DisableIT_AWD3(hadc->Instance);
+        }
+      }
+    }
+
+  }
+  /* If a conversion is on going on ADC group regular or injected, no update  */
+  /* could be done on neither of the AWD configuration structure parameters.  */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+    tmp_hal_status = HAL_ERROR;
+  }
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Exported_Functions_Group4 Peripheral State functions
+  *  @brief    ADC Peripheral State functions
+  *
+@verbatim
+ ===============================================================================
+            ##### Peripheral state and errors functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions to get in run-time the status of the
+    peripheral.
+      (+) Check the ADC state
+      (+) Check the ADC error code
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Return the ADC handle state.
+  * @note   ADC state machine is managed by bitfields, ADC status must be
+  *         compared with states bits.
+  *         For example:
+  *           " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_REG_BUSY) != 0UL) "
+  *           " if ((HAL_ADC_GetState(hadc1) & HAL_ADC_STATE_AWD1) != 0UL) "
+  * @param hadc ADC handle
+  * @retval ADC handle state (bitfield on 32 bits)
+  */
+uint32_t HAL_ADC_GetState(const ADC_HandleTypeDef *hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Return ADC handle state */
+  return hadc->State;
+}
+
+/**
+  * @brief  Return the ADC error code.
+  * @param hadc ADC handle
+  * @retval ADC error code (bitfield on 32 bits)
+  */
+uint32_t HAL_ADC_GetError(const ADC_HandleTypeDef *hadc)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  return hadc->ErrorCode;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_Private_Functions ADC Private Functions
+  * @{
+  */
+
+/**
+  * @brief  Stop ADC conversion.
+  * @param hadc ADC handle
+  * @param ConversionGroup ADC group regular and/or injected.
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_REGULAR_GROUP           ADC regular conversion type.
+  *            @arg @ref ADC_INJECTED_GROUP          ADC injected conversion type.
+  *            @arg @ref ADC_REGULAR_INJECTED_GROUP  ADC regular and injected conversion type.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef ADC_ConversionStop(ADC_HandleTypeDef *hadc, uint32_t ConversionGroup)
+{
+  uint32_t tickstart;
+  uint32_t Conversion_Timeout_CPU_cycles = 0UL;
+  uint32_t conversion_group_reassigned = ConversionGroup;
+  uint32_t tmp_ADC_CR_ADSTART_JADSTART;
+  uint32_t tmp_adc_is_conversion_on_going_regular;
+  uint32_t tmp_adc_is_conversion_on_going_injected;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_CONVERSION_GROUP(ConversionGroup));
+
+  /* Verification if ADC is not already stopped (on regular and injected      */
+  /* groups) to bypass this function if not needed.                           */
+  tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+  tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
+  if ((tmp_adc_is_conversion_on_going_regular != 0UL)
+      || (tmp_adc_is_conversion_on_going_injected != 0UL)
+     )
+  {
+    /* Particular case of continuous auto-injection mode combined with        */
+    /* auto-delay mode.                                                       */
+    /* In auto-injection mode, regular group stop ADC_CR_ADSTP is used (not   */
+    /* injected group stop ADC_CR_JADSTP).                                    */
+    /* Procedure to be followed: Wait until JEOS=1, clear JEOS, set ADSTP=1   */
+    /* (see reference manual).                                                */
+    if (((hadc->Instance->CFGR & ADC_CFGR_JAUTO) != 0UL)
+        && (hadc->Init.ContinuousConvMode == ENABLE)
+        && (hadc->Init.LowPowerAutoWait == ENABLE)
+       )
+    {
+      /* Use stop of regular group */
+      conversion_group_reassigned = ADC_REGULAR_GROUP;
+
+      /* Wait until JEOS=1 (maximum Timeout: 4 injected conversions) */
+      while (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS) == 0UL)
+      {
+        if (Conversion_Timeout_CPU_cycles >= (ADC_CONVERSION_TIME_MAX_CPU_CYCLES * 4UL))
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+          /* Set ADC error code to ADC peripheral internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+          return HAL_ERROR;
+        }
+        Conversion_Timeout_CPU_cycles ++;
+      }
+
+      /* Clear JEOS */
+      __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOS);
+    }
+
+    /* Stop potential conversion on going on ADC group regular */
+    if (conversion_group_reassigned != ADC_INJECTED_GROUP)
+    {
+      /* Software is allowed to set ADSTP only when ADSTART=1 and ADDIS=0 */
+      if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) != 0UL)
+      {
+        if (LL_ADC_IsDisableOngoing(hadc->Instance) == 0UL)
+        {
+          /* Stop ADC group regular conversion */
+          LL_ADC_REG_StopConversion(hadc->Instance);
+        }
+      }
+    }
+
+    /* Stop potential conversion on going on ADC group injected */
+    if (conversion_group_reassigned != ADC_REGULAR_GROUP)
+    {
+      /* Software is allowed to set JADSTP only when JADSTART=1 and ADDIS=0 */
+      if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) != 0UL)
+      {
+        if (LL_ADC_IsDisableOngoing(hadc->Instance) == 0UL)
+        {
+          /* Stop ADC group injected conversion */
+          LL_ADC_INJ_StopConversion(hadc->Instance);
+        }
+      }
+    }
+
+    /* Selection of start and stop bits with respect to the regular or injected group */
+    switch (conversion_group_reassigned)
+    {
+      case ADC_REGULAR_INJECTED_GROUP:
+        tmp_ADC_CR_ADSTART_JADSTART = (ADC_CR_ADSTART | ADC_CR_JADSTART);
+        break;
+      case ADC_INJECTED_GROUP:
+        tmp_ADC_CR_ADSTART_JADSTART = ADC_CR_JADSTART;
+        break;
+      /* Case ADC_REGULAR_GROUP only*/
+      default:
+        tmp_ADC_CR_ADSTART_JADSTART = ADC_CR_ADSTART;
+        break;
+    }
+
+    /* Wait for conversion effectively stopped */
+    tickstart = HAL_GetTick();
+
+    while ((hadc->Instance->CR & tmp_ADC_CR_ADSTART_JADSTART) != 0UL)
+    {
+      if ((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* New check to avoid false timeout detection in case of preemption */
+        if((hadc->Instance->CR & tmp_ADC_CR_ADSTART_JADSTART) != 0UL)
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+          /* Set ADC error code to ADC peripheral internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+          return HAL_ERROR;
+        }
+      }
+    }
+
+  }
+
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+
+
+/**
+  * @brief  Enable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC must be disabled
+  *         and voltage regulator must be enabled (done into HAL_ADC_Init()).
+  * @param hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef ADC_Enable(ADC_HandleTypeDef *hadc)
+{
+  uint32_t tickstart;
+
+  /* ADC enable and wait for ADC ready (in case of ADC is disabled or         */
+  /* enabling phase not yet completed: flag ADC ready not yet set).           */
+  /* Timeout implemented to not be stuck if ADC cannot be enabled (possible   */
+  /* causes: ADC clock not running, ...).                                     */
+  if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+  {
+    /* Check if conditions to enable the ADC are fulfilled */
+    if ((hadc->Instance->CR & (ADC_CR_ADCAL | ADC_CR_JADSTP | ADC_CR_ADSTP | ADC_CR_JADSTART | ADC_CR_ADSTART | ADC_CR_ADDIS | ADC_CR_ADEN)) != 0UL)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+      /* Set ADC error code to ADC peripheral internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+      return HAL_ERROR;
+    }
+
+    /* Enable the ADC peripheral */
+    LL_ADC_Enable(hadc->Instance);
+
+    /* Wait for ADC effectively enabled */
+    tickstart = HAL_GetTick();
+
+    /* Poll for ADC ready flag raised except case of multimode enabled
+       and ADC slave selected. */
+    uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+    if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+        || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+       )
+    {
+      while (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_RDY) == 0UL)
+      {
+        /*  If ADEN bit is set less than 4 ADC clock cycles after the ADCAL bit
+            has been cleared (after a calibration), ADEN bit is reset by the
+            calibration logic.
+            The workaround is to continue setting ADEN until ADRDY is becomes 1.
+            Additionally, ADC_ENABLE_TIMEOUT is defined to encompass this
+            4 ADC clock cycle duration */
+        /* Note: Test of ADC enabled required due to hardware constraint to     */
+        /*       not enable ADC if already enabled.                             */
+        if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+        {
+          LL_ADC_Enable(hadc->Instance);
+        }
+
+        if ((HAL_GetTick() - tickstart) > ADC_ENABLE_TIMEOUT)
+        {
+          /* New check to avoid false timeout detection in case of preemption */
+          if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_RDY) == 0UL)
+          {
+            /* Update ADC state machine to error */
+            SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+            /* Set ADC error code to ADC peripheral internal error */
+            SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+            return HAL_ERROR;
+          }
+        }
+      }
+    }
+  }
+
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disable the selected ADC.
+  * @note   Prerequisite condition to use this function: ADC conversions must be
+  *         stopped.
+  * @param hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef ADC_Disable(ADC_HandleTypeDef *hadc)
+{
+  uint32_t tickstart;
+  const uint32_t tmp_adc_is_disable_on_going = LL_ADC_IsDisableOngoing(hadc->Instance);
+
+  /* Verification if ADC is not already disabled:                             */
+  /* Note: forbidden to disable ADC (set bit ADC_CR_ADDIS) if ADC is already  */
+  /*       disabled.                                                          */
+  if ((LL_ADC_IsEnabled(hadc->Instance) != 0UL)
+      && (tmp_adc_is_disable_on_going == 0UL)
+     )
+  {
+    /* Check if conditions to disable the ADC are fulfilled */
+    if ((hadc->Instance->CR & (ADC_CR_JADSTART | ADC_CR_ADSTART | ADC_CR_ADEN)) == ADC_CR_ADEN)
+    {
+      /* Disable the ADC peripheral */
+      LL_ADC_Disable(hadc->Instance);
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOSMP | ADC_FLAG_RDY));
+    }
+    else
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+      /* Set ADC error code to ADC peripheral internal error */
+      SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+      return HAL_ERROR;
+    }
+
+    /* Wait for ADC effectively disabled */
+    /* Get tick count */
+    tickstart = HAL_GetTick();
+
+    while ((hadc->Instance->CR & ADC_CR_ADEN) != 0UL)
+    {
+      if ((HAL_GetTick() - tickstart) > ADC_DISABLE_TIMEOUT)
+      {
+        /* New check to avoid false timeout detection in case of preemption */
+        if ((hadc->Instance->CR & ADC_CR_ADEN) != 0UL)
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+          /* Set ADC error code to ADC peripheral internal error */
+          SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+          return HAL_ERROR;
+        }
+      }
+    }
+  }
+
+  /* Return HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  DMA transfer complete callback.
+  * @param hdma pointer to DMA handle.
+  * @retval None
+  */
+void ADC_DMAConvCplt(DMA_HandleTypeDef *hdma)
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef *hadc = (ADC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+  /* Update state machine on conversion status if not in error state */
+  if ((hadc->State & (HAL_ADC_STATE_ERROR_INTERNAL | HAL_ADC_STATE_ERROR_DMA)) == 0UL)
+  {
+    /* Set ADC state */
+    SET_BIT(hadc->State, HAL_ADC_STATE_REG_EOC);
+
+    /* Determine whether any further conversion upcoming on group regular     */
+    /* by external trigger, continuous mode or scan sequence on going         */
+    /* to disable interruption.                                               */
+    /* Is it the end of the regular sequence ? */
+    if ((hadc->Instance->ISR & ADC_FLAG_EOS) != 0UL)
+    {
+      /* Are conversions software-triggered ? */
+      if (LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance) != 0UL)
+      {
+        /* Is CONT bit set ? */
+        if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_CONT) == 0UL)
+        {
+          /* CONT bit is not set, no more conversions expected */
+          CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+          if ((hadc->State & HAL_ADC_STATE_INJ_BUSY) == 0UL)
+          {
+            SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+          }
+        }
+      }
+    }
+    else
+    {
+      /* DMA End of Transfer interrupt was triggered but conversions sequence
+         is not over. If DMACFG is set to 0, conversions are stopped. */
+      if (READ_BIT(hadc->Instance->CFGR, ADC_CFGR_DMNGT) == 0UL)
+      {
+        /* DMACFG bit is not set, conversions are stopped. */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+        if ((hadc->State & HAL_ADC_STATE_INJ_BUSY) == 0UL)
+        {
+          SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+        }
+      }
+    }
+
+    /* Conversion complete callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+    hadc->ConvCpltCallback(hadc);
+#else
+    HAL_ADC_ConvCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+  }
+  else /* DMA and-or internal error occurred */
+  {
+    if ((hadc->State & HAL_ADC_STATE_ERROR_INTERNAL) != 0UL)
+    {
+      /* Call HAL ADC Error Callback function */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+      hadc->ErrorCallback(hadc);
+#else
+      HAL_ADC_ErrorCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+    }
+    else
+    {
+      /* Call ADC DMA error callback */
+      hadc->DMA_Handle->XferErrorCallback(hdma);
+    }
+  }
+}
+
+/**
+  * @brief  DMA half transfer complete callback.
+  * @param hdma pointer to DMA handle.
+  * @retval None
+  */
+void ADC_DMAHalfConvCplt(DMA_HandleTypeDef *hdma)
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef *hadc = (ADC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+  /* Half conversion callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+  hadc->ConvHalfCpltCallback(hadc);
+#else
+  HAL_ADC_ConvHalfCpltCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+}
+
+/**
+  * @brief  DMA error callback.
+  * @param hdma pointer to DMA handle.
+  * @retval None
+  */
+void ADC_DMAError(DMA_HandleTypeDef *hdma)
+{
+  /* Retrieve ADC handle corresponding to current DMA handle */
+  ADC_HandleTypeDef *hadc = (ADC_HandleTypeDef *)((DMA_HandleTypeDef *)hdma)->Parent;
+
+  /* Set ADC state */
+  SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+
+  /* Set ADC error code to DMA error */
+  SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_DMA);
+
+  /* Error callback */
+#if (USE_HAL_ADC_REGISTER_CALLBACKS == 1)
+  hadc->ErrorCallback(hadc);
+#else
+  HAL_ADC_ErrorCallback(hadc);
+#endif /* USE_HAL_ADC_REGISTER_CALLBACKS */
+}
+
+/**
+  * @brief  Configure boost mode of selected ADC.
+  * @note   Prerequisite condition to use this function: ADC conversions must be
+  *         stopped.
+  * @param  hadc ADC handle
+  * @retval None.
+  */
+void ADC_ConfigureBoostMode(ADC_HandleTypeDef *hadc)
+{
+  uint32_t freq;
+  if (ADC_IS_SYNCHRONOUS_CLOCK_MODE(hadc))
+  {
+    freq = HAL_RCC_GetHCLKFreq();
+    switch (hadc->Init.ClockPrescaler)
+    {
+      case ADC_CLOCK_SYNC_PCLK_DIV1:
+      case ADC_CLOCK_SYNC_PCLK_DIV2:
+        freq /= (hadc->Init.ClockPrescaler >> ADC_CCR_CKMODE_Pos);
+        break;
+      case ADC_CLOCK_SYNC_PCLK_DIV4:
+        freq /= 4UL;
+        break;
+      default:
+        break;
+    }
+  }
+  else
+  {
+    freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_ADC);
+    switch (hadc->Init.ClockPrescaler)
+    {
+      case ADC_CLOCK_ASYNC_DIV2:
+      case ADC_CLOCK_ASYNC_DIV4:
+      case ADC_CLOCK_ASYNC_DIV6:
+      case ADC_CLOCK_ASYNC_DIV8:
+      case ADC_CLOCK_ASYNC_DIV10:
+      case ADC_CLOCK_ASYNC_DIV12:
+        freq /= ((hadc->Init.ClockPrescaler >> ADC_CCR_PRESC_Pos) << 1UL);
+        break;
+      case ADC_CLOCK_ASYNC_DIV16:
+        freq /= 16UL;
+        break;
+      case ADC_CLOCK_ASYNC_DIV32:
+        freq /= 32UL;
+        break;
+      case ADC_CLOCK_ASYNC_DIV64:
+        freq /= 64UL;
+        break;
+      case ADC_CLOCK_ASYNC_DIV128:
+        freq /= 128UL;
+        break;
+      case ADC_CLOCK_ASYNC_DIV256:
+        freq /= 256UL;
+        break;
+      default:
+        break;
+    }
+  }
+
+#if defined(ADC_VER_V5_3) || defined(ADC_VER_V5_V90)
+  freq /= 2U;
+  if (freq <= 6250000UL)
+  {
+    MODIFY_REG(hadc->Instance->CR, ADC_CR_BOOST, 0UL);
+  }
+  else if (freq <= 12500000UL)
+  {
+    MODIFY_REG(hadc->Instance->CR, ADC_CR_BOOST, ADC_CR_BOOST_0);
+  }
+  else if (freq <= 25000000UL)
+  {
+    MODIFY_REG(hadc->Instance->CR, ADC_CR_BOOST, ADC_CR_BOOST_1);
+  }
+  else /* if(freq > 25000000UL) */
+  {
+    MODIFY_REG(hadc->Instance->CR, ADC_CR_BOOST, ADC_CR_BOOST_1 | ADC_CR_BOOST_0);
+  }
+#else
+  if (HAL_GetREVID() <= REV_ID_Y) /* STM32H7 silicon Rev.Y */
+  {
+    if (freq > 20000000UL)
+    {
+      SET_BIT(hadc->Instance->CR, ADC_CR_BOOST_0);
+    }
+    else
+    {
+      CLEAR_BIT(hadc->Instance->CR, ADC_CR_BOOST_0);
+    }
+  }
+  else /* STM32H7 silicon Rev.V */
+  {
+    freq /= 2U; /* divider by 2 for Rev.V */
+
+    if (freq <= 6250000UL)
+    {
+      MODIFY_REG(hadc->Instance->CR, ADC_CR_BOOST, 0UL);
+    }
+    else if (freq <= 12500000UL)
+    {
+      MODIFY_REG(hadc->Instance->CR, ADC_CR_BOOST, ADC_CR_BOOST_0);
+    }
+    else if (freq <= 25000000UL)
+    {
+      MODIFY_REG(hadc->Instance->CR, ADC_CR_BOOST, ADC_CR_BOOST_1);
+    }
+    else /* if(freq > 25000000UL) */
+    {
+      MODIFY_REG(hadc->Instance->CR, ADC_CR_BOOST, ADC_CR_BOOST_1 | ADC_CR_BOOST_0);
+    }
+  }
+#endif /* ADC_VER_V5_3 */
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+

--- a/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_adc_ex.c
+++ b/lt/platforms/st/thirdparty/vendor-sdk/stmicro/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_adc_ex.c
@@ -1,0 +1,2659 @@
+/**
+  ******************************************************************************
+  * @file    stm32h7xx_hal_adc_ex.c
+  * @author  MCD Application Team
+  * @brief   This file provides firmware functions to manage the following
+  *          functionalities of the Analog to Digital Converter (ADC)
+  *          peripheral:
+  *           + Peripheral Control functions
+  *          Other functions (generic functions) are available in file
+  *          "stm32h7xx_hal_adc.c".
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  @verbatim
+  [..]
+  (@) Sections "ADC peripheral features" and "How to use this driver" are
+      available in file of generic functions "stm32h7xx_hal_adc.c".
+  [..]
+  @endverbatim
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32h7xx_hal.h"
+
+/** @addtogroup STM32H7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup ADCEx ADCEx
+  * @brief ADC Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_ADC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+
+/** @defgroup ADCEx_Private_Constants ADC Extended Private Constants
+  * @{
+  */
+
+#define ADC_JSQR_FIELDS  ((ADC_JSQR_JL | ADC_JSQR_JEXTSEL | ADC_JSQR_JEXTEN |\
+                           ADC_JSQR_JSQ1  | ADC_JSQR_JSQ2 |\
+                           ADC_JSQR_JSQ3 | ADC_JSQR_JSQ4 ))  /*!< ADC_JSQR fields of parameters that can be updated anytime
+                                                                  once the ADC is enabled */
+
+/* Fixed timeout value for ADC calibration.                                   */
+/* Fixed timeout value for ADC calibration.                                     */
+/* Values defined to be higher than worst cases: low clock frequency,         */
+/* maximum prescalers.                                                        */
+/* Ex of profile low frequency : f_ADC at 0.125 Mhz (minimum value              */
+/* according to Data sheet), calibration_time MAX = 165010 / f_ADC              */
+/*           165010 / 125000 = 1.32s                                            */
+/* At maximum CPU speed (480 MHz), this means                                   */
+/*    1.32 * 480 MHz = 633600000 CPU cycles                                     */
+#define ADC_CALIBRATION_TIMEOUT         (633600000U)   /*!< ADC calibration time-out value */
+
+
+/**
+  * @}
+  */
+
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup ADCEx_Exported_Functions ADC Extended Exported Functions
+  * @{
+  */
+
+/** @defgroup ADCEx_Exported_Functions_Group1 Extended Input and Output operation functions
+  * @brief    Extended IO operation functions
+  *
+@verbatim
+ ===============================================================================
+                      ##### IO operation functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+
+      (+) Perform the ADC self-calibration for single or differential ending.
+      (+) Get calibration factors for single or differential ending.
+      (+) Set calibration factors for single or differential ending.
+
+      (+) Start conversion of ADC group injected.
+      (+) Stop conversion of ADC group injected.
+      (+) Poll for conversion complete on ADC group injected.
+      (+) Get result of ADC group injected channel conversion.
+      (+) Start conversion of ADC group injected and enable interruptions.
+      (+) Stop conversion of ADC group injected and disable interruptions.
+
+      (+) When multimode feature is available, start multimode and enable DMA transfer.
+      (+) Stop multimode and disable ADC DMA transfer.
+      (+) Get result of multimode conversion.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Perform an ADC automatic self-calibration
+  *         Calibration prerequisite: ADC must be disabled (execute this
+  *         function before HAL_ADC_Start() or after HAL_ADC_Stop() ).
+  * @param  hadc       ADC handle
+* @param  CalibrationMode       Selection of calibration offset or
+  *         linear calibration offset.
+  *           @arg ADC_CALIB_OFFSET       Channel in mode calibration offset
+  *           @arg ADC_CALIB_OFFSET_LINEARITY Channel in mode linear calibration offset
+  * @param  SingleDiff Selection of single-ended or differential input
+  *         This parameter can be one of the following values:
+  *           @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
+  *           @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_Start(ADC_HandleTypeDef *hadc, uint32_t CalibrationMode, uint32_t SingleDiff)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  __IO uint32_t wait_loop_index = 0UL;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Calibration prerequisite: ADC must be disabled. */
+
+  /* Disable the ADC (if not already disabled) */
+  tmp_hal_status = ADC_Disable(hadc);
+
+  /* Check if ADC is effectively disabled */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                      HAL_ADC_STATE_BUSY_INTERNAL);
+
+    /* Start ADC calibration in mode single-ended or differential */
+    LL_ADC_StartCalibration(hadc->Instance, CalibrationMode, SingleDiff);
+
+    /* Wait for calibration completion */
+    while (LL_ADC_IsCalibrationOnGoing(hadc->Instance) != 0UL)
+    {
+      wait_loop_index++;
+      if (wait_loop_index >= ADC_CALIBRATION_TIMEOUT)
+      {
+        /* Update ADC state machine to error */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_BUSY_INTERNAL,
+                          HAL_ADC_STATE_ERROR_INTERNAL);
+
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+
+        return HAL_ERROR;
+      }
+    }
+
+    /* Set ADC state */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_BUSY_INTERNAL,
+                      HAL_ADC_STATE_READY);
+  }
+  else
+  {
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+    /* Note: No need to update variable "tmp_hal_status" here: already set    */
+    /*       to state "HAL_ERROR" by function disabling the ADC.              */
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Get the calibration factor.
+  * @param hadc ADC handle.
+  * @param SingleDiff This parameter can be only:
+  *           @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
+  *           @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended
+  * @retval Calibration value.
+  */
+uint32_t HAL_ADCEx_Calibration_GetValue(const ADC_HandleTypeDef *hadc, uint32_t SingleDiff)
+{
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff));
+
+  /* Return the selected ADC calibration value */
+  return LL_ADC_GetCalibrationOffsetFactor(hadc->Instance, SingleDiff);
+}
+
+/**
+  * @brief  Get the calibration factor from automatic conversion result
+  * @param  hadc ADC handle
+  * @param  LinearCalib_Buffer: Linear calibration factor
+  * @retval HAL state
+  */
+HAL_StatusTypeDef HAL_ADCEx_LinearCalibration_GetValue(ADC_HandleTypeDef *hadc, uint32_t *LinearCalib_Buffer)
+{
+  uint32_t cnt;
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t temp_REG_IsConversionOngoing = 0UL;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Enable the ADC ADEN = 1 to be able to read the linear calibration factor */
+  if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+  {
+    tmp_hal_status = ADC_Enable(hadc);
+  }
+
+  if (tmp_hal_status == HAL_OK)
+  {
+    if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) != 0UL)
+    {
+      LL_ADC_REG_StopConversion(hadc->Instance);
+      temp_REG_IsConversionOngoing = 1UL;
+    }
+    for (cnt = ADC_LINEAR_CALIB_REG_COUNT; cnt > 0UL; cnt--)
+    {
+      LinearCalib_Buffer[cnt - 1U] = LL_ADC_GetCalibrationLinearFactor(hadc->Instance, ADC_CR_LINCALRDYW6 >> (ADC_LINEAR_CALIB_REG_COUNT - cnt));
+    }
+    if (temp_REG_IsConversionOngoing != 0UL)
+    {
+      LL_ADC_REG_StartConversion(hadc->Instance);
+    }
+  }
+
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Set the calibration factor to overwrite automatic conversion result.
+  *         ADC must be enabled and no conversion is ongoing.
+  * @param hadc ADC handle
+  * @param SingleDiff This parameter can be only:
+  *           @arg @ref ADC_SINGLE_ENDED       Channel in mode input single ended
+  *           @arg @ref ADC_DIFFERENTIAL_ENDED Channel in mode input differential ended
+  * @param CalibrationFactor Calibration factor On devices STM32H72xx and STM32H73xx this parameter is coded on 11 bits
+  *                                             maximum for ADC1/2 and on 7 bits for ADC3.
+  *                                             On devices STM32H74xx and STM32H75xx this parameter is coded on 11 bits.
+  * @retval HAL state
+  */
+HAL_StatusTypeDef HAL_ADCEx_Calibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t SingleDiff, uint32_t CalibrationFactor)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tmp_adc_is_conversion_on_going_regular;
+  uint32_t tmp_adc_is_conversion_on_going_injected;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(SingleDiff));
+
+#if defined(ADC_VER_V5_V90)
+  if (hadc->Instance == ADC3)
+  {
+    assert_param(IS_ADC_CALFACT_ADC3(CalibrationFactor));
+  }
+  else
+  {
+    assert_param(IS_ADC_CALFACT(CalibrationFactor));
+  }
+#else
+  assert_param(IS_ADC_CALFACT(CalibrationFactor));
+#endif
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Verification of hardware constraints before modifying the calibration    */
+  /* factors register: ADC must be enabled, no conversion on going.           */
+  tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+  tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
+
+  if ((LL_ADC_IsEnabled(hadc->Instance) != 0UL)
+      && (tmp_adc_is_conversion_on_going_regular == 0UL)
+      && (tmp_adc_is_conversion_on_going_injected == 0UL)
+     )
+  {
+    /* Set the selected ADC calibration value */
+    LL_ADC_SetCalibrationOffsetFactor(hadc->Instance, SingleDiff, CalibrationFactor);
+  }
+  else
+  {
+    /* Update ADC state machine */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+    /* Update ADC error code */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+    /* Update ADC state machine to error */
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Set the linear calibration factor
+  * @param  hadc ADC handle
+  * @param  LinearCalib_Buffer: Linear calibration factor
+  * @retval HAL state
+  */
+HAL_StatusTypeDef HAL_ADCEx_LinearCalibration_SetValue(ADC_HandleTypeDef *hadc, uint32_t *LinearCalib_Buffer)
+{
+  uint32_t cnt;
+  __IO uint32_t wait_loop_index = 0;
+  uint32_t temp_REG_IsConversionOngoing = 0UL;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* - Exit from deep-power-down mode and ADC voltage regulator enable        */
+  /*  Exit deep power down mode if still in that state                        */
+  if (HAL_IS_BIT_SET(hadc->Instance->CR, ADC_CR_DEEPPWD))
+  {
+    /* Exit deep power down mode */
+    CLEAR_BIT(hadc->Instance->CR, ADC_CR_DEEPPWD);
+
+    /* System was in deep power down mode, calibration must
+       be relaunched or a previously saved calibration factor
+       re-applied once the ADC voltage regulator is enabled */
+  }
+
+
+  if (HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADVREGEN))
+  {
+    /* Enable ADC internal voltage regulator                                  */
+    SET_BIT(hadc->Instance->CR, ADC_CR_ADVREGEN);
+    /* Delay for ADC stabilization time                                       */
+    /* Wait loop initialization and execution                                 */
+    /* Note: Variable divided by 2 to compensate partially                    */
+    /*       CPU processing cycles.                                           */
+    wait_loop_index = ((ADC_STAB_DELAY_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
+    while (wait_loop_index != 0UL)
+    {
+      wait_loop_index--;
+    }
+  }
+
+
+  /* Verification that ADC voltage regulator is correctly enabled, whether    */
+  /* or not ADC is coming from state reset (if any potential problem of       */
+  /* clocking, voltage regulator would not be enabled).                       */
+  if (HAL_IS_BIT_CLR(hadc->Instance->CR, ADC_CR_ADVREGEN))
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+    /* Set ADC error code to ADC peripheral internal error */
+    SET_BIT(hadc->ErrorCode, HAL_ADC_ERROR_INTERNAL);
+
+    return  HAL_ERROR;
+  }
+  /* Enable the ADC peripheral */
+  if (LL_ADC_IsEnabled(hadc->Instance) == 0UL) /* Enable the ADC if it is disabled */
+  {
+    if (ADC_Enable(hadc) != HAL_OK)
+    {
+      return  HAL_ERROR;
+    }
+    else
+    {
+      for (cnt = ADC_LINEAR_CALIB_REG_COUNT; cnt > 0UL ; cnt--)
+      {
+        LL_ADC_SetCalibrationLinearFactor(hadc->Instance, ADC_CR_LINCALRDYW6 >> (ADC_LINEAR_CALIB_REG_COUNT - cnt), LinearCalib_Buffer[cnt - 1U]);
+      }
+      (void)ADC_Disable(hadc);
+    }
+  }
+  else  /* ADC is already enabled, so no need to enable it but need to stop conversion */
+  {
+    if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) != 0UL)
+    {
+      LL_ADC_REG_StopConversion(hadc->Instance);
+      temp_REG_IsConversionOngoing = 1UL;
+    }
+    for (cnt = ADC_LINEAR_CALIB_REG_COUNT; cnt > 0UL ; cnt--)
+    {
+      LL_ADC_SetCalibrationLinearFactor(hadc->Instance, ADC_CR_LINCALRDYW6 >> (ADC_LINEAR_CALIB_REG_COUNT - cnt), LinearCalib_Buffer[cnt - 1U]);
+    }
+    if (temp_REG_IsConversionOngoing != 0UL)
+    {
+      LL_ADC_REG_StartConversion(hadc->Instance);
+    }
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  Load the calibration factor from engi bytes
+  * @param  hadc ADC handle
+  * @retval HAL state
+  */
+HAL_StatusTypeDef HAL_ADCEx_LinearCalibration_FactorLoad(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t cnt, FactorOffset;
+  uint32_t LinearCalib_Buffer[ADC_LINEAR_CALIB_REG_COUNT];
+
+  /* Linearity calibration is retrieved from engi bytes
+     read values from registers and put them to the CALFACT2 register */
+  /* If needed linearity calibration can be done in runtime using
+     LL_ADC_GetCalibrationLinearFactor()                             */
+  if (hadc->Instance == ADC1)
+  {
+    FactorOffset = 0UL;
+  }
+  else if (hadc->Instance == ADC2)
+  {
+    FactorOffset = 8UL;
+  }
+  else   /*Case ADC3*/
+  {
+    FactorOffset = 16UL;
+  }
+
+  for (cnt = 0UL; cnt < ADC_LINEAR_CALIB_REG_COUNT; cnt++)
+  {
+    LinearCalib_Buffer[cnt] = *(uint32_t *)(ADC_LINEAR_CALIB_REG_1_ADDR + FactorOffset + cnt);
+  }
+  if (HAL_ADCEx_LinearCalibration_SetValue(hadc, (uint32_t *)LinearCalib_Buffer) != HAL_OK)
+  {
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Enable ADC, start conversion of injected group.
+  * @note   Interruptions enabled in this function: None.
+  * @note   Case of multimode enabled when multimode feature is available:
+  *         HAL_ADCEx_InjectedStart() API must be called for ADC slave first,
+  *         then for ADC master.
+  *         For ADC slave, ADC is enabled only (conversion is not started).
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param hadc ADC handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  uint32_t tmp_config_injected_queue;
+  uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) != 0UL)
+  {
+    return HAL_BUSY;
+  }
+  else
+  {
+    /* In case of software trigger detection enabled, JQDIS must be set
+      (which can be done only if ADSTART and JADSTART are both cleared).
+       If JQDIS is not set at that point, returns an error
+       - since software trigger detection is disabled. User needs to
+       resort to HAL_ADCEx_DisableInjectedQueue() API to set JQDIS.
+       - or (if JQDIS is intentionally reset) since JEXTEN = 0 which means
+         the queue is empty */
+    tmp_config_injected_queue = READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS);
+
+    if ((READ_BIT(hadc->Instance->JSQR, ADC_JSQR_JEXTEN) == 0UL)
+        && (tmp_config_injected_queue == 0UL)
+       )
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      return HAL_ERROR;
+    }
+
+    /* Process locked */
+    __HAL_LOCK(hadc);
+
+    /* Enable the ADC peripheral */
+    tmp_hal_status = ADC_Enable(hadc);
+
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Check if a regular conversion is ongoing */
+      if ((hadc->State & HAL_ADC_STATE_REG_BUSY) != 0UL)
+      {
+        /* Reset ADC error code field related to injected conversions only */
+        CLEAR_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);
+      }
+      else
+      {
+        /* Set ADC error code to none */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+
+      /* Set ADC state                                                        */
+      /* - Clear state bitfield related to injected group conversion results  */
+      /* - Set state bitfield related to injected operation                   */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_INJ_EOC,
+                        HAL_ADC_STATE_INJ_BUSY);
+
+      /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - if ADC instance is master or if multimode feature is not available
+        - if multimode setting is disabled (ADC instance slave in independent mode) */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+         )
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+
+      /* Clear ADC group injected group conversion flag */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_JEOC | ADC_FLAG_JEOS));
+
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+
+      /* Enable conversion of injected group, if automatic injected conversion  */
+      /* is disabled.                                                           */
+      /* If software start has been selected, conversion starts immediately.    */
+      /* If external trigger has been selected, conversion will start at next   */
+      /* trigger event.                                                         */
+      /* Case of multimode enabled (when multimode feature is available):       */
+      /* if ADC is slave,                                                       */
+      /*    - ADC is enabled only (conversion is not started),                  */
+      /*    - if multimode only concerns regular conversion, ADC is enabled     */
+      /*     and conversion is started.                                         */
+      /* If ADC is master or independent,                                       */
+      /*    - ADC is enabled and conversion is started.                         */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_REG_SIMULT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_REG_INTERL)
+         )
+      {
+        /* ADC instance is not a multimode slave instance with multimode injected conversions enabled */
+        if (LL_ADC_INJ_GetTrigAuto(hadc->Instance) == LL_ADC_INJ_TRIG_INDEPENDENT)
+        {
+          LL_ADC_INJ_StartConversion(hadc->Instance);
+        }
+      }
+      else
+      {
+        /* ADC instance is not a multimode slave instance with multimode injected conversions enabled */
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+
+    /* Return function status */
+    return tmp_hal_status;
+  }
+}
+
+/**
+  * @brief  Stop conversion of injected channels. Disable ADC peripheral if
+  *         no regular conversion is on going.
+  * @note   If ADC must be disabled and if conversion is on going on
+  *         regular group, function HAL_ADC_Stop must be used to stop both
+  *         injected and regular groups, and disable the ADC.
+  * @note   If injected group mode auto-injection is enabled,
+  *         function HAL_ADC_Stop must be used.
+  * @note   In case of multimode enabled (when multimode feature is available),
+  *         HAL_ADCEx_InjectedStop() must be called for ADC master first, then for ADC slave.
+  *         For ADC master, conversion is stopped and ADC is disabled.
+  *         For ADC slave, ADC is disabled only (conversion stop of ADC master
+  *         has already stopped conversion of ADC slave).
+  * @param hadc ADC handle.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* 1. Stop potential conversion on going on injected group only. */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if injected conversions are effectively stopped   */
+  /* and if no conversion on regular group is on-going                       */
+  if (tmp_hal_status == HAL_OK)
+  {
+    if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
+    {
+      /* 2. Disable the ADC peripheral */
+      tmp_hal_status = ADC_Disable(hadc);
+
+      /* Check if ADC is effectively disabled */
+      if (tmp_hal_status == HAL_OK)
+      {
+        /* Set ADC state */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                          HAL_ADC_STATE_READY);
+      }
+    }
+    /* Conversion on injected group is stopped, but ADC not disabled since    */
+    /* conversion on regular group is still running.                          */
+    else
+    {
+      /* Set ADC state */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Wait for injected group conversion to be completed.
+  * @param hadc ADC handle
+  * @param Timeout Timeout value in millisecond.
+  * @note   Depending on hadc->Init.EOCSelection, JEOS or JEOC is
+  *         checked and cleared depending on AUTDLY bit status.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedPollForConversion(ADC_HandleTypeDef *hadc, uint32_t Timeout)
+{
+  uint32_t tickstart;
+  uint32_t tmp_Flag_End;
+  uint32_t tmp_adc_inj_is_trigger_source_sw_start;
+  uint32_t tmp_adc_reg_is_trigger_source_sw_start;
+  uint32_t tmp_cfgr;
+  const ADC_TypeDef *tmpADC_Master;
+  uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* If end of sequence selected */
+  if (hadc->Init.EOCSelection == ADC_EOC_SEQ_CONV)
+  {
+    tmp_Flag_End = ADC_FLAG_JEOS;
+  }
+  else /* end of conversion selected */
+  {
+    tmp_Flag_End = ADC_FLAG_JEOC;
+  }
+
+  /* Get timeout */
+  tickstart = HAL_GetTick();
+
+  /* Wait until End of Conversion or Sequence flag is raised */
+  while ((hadc->Instance->ISR & tmp_Flag_End) == 0UL)
+  {
+    /* Check if timeout is disabled (set to infinite wait) */
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if (((HAL_GetTick() - tickstart) > Timeout) || (Timeout == 0UL))
+      {
+        if((hadc->Instance->ISR & tmp_Flag_End) == 0UL)
+        {
+          /* Update ADC state machine to timeout */
+          SET_BIT(hadc->State, HAL_ADC_STATE_TIMEOUT);
+
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+
+          return HAL_TIMEOUT;
+        }
+      }
+    }
+  }
+
+  /* Retrieve ADC configuration */
+  tmp_adc_inj_is_trigger_source_sw_start = LL_ADC_INJ_IsTriggerSourceSWStart(hadc->Instance);
+  tmp_adc_reg_is_trigger_source_sw_start = LL_ADC_REG_IsTriggerSourceSWStart(hadc->Instance);
+  /* Get relevant register CFGR in ADC instance of ADC master or slave  */
+  /* in function of multimode state (for devices with multimode         */
+  /* available).                                                        */
+  if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+      || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+      || (tmp_multimode_config == LL_ADC_MULTI_DUAL_REG_SIMULT)
+      || (tmp_multimode_config == LL_ADC_MULTI_DUAL_REG_INTERL)
+     )
+  {
+    tmp_cfgr = READ_REG(hadc->Instance->CFGR);
+  }
+  else
+  {
+    tmpADC_Master = __LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance);
+    tmp_cfgr = READ_REG(tmpADC_Master->CFGR);
+  }
+
+  /* Update ADC state machine */
+  SET_BIT(hadc->State, HAL_ADC_STATE_INJ_EOC);
+
+  /* Determine whether any further conversion upcoming on group injected      */
+  /* by external trigger or by automatic injected conversion                  */
+  /* from group regular.                                                      */
+  if ((tmp_adc_inj_is_trigger_source_sw_start != 0UL)            ||
+      ((READ_BIT(tmp_cfgr, ADC_CFGR_JAUTO) == 0UL)      &&
+       ((tmp_adc_reg_is_trigger_source_sw_start != 0UL)  &&
+        (READ_BIT(tmp_cfgr, ADC_CFGR_CONT) == 0UL))))
+  {
+    /* Check whether end of sequence is reached */
+    if (__HAL_ADC_GET_FLAG(hadc, ADC_FLAG_JEOS))
+    {
+      /* Particular case if injected contexts queue is enabled:             */
+      /* when the last context has been fully processed, JSQR is reset      */
+      /* by the hardware. Even if no injected conversion is planned to come */
+      /* (queue empty, triggers are ignored), it can start again            */
+      /* immediately after setting a new context (JADSTART is still set).   */
+      /* Therefore, state of HAL ADC injected group is kept to busy.        */
+      if (READ_BIT(tmp_cfgr, ADC_CFGR_JQM) == 0UL)
+      {
+        /* Set ADC state */
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+
+        if ((hadc->State & HAL_ADC_STATE_REG_BUSY) == 0UL)
+        {
+          SET_BIT(hadc->State, HAL_ADC_STATE_READY);
+        }
+      }
+    }
+  }
+
+  /* Clear polled flag */
+  if (tmp_Flag_End == ADC_FLAG_JEOS)
+  {
+    /* Clear end of sequence JEOS flag of injected group if low power feature */
+    /* "LowPowerAutoWait " is disabled, to not interfere with this feature.   */
+    /* For injected groups, no new conversion will start before JEOS is       */
+    /* cleared.                                                               */
+    if (READ_BIT(tmp_cfgr, ADC_CFGR_AUTDLY) == 0UL)
+    {
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_JEOC | ADC_FLAG_JEOS));
+    }
+  }
+  else
+  {
+    __HAL_ADC_CLEAR_FLAG(hadc, ADC_FLAG_JEOC);
+  }
+
+  /* Return API HAL status */
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enable ADC, start conversion of injected group with interruption.
+  * @note   Interruptions enabled in this function according to initialization
+  *         setting : JEOC (end of conversion) or JEOS (end of sequence)
+  * @note   Case of multimode enabled (when multimode feature is enabled):
+  *         HAL_ADCEx_InjectedStart_IT() API must be called for ADC slave first,
+  *         then for ADC master.
+  *         For ADC slave, ADC is enabled only (conversion is not started).
+  *         For ADC master, ADC is enabled and multimode conversion is started.
+  * @param hadc ADC handle.
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStart_IT(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  uint32_t tmp_config_injected_queue;
+  uint32_t tmp_multimode_config = LL_ADC_GetMultimode(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) != 0UL)
+  {
+    return HAL_BUSY;
+  }
+  else
+  {
+    /* In case of software trigger detection enabled, JQDIS must be set
+      (which can be done only if ADSTART and JADSTART are both cleared).
+       If JQDIS is not set at that point, returns an error
+       - since software trigger detection is disabled. User needs to
+       resort to HAL_ADCEx_DisableInjectedQueue() API to set JQDIS.
+       - or (if JQDIS is intentionally reset) since JEXTEN = 0 which means
+         the queue is empty */
+    tmp_config_injected_queue = READ_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS);
+
+    if ((READ_BIT(hadc->Instance->JSQR, ADC_JSQR_JEXTEN) == 0UL)
+        && (tmp_config_injected_queue == 0UL)
+       )
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+      return HAL_ERROR;
+    }
+
+    /* Process locked */
+    __HAL_LOCK(hadc);
+
+    /* Enable the ADC peripheral */
+    tmp_hal_status = ADC_Enable(hadc);
+
+    /* Start conversion if ADC is effectively enabled */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Check if a regular conversion is ongoing */
+      if ((hadc->State & HAL_ADC_STATE_REG_BUSY) != 0UL)
+      {
+        /* Reset ADC error code field related to injected conversions only */
+        CLEAR_BIT(hadc->ErrorCode, HAL_ADC_ERROR_JQOVF);
+      }
+      else
+      {
+        /* Set ADC error code to none */
+        ADC_CLEAR_ERRORCODE(hadc);
+      }
+
+      /* Set ADC state                                                        */
+      /* - Clear state bitfield related to injected group conversion results  */
+      /* - Set state bitfield related to injected operation                   */
+      ADC_STATE_CLR_SET(hadc->State,
+                        HAL_ADC_STATE_READY | HAL_ADC_STATE_INJ_EOC,
+                        HAL_ADC_STATE_INJ_BUSY);
+
+      /* Reset HAL_ADC_STATE_MULTIMODE_SLAVE bit
+        - if ADC instance is master or if multimode feature is not available
+        - if multimode setting is disabled (ADC instance slave in independent mode) */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+         )
+      {
+        CLEAR_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+
+      /* Clear ADC group injected group conversion flag */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_JEOC | ADC_FLAG_JEOS));
+
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+
+      /* Enable ADC Injected context queue overflow interrupt if this feature   */
+      /* is enabled.                                                            */
+      if ((hadc->Instance->CFGR & ADC_CFGR_JQM) != 0UL)
+      {
+        __HAL_ADC_ENABLE_IT(hadc, ADC_FLAG_JQOVF);
+      }
+
+      /* Enable ADC end of conversion interrupt */
+      switch (hadc->Init.EOCSelection)
+      {
+        case ADC_EOC_SEQ_CONV:
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOC);
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOS);
+          break;
+        /* case ADC_EOC_SINGLE_CONV */
+        default:
+          __HAL_ADC_DISABLE_IT(hadc, ADC_IT_JEOS);
+          __HAL_ADC_ENABLE_IT(hadc, ADC_IT_JEOC);
+          break;
+      }
+
+      /* Enable conversion of injected group, if automatic injected conversion  */
+      /* is disabled.                                                           */
+      /* If software start has been selected, conversion starts immediately.    */
+      /* If external trigger has been selected, conversion will start at next   */
+      /* trigger event.                                                         */
+      /* Case of multimode enabled (when multimode feature is available):       */
+      /* if ADC is slave,                                                       */
+      /*    - ADC is enabled only (conversion is not started),                  */
+      /*    - if multimode only concerns regular conversion, ADC is enabled     */
+      /*     and conversion is started.                                         */
+      /* If ADC is master or independent,                                       */
+      /*    - ADC is enabled and conversion is started.                         */
+      if ((__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) == hadc->Instance)
+          || (tmp_multimode_config == LL_ADC_MULTI_INDEPENDENT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_REG_SIMULT)
+          || (tmp_multimode_config == LL_ADC_MULTI_DUAL_REG_INTERL)
+         )
+      {
+        /* ADC instance is not a multimode slave instance with multimode injected conversions enabled */
+        if (LL_ADC_INJ_GetTrigAuto(hadc->Instance) == LL_ADC_INJ_TRIG_INDEPENDENT)
+        {
+          LL_ADC_INJ_StartConversion(hadc->Instance);
+        }
+      }
+      else
+      {
+        /* ADC instance is not a multimode slave instance with multimode injected conversions enabled */
+        SET_BIT(hadc->State, HAL_ADC_STATE_MULTIMODE_SLAVE);
+      }
+
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+
+    /* Return function status */
+    return tmp_hal_status;
+  }
+}
+
+/**
+  * @brief  Stop conversion of injected channels, disable interruption of
+  *         end-of-conversion. Disable ADC peripheral if no regular conversion
+  *         is on going.
+  * @note   If ADC must be disabled and if conversion is on going on
+  *         regular group, function HAL_ADC_Stop must be used to stop both
+  *         injected and regular groups, and disable the ADC.
+  * @note   If injected group mode auto-injection is enabled,
+  *         function HAL_ADC_Stop must be used.
+  * @note   Case of multimode enabled (when multimode feature is available):
+  *         HAL_ADCEx_InjectedStop_IT() API must be called for ADC master first,
+  *         then for ADC slave.
+  *         For ADC master, conversion is stopped and ADC is disabled.
+  *         For ADC slave, ADC is disabled only (conversion stop of ADC master
+  *         has already stopped conversion of ADC slave).
+  * @note   In case of auto-injection mode, HAL_ADC_Stop() must be used.
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedStop_IT(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* 1. Stop potential conversion on going on injected group only. */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if injected conversions are effectively stopped   */
+  /* and if no conversion on the other group (regular group) is intended to   */
+  /* continue.                                                                */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Disable ADC end of conversion interrupt for injected channels */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_JEOC | ADC_IT_JEOS | ADC_FLAG_JQOVF));
+
+    if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
+    {
+      /* 2. Disable the ADC peripheral */
+      tmp_hal_status = ADC_Disable(hadc);
+
+      /* Check if ADC is effectively disabled */
+      if (tmp_hal_status == HAL_OK)
+      {
+        /* Set ADC state */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                          HAL_ADC_STATE_READY);
+      }
+    }
+    /* Conversion on injected group is stopped, but ADC not disabled since    */
+    /* conversion on regular group is still running.                          */
+    else
+    {
+      /* Set ADC state */
+      CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Enable ADC, start MultiMode conversion and transfer regular results through DMA.
+  * @note   Multimode must have been previously configured using
+  *         HAL_ADCEx_MultiModeConfigChannel() function.
+  *         Interruptions enabled in this function:
+  *          overrun, DMA half transfer, DMA transfer complete.
+  *         Each of these interruptions has its dedicated callback function.
+  * @note   Case of ADC slave using its own DMA channel (typical case being both ADC instances using DMA channel
+  *         of ADC master with data concatenated): multimode must be configured without data packing and
+  *         this function must be called first with handle of ADC slave, then with handle of ADC master.
+  * @note   State field of Slave ADC handle is not updated in this configuration:
+  *         user should not rely on it for information related to Slave regular
+  *         conversions.
+  * @param hadc ADC handle of ADC master (handle of ADC slave must not be used)
+  * @param pData Destination Buffer address.
+  * @param Length Length of data to be transferred from ADC peripheral to memory.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStart_DMA(ADC_HandleTypeDef *hadc, const uint32_t *pData, uint32_t Length)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  ADC_HandleTypeDef tmphadcSlave;
+  ADC_Common_TypeDef *tmpADC_Common;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  assert_param(IS_FUNCTIONAL_STATE(hadc->Init.ContinuousConvMode));
+  assert_param(IS_ADC_EXTTRIG_EDGE(hadc->Init.ExternalTrigConvEdge));
+
+  if (LL_ADC_REG_IsConversionOngoing(hadc->Instance) != 0UL)
+  {
+    return HAL_BUSY;
+  }
+  else
+  {
+    /* Process locked */
+    __HAL_LOCK(hadc);
+
+    /* Case of ADC slave using its own DMA channel: check whether handle selected
+       corresponds to ADC master or slave instance */
+    if (__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) != hadc->Instance)
+    {
+      /* Case of ADC slave selected: enable ADC instance */
+      tmp_hal_status = ADC_Enable(hadc);
+    }
+    else
+    {
+      tmphadcSlave.State = HAL_ADC_STATE_RESET;
+      tmphadcSlave.ErrorCode = HAL_ADC_ERROR_NONE;
+      /* Set a temporary handle of the ADC slave associated to the ADC master   */
+      ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+
+      if (tmphadcSlave.Instance == NULL)
+      {
+        /* Set ADC state */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+        /* Process unlocked */
+        __HAL_UNLOCK(hadc);
+
+        return HAL_ERROR;
+      }
+
+      /* Enable the ADC peripherals: master and slave (in case if not already   */
+      /* enabled previously)                                                    */
+      tmp_hal_status = ADC_Enable(hadc);
+      if (tmp_hal_status == HAL_OK)
+      {
+        tmp_hal_status = ADC_Enable(&tmphadcSlave);
+      }
+    }
+
+    /* Start multimode conversion of ADCs pair */
+    if (tmp_hal_status == HAL_OK)
+    {
+      /* Set ADC state */
+      ADC_STATE_CLR_SET(hadc->State,
+                        (HAL_ADC_STATE_READY | HAL_ADC_STATE_REG_EOC | HAL_ADC_STATE_REG_OVR | HAL_ADC_STATE_REG_EOSMP),
+                        HAL_ADC_STATE_REG_BUSY);
+
+      /* Set ADC error code to none */
+      ADC_CLEAR_ERRORCODE(hadc);
+
+      /* Set the DMA transfer complete callback */
+      hadc->DMA_Handle->XferCpltCallback = ADC_DMAConvCplt;
+
+      /* Set the DMA half transfer complete callback */
+      hadc->DMA_Handle->XferHalfCpltCallback = ADC_DMAHalfConvCplt;
+
+      /* Set the DMA error callback */
+      hadc->DMA_Handle->XferErrorCallback = ADC_DMAError ;
+
+      /* Manage ADC and DMA start: ADC overrun interruption, DMA start, ADC     */
+      /* start (in case of SW start):                                           */
+
+      /* Clear regular group conversion flag and overrun flag */
+      /* (To ensure of no unknown state from potential previous ADC operations) */
+      __HAL_ADC_CLEAR_FLAG(hadc, (ADC_FLAG_EOC | ADC_FLAG_EOS | ADC_FLAG_OVR));
+
+      /* Process unlocked */
+      /* Unlock before starting ADC conversions: in case of potential         */
+      /* interruption, to let the process to ADC IRQ Handler.                 */
+      __HAL_UNLOCK(hadc);
+
+      /* Enable ADC overrun interrupt */
+      __HAL_ADC_ENABLE_IT(hadc, ADC_IT_OVR);
+
+      /* Case of ADC slave using its own DMA channel: check whether handle selected
+         corresponds to ADC master or slave instance */
+      if (__LL_ADC_MULTI_INSTANCE_MASTER(hadc->Instance) != hadc->Instance)
+      {
+        /* Case of ADC slave selected: Start the DMA channel. */
+        /* Note: Data transfer will start upon next call of this function using handle of ADC master */
+        tmp_hal_status = HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&hadc->Instance->DR, (uint32_t)pData, Length);
+      }
+      else
+      {
+        /* Pointer to the common control register  */
+        tmpADC_Common = __LL_ADC_COMMON_INSTANCE(hadc->Instance);
+
+        /* Start the DMA channel */
+        tmp_hal_status = HAL_DMA_Start_IT(hadc->DMA_Handle, (uint32_t)&tmpADC_Common->CDR, (uint32_t)pData, Length);
+
+        /* Enable conversion of regular group.                                    */
+        /* If software start has been selected, conversion starts immediately.    */
+        /* If external trigger has been selected, conversion will start at next   */
+        /* trigger event.                                                         */
+        /* Start ADC group regular conversion */
+        LL_ADC_REG_StartConversion(hadc->Instance);
+      }
+    }
+    else
+    {
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+    }
+
+    /* Return function status */
+    return tmp_hal_status;
+  }
+}
+
+/**
+  * @brief  Stop multimode ADC conversion, disable ADC DMA transfer, disable ADC peripheral.
+  * @note   Multimode is kept enabled after this function. MultiMode DMA bits
+  *         (MDMA and DMACFG bits of common CCR register) are maintained. To disable
+  *         Multimode (set with HAL_ADCEx_MultiModeConfigChannel()), ADC must be
+  *         reinitialized using HAL_ADC_Init() or HAL_ADC_DeInit(), or the user can
+  *         resort to HAL_ADCEx_DisableMultiMode() API.
+  * @note   In case of DMA configured in circular mode, function
+  *         HAL_ADC_Stop_DMA() must be called after this function with handle of
+  *         ADC slave, to properly disable the DMA channel.
+  * @param hadc ADC handle of ADC master (handle of ADC slave must not be used)
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeStop_DMA(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  uint32_t tickstart;
+  ADC_HandleTypeDef tmphadcSlave;
+  uint32_t tmphadcSlave_conversion_on_going;
+  HAL_StatusTypeDef tmphadcSlave_disable_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+
+  /* 1. Stop potential multimode conversion on going, on regular and injected groups */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_INJECTED_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    tmphadcSlave.State = HAL_ADC_STATE_RESET;
+    tmphadcSlave.ErrorCode = HAL_ADC_ERROR_NONE;
+
+    /* Set a temporary handle of the ADC slave associated to the ADC master   */
+    ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+
+    if (tmphadcSlave.Instance == NULL)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+
+      return HAL_ERROR;
+    }
+
+    /* Procedure to disable the ADC peripheral: wait for conversions          */
+    /* effectively stopped (ADC master and ADC slave), then disable ADC       */
+
+    /* 1. Wait for ADC conversion completion for ADC master and ADC slave */
+    tickstart = HAL_GetTick();
+
+    tmphadcSlave_conversion_on_going = LL_ADC_REG_IsConversionOngoing((&tmphadcSlave)->Instance);
+    while ((LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 1UL)
+           || (tmphadcSlave_conversion_on_going == 1UL)
+          )
+    {
+      if ((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* New check to avoid false timeout detection in case of preemption */
+        tmphadcSlave_conversion_on_going = LL_ADC_REG_IsConversionOngoing((&tmphadcSlave)->Instance);
+
+        if((LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 1UL)
+           || (tmphadcSlave_conversion_on_going == 1UL)
+          )
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+
+          return HAL_ERROR;
+        }
+      }
+
+      tmphadcSlave_conversion_on_going = LL_ADC_REG_IsConversionOngoing((&tmphadcSlave)->Instance);
+    }
+
+    /* Disable the DMA channel (in case of DMA in circular mode or stop       */
+    /* while DMA transfer is on going)                                        */
+    /* Note: DMA channel of ADC slave should be stopped after this function   */
+    /*       with HAL_ADC_Stop_DMA() API.                                     */
+    tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
+
+    /* Check if DMA channel effectively disabled */
+    if (tmp_hal_status == HAL_ERROR)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+    }
+
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+
+    /* 2. Disable the ADC peripherals: master and slave */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed, to keep in */
+    /* memory a potential failing status.                                     */
+    if (tmp_hal_status == HAL_OK)
+    {
+      tmphadcSlave_disable_status = ADC_Disable(&tmphadcSlave);
+      if ((ADC_Disable(hadc) == HAL_OK)           &&
+          (tmphadcSlave_disable_status == HAL_OK))
+      {
+        tmp_hal_status = HAL_OK;
+      }
+    }
+    else
+    {
+      /* In case of error, attempt to disable ADC master and slave without status assert */
+      (void) ADC_Disable(hadc);
+      (void) ADC_Disable(&tmphadcSlave);
+    }
+
+    /* Set ADC state (ADC master) */
+    ADC_STATE_CLR_SET(hadc->State,
+                      HAL_ADC_STATE_REG_BUSY | HAL_ADC_STATE_INJ_BUSY,
+                      HAL_ADC_STATE_READY);
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Return the last ADC Master and Slave regular conversions results when in multimode configuration.
+  * @param hadc ADC handle of ADC Master (handle of ADC Slave must not be used)
+  * @retval The converted data values.
+  */
+uint32_t HAL_ADCEx_MultiModeGetValue(const ADC_HandleTypeDef *hadc)
+{
+  const ADC_Common_TypeDef *tmpADC_Common;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+
+  /* Prevent unused argument(s) compilation warning if no assert_param check */
+  /* and possible no usage in __LL_ADC_COMMON_INSTANCE() below               */
+  UNUSED(hadc);
+
+  /* Pointer to the common control register  */
+  tmpADC_Common = __LL_ADC_COMMON_INSTANCE(hadc->Instance);
+
+  /* Return the multi mode conversion value */
+  return tmpADC_Common->CDR;
+}
+
+/**
+  * @brief  Get ADC injected group conversion result.
+  * @note   Reading register JDRx automatically clears ADC flag JEOC
+  *         (ADC group injected end of unitary conversion).
+  * @note   This function does not clear ADC flag JEOS
+  *         (ADC group injected end of sequence conversion)
+  *         Occurrence of flag JEOS rising:
+  *          - If sequencer is composed of 1 rank, flag JEOS is equivalent
+  *            to flag JEOC.
+  *          - If sequencer is composed of several ranks, during the scan
+  *            sequence flag JEOC only is raised, at the end of the scan sequence
+  *            both flags JEOC and EOS are raised.
+  *         Flag JEOS must not be cleared by this function because
+  *         it would not be compliant with low power features
+  *         (feature low power auto-wait, not available on all STM32 families).
+  *         To clear this flag, either use function:
+  *         in programming model IT: @ref HAL_ADC_IRQHandler(), in programming
+  *         model polling: @ref HAL_ADCEx_InjectedPollForConversion()
+  *         or @ref __HAL_ADC_CLEAR_FLAG(&hadc, ADC_FLAG_JEOS).
+  * @param hadc ADC handle
+  * @param InjectedRank the converted ADC injected rank.
+  *          This parameter can be one of the following values:
+  *            @arg @ref ADC_INJECTED_RANK_1 ADC group injected rank 1
+  *            @arg @ref ADC_INJECTED_RANK_2 ADC group injected rank 2
+  *            @arg @ref ADC_INJECTED_RANK_3 ADC group injected rank 3
+  *            @arg @ref ADC_INJECTED_RANK_4 ADC group injected rank 4
+  * @retval ADC group injected conversion data
+  */
+uint32_t HAL_ADCEx_InjectedGetValue(const ADC_HandleTypeDef *hadc, uint32_t InjectedRank)
+{
+  uint32_t tmp_jdr;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_INJECTED_RANK(InjectedRank));
+
+  /* Get ADC converted value */
+  switch (InjectedRank)
+  {
+    case ADC_INJECTED_RANK_4:
+      tmp_jdr = hadc->Instance->JDR4;
+      break;
+    case ADC_INJECTED_RANK_3:
+      tmp_jdr = hadc->Instance->JDR3;
+      break;
+    case ADC_INJECTED_RANK_2:
+      tmp_jdr = hadc->Instance->JDR2;
+      break;
+    case ADC_INJECTED_RANK_1:
+    default:
+      tmp_jdr = hadc->Instance->JDR1;
+      break;
+  }
+
+  /* Return ADC converted value */
+  return tmp_jdr;
+}
+
+/**
+  * @brief  Injected conversion complete callback in non-blocking mode.
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_InjectedConvCpltCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_InjectedConvCpltCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Injected context queue overflow callback.
+  * @note   This callback is called if injected context queue is enabled
+            (parameter "QueueInjectedContext" in injected channel configuration)
+            and if a new injected context is set when queue is full (maximum 2
+            contexts).
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_InjectedQueueOverflowCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_InjectedQueueOverflowCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Analog watchdog 2 callback in non-blocking mode.
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_LevelOutOfWindow2Callback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_LevelOutOfWindow2Callback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Analog watchdog 3 callback in non-blocking mode.
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_LevelOutOfWindow3Callback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_LevelOutOfWindow3Callback must be implemented in the user file.
+  */
+}
+
+
+/**
+  * @brief  End Of Sampling callback in non-blocking mode.
+  * @param hadc ADC handle
+  * @retval None
+  */
+__weak void HAL_ADCEx_EndOfSamplingCallback(ADC_HandleTypeDef *hadc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
+  /* NOTE : This function should not be modified. When the callback is needed,
+            function HAL_ADCEx_EndOfSamplingCallback must be implemented in the user file.
+  */
+}
+
+/**
+  * @brief  Stop ADC conversion of regular group (and injected channels in
+  *         case of auto_injection mode), disable ADC peripheral if no
+  *         conversion is on going on injected group.
+  * @param hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* 1. Stop potential regular conversion on going */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+
+  /* Disable ADC peripheral if regular conversions are effectively stopped
+     and if no injected conversions are on-going */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Clear HAL_ADC_STATE_REG_BUSY bit */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+
+    if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) == 0UL)
+    {
+      /* 2. Disable the ADC peripheral */
+      tmp_hal_status = ADC_Disable(hadc);
+
+      /* Check if ADC is effectively disabled */
+      if (tmp_hal_status == HAL_OK)
+      {
+        /* Set ADC state */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_INJ_BUSY,
+                          HAL_ADC_STATE_READY);
+      }
+    }
+    /* Conversion on injected group is stopped, but ADC not disabled since    */
+    /* conversion on regular group is still running.                          */
+    else
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+
+/**
+  * @brief  Stop ADC conversion of ADC groups regular and injected,
+  *         disable interrution of end-of-conversion,
+  *         disable ADC peripheral if no conversion is on going
+  *         on injected group.
+  * @param hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_IT(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* 1. Stop potential regular conversion on going */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped
+    and if no injected conversion is on-going */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Clear HAL_ADC_STATE_REG_BUSY bit */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+
+    /* Disable all regular-related interrupts */
+    __HAL_ADC_DISABLE_IT(hadc, (ADC_IT_EOC | ADC_IT_EOS | ADC_IT_OVR));
+
+    /* 2. Disable ADC peripheral if no injected conversions are on-going */
+    if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) == 0UL)
+    {
+      tmp_hal_status = ADC_Disable(hadc);
+      /* if no issue reported */
+      if (tmp_hal_status == HAL_OK)
+      {
+        /* Set ADC state */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_INJ_BUSY,
+                          HAL_ADC_STATE_READY);
+      }
+    }
+    else
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Stop ADC conversion of regular group (and injected group in
+  *         case of auto_injection mode), disable ADC DMA transfer, disable
+  *         ADC peripheral if no conversion is on going
+  *         on injected group.
+  * @note   HAL_ADCEx_RegularStop_DMA() function is dedicated to single-ADC mode only.
+  *         For multimode (when multimode feature is available),
+  *         HAL_ADCEx_RegularMultiModeStop_DMA() API must be used.
+  * @param hadc ADC handle
+  * @retval HAL status.
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularStop_DMA(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* 1. Stop potential regular conversion on going */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped
+     and if no injected conversion is on-going */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Clear HAL_ADC_STATE_REG_BUSY bit */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+
+    /* Disable ADC DMA (ADC DMA configuration ADC_CFGR_DMACFG is kept) */
+    MODIFY_REG(hadc->Instance->CFGR, ADC_CFGR_DMNGT_0 | ADC_CFGR_DMNGT_1, 0UL);
+
+    /* Disable the DMA channel (in case of DMA in circular mode or stop while */
+    /* while DMA transfer is on going)                                        */
+    tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
+
+    /* Check if DMA channel effectively disabled */
+    if (tmp_hal_status != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+    }
+
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+
+    /* 2. Disable the ADC peripheral */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed,          */
+    /* to keep in memory a potential failing status.                          */
+    if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) == 0UL)
+    {
+      if (tmp_hal_status == HAL_OK)
+      {
+        tmp_hal_status = ADC_Disable(hadc);
+      }
+      else
+      {
+        (void)ADC_Disable(hadc);
+      }
+
+      /* Check if ADC is effectively disabled */
+      if (tmp_hal_status == HAL_OK)
+      {
+        /* Set ADC state */
+        ADC_STATE_CLR_SET(hadc->State,
+                          HAL_ADC_STATE_INJ_BUSY,
+                          HAL_ADC_STATE_READY);
+      }
+    }
+    else
+    {
+      SET_BIT(hadc->State, HAL_ADC_STATE_INJ_BUSY);
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Stop DMA-based multimode ADC conversion, disable ADC DMA transfer, disable ADC peripheral if no injected conversion is on-going.
+  * @note   Multimode is kept enabled after this function. Multimode DMA bits
+  *         (MDMA and DMACFG bits of common CCR register) are maintained. To disable
+  *         multimode (set with HAL_ADCEx_MultiModeConfigChannel()), ADC must be
+  *         reinitialized using HAL_ADC_Init() or HAL_ADC_DeInit(), or the user can
+  *         resort to HAL_ADCEx_DisableMultiMode() API.
+  * @note   In case of DMA configured in circular mode, function
+  *         HAL_ADCEx_RegularStop_DMA() must be called after this function with handle of
+  *         ADC slave, to properly disable the DMA channel.
+  * @param hadc ADC handle of ADC master (handle of ADC slave must not be used)
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_RegularMultiModeStop_DMA(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  uint32_t tickstart;
+  ADC_HandleTypeDef tmphadcSlave;
+  uint32_t tmphadcSlave_conversion_on_going;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+
+  /* 1. Stop potential multimode conversion on going, on regular groups */
+  tmp_hal_status = ADC_ConversionStop(hadc, ADC_REGULAR_GROUP);
+
+  /* Disable ADC peripheral if conversions are effectively stopped */
+  if (tmp_hal_status == HAL_OK)
+  {
+    /* Clear HAL_ADC_STATE_REG_BUSY bit */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_REG_BUSY);
+
+    tmphadcSlave.State = HAL_ADC_STATE_RESET;
+    tmphadcSlave.ErrorCode = HAL_ADC_ERROR_NONE;
+
+    /* Set a temporary handle of the ADC slave associated to the ADC master   */
+    ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+
+    if (tmphadcSlave.Instance == NULL)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+      /* Process unlocked */
+      __HAL_UNLOCK(hadc);
+
+      return HAL_ERROR;
+    }
+
+    /* Procedure to disable the ADC peripheral: wait for conversions          */
+    /* effectively stopped (ADC master and ADC slave), then disable ADC       */
+
+    /* 1. Wait for ADC conversion completion for ADC master and ADC slave */
+    tickstart = HAL_GetTick();
+
+    tmphadcSlave_conversion_on_going = LL_ADC_REG_IsConversionOngoing((&tmphadcSlave)->Instance);
+    while ((LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 1UL)
+           || (tmphadcSlave_conversion_on_going == 1UL)
+          )
+    {
+      if ((HAL_GetTick() - tickstart) > ADC_STOP_CONVERSION_TIMEOUT)
+      {
+        /* New check to avoid false timeout detection in case of preemption */
+        tmphadcSlave_conversion_on_going = LL_ADC_REG_IsConversionOngoing((&tmphadcSlave)->Instance);
+
+        if((LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 1UL)
+           || (tmphadcSlave_conversion_on_going == 1UL)
+          )
+        {
+          /* Update ADC state machine to error */
+          SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_INTERNAL);
+
+          /* Process unlocked */
+          __HAL_UNLOCK(hadc);
+
+          return HAL_ERROR;
+        }
+      }
+
+      tmphadcSlave_conversion_on_going = LL_ADC_REG_IsConversionOngoing((&tmphadcSlave)->Instance);
+    }
+
+    /* Disable the DMA channel (in case of DMA in circular mode or stop       */
+    /* while DMA transfer is on going)                                        */
+    /* Note: DMA channel of ADC slave should be stopped after this function   */
+    /* with HAL_ADCEx_RegularStop_DMA() API.                                  */
+    tmp_hal_status = HAL_DMA_Abort(hadc->DMA_Handle);
+
+    /* Check if DMA channel effectively disabled */
+    if (tmp_hal_status != HAL_OK)
+    {
+      /* Update ADC state machine to error */
+      SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_DMA);
+    }
+
+    /* Disable ADC overrun interrupt */
+    __HAL_ADC_DISABLE_IT(hadc, ADC_IT_OVR);
+
+    /* 2. Disable the ADC peripherals: master and slave if no injected        */
+    /*   conversion is on-going.                                              */
+    /* Update "tmp_hal_status" only if DMA channel disabling passed, to keep in */
+    /* memory a potential failing status.                                     */
+    if (tmp_hal_status == HAL_OK)
+    {
+      if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) == 0UL)
+      {
+        tmp_hal_status =  ADC_Disable(hadc);
+        if (tmp_hal_status == HAL_OK)
+        {
+          if (LL_ADC_INJ_IsConversionOngoing((&tmphadcSlave)->Instance) == 0UL)
+          {
+            tmp_hal_status =  ADC_Disable(&tmphadcSlave);
+          }
+        }
+      }
+
+      if (tmp_hal_status == HAL_OK)
+      {
+        /* Both Master and Slave ADC's could be disabled. Update Master State */
+        /* Clear HAL_ADC_STATE_INJ_BUSY bit, set HAL_ADC_STATE_READY bit */
+        ADC_STATE_CLR_SET(hadc->State, HAL_ADC_STATE_INJ_BUSY, HAL_ADC_STATE_READY);
+      }
+      else
+      {
+        /* injected (Master or Slave) conversions are still on-going,
+           no Master State change */
+      }
+    }
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup ADCEx_Exported_Functions_Group2 ADC Extended Peripheral Control functions
+  * @brief    ADC Extended Peripheral Control functions
+  *
+@verbatim
+ ===============================================================================
+             ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) Configure channels on injected group
+      (+) Configure multimode when multimode feature is available
+      (+) Enable or Disable Injected Queue
+      (+) Disable ADC voltage regulator
+      (+) Enter ADC deep-power-down mode
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Configure a channel to be assigned to ADC group injected.
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes injected group, following calls to this
+  *         function can be used to reconfigure some parameters of structure
+  *         "ADC_InjectionConfTypeDef" on the fly, without resetting the ADC.
+  *         The setting of these parameters is conditioned to ADC state:
+  *         Refer to comments of structure "ADC_InjectionConfTypeDef".
+  * @note   In case of usage of internal measurement channels:
+  *         Vbat/VrefInt/TempSensor.
+  *         These internal paths can be disabled using function
+  *         HAL_ADC_DeInit().
+  * @note   Caution: For Injected Context Queue use, a context must be fully
+  *         defined before start of injected conversion. All channels are configured
+  *         consecutively for the same ADC instance. Therefore, the number of calls to
+  *         HAL_ADCEx_InjectedConfigChannel() must be equal to the value of parameter
+  *         InjectedNbrOfConversion for each context.
+  *  - Example 1: If 1 context is intended to be used (or if there is no use of the
+  *    Injected Queue Context feature) and if the context contains 3 injected ranks
+  *    (InjectedNbrOfConversion = 3), HAL_ADCEx_InjectedConfigChannel() must be
+  *    called once for each channel (i.e. 3 times) before starting a conversion.
+  *    This function must not be called to configure a 4th injected channel:
+  *    it would start a new context into context queue.
+  *  - Example 2: If 2 contexts are intended to be used and each of them contains
+  *    3 injected ranks (InjectedNbrOfConversion = 3),
+  *    HAL_ADCEx_InjectedConfigChannel() must be called once for each channel and
+  *    for each context (3 channels x 2 contexts = 6 calls). Conversion can
+  *    start once the 1st context is set, that is after the first three
+  *    HAL_ADCEx_InjectedConfigChannel() calls. The 2nd context can be set on the fly.
+  * @param hadc ADC handle
+  * @param sConfigInjected Structure of ADC injected group and ADC channel for
+  *         injected group.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_InjectedConfigChannel(ADC_HandleTypeDef *hadc, ADC_InjectionConfTypeDef *sConfigInjected)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  uint32_t tmpOffsetShifted;
+  uint32_t tmp_config_internal_channel;
+  uint32_t tmp_adc_is_conversion_on_going_regular;
+  uint32_t tmp_adc_is_conversion_on_going_injected;
+  __IO uint32_t wait_loop_index = 0;
+
+  uint32_t tmp_JSQR_ContextQueueBeingBuilt = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_SAMPLE_TIME(sConfigInjected->InjectedSamplingTime));
+  assert_param(IS_ADC_SINGLE_DIFFERENTIAL(sConfigInjected->InjectedSingleDiff));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->AutoInjectedConv));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->QueueInjectedContext));
+  assert_param(IS_ADC_EXTTRIGINJEC_EDGE(sConfigInjected->ExternalTrigInjecConvEdge));
+  assert_param(IS_ADC_EXTTRIGINJEC(sConfigInjected->ExternalTrigInjecConv));
+  assert_param(IS_ADC_OFFSET_NUMBER(sConfigInjected->InjectedOffsetNumber));
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->InjecOversamplingMode));
+#if defined(ADC_VER_V5_V90)
+  assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->InjectedOffsetSaturation));
+  if (hadc->Instance == ADC3)
+  {
+    assert_param(IS_ADC3_OFFSET_SIGN(sConfigInjected->InjectedOffsetSign));
+    assert_param(IS_ADC3_RANGE(ADC_GET_RESOLUTION(hadc), sConfigInjected->InjectedOffset));
+  }
+  else
+#endif /* ADC_VER_V5_V90 */
+  {
+    assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfigInjected->InjectedOffset));
+  }
+
+  if (hadc->Init.ScanConvMode != ADC_SCAN_DISABLE)
+  {
+    assert_param(IS_ADC_INJECTED_RANK(sConfigInjected->InjectedRank));
+    assert_param(IS_ADC_INJECTED_NB_CONV(sConfigInjected->InjectedNbrOfConversion));
+    assert_param(IS_FUNCTIONAL_STATE(sConfigInjected->InjectedDiscontinuousConvMode));
+  }
+
+  /* Check offset range according to oversampling setting */
+  if (hadc->Init.OversamplingMode == ENABLE)
+  {
+    assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfigInjected->InjectedOffset / (hadc->Init.Oversampling.Ratio + 1U)));
+  }
+  else
+  {
+    assert_param(IS_ADC_RANGE(ADC_GET_RESOLUTION(hadc), sConfigInjected->InjectedOffset));
+  }
+#if defined(ADC_VER_V5_V90)
+  /* if JOVSE is set, the value of the OFFSETy_EN bit in ADCx_OFRy register is
+     ignored (considered as reset) */
+  if (hadc->Instance == ADC3)
+  {
+    assert_param(!((sConfigInjected->InjectedOffsetNumber != ADC_OFFSET_NONE) && (sConfigInjected->InjecOversamplingMode == ENABLE)));
+  }
+#endif  /* ADC_VER_V5_V90 */
+  /* JDISCEN and JAUTO bits can't be set at the same time  */
+  assert_param(!((sConfigInjected->InjectedDiscontinuousConvMode == ENABLE) && (sConfigInjected->AutoInjectedConv == ENABLE)));
+
+  /*  DISCEN and JAUTO bits can't be set at the same time */
+  assert_param(!((hadc->Init.DiscontinuousConvMode == ENABLE) && (sConfigInjected->AutoInjectedConv == ENABLE)));
+
+  /* Verification of channel number */
+  if (sConfigInjected->InjectedSingleDiff != ADC_DIFFERENTIAL_ENDED)
+  {
+    assert_param(IS_ADC_CHANNEL(sConfigInjected->InjectedChannel));
+  }
+  else
+  {
+    if (hadc->Instance == ADC1)
+    {
+      assert_param(IS_ADC1_DIFF_CHANNEL(sConfigInjected->InjectedChannel));
+    }
+    if (hadc->Instance == ADC2)
+    {
+      assert_param(IS_ADC2_DIFF_CHANNEL(sConfigInjected->InjectedChannel));
+    }
+#if defined (ADC3)
+    if (hadc->Instance == ADC3)
+    {
+      assert_param(IS_ADC3_DIFF_CHANNEL(sConfigInjected->InjectedChannel));
+    }
+#endif
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  /* Configuration of injected group sequencer:                               */
+  /* Hardware constraint: Must fully define injected context register JSQR    */
+  /* before make it entering into injected sequencer queue.                   */
+  /*                                                                          */
+  /* - if scan mode is disabled:                                              */
+  /*    * Injected channels sequence length is set to 0x00: 1 channel         */
+  /*      converted (channel on injected rank 1)                              */
+  /*      Parameter "InjectedNbrOfConversion" is discarded.                   */
+  /*    * Injected context register JSQR setting is simple: register is fully */
+  /*      defined on one call of this function (for injected rank 1) and can  */
+  /*      be entered into queue directly.                                     */
+  /* - if scan mode is enabled:                                               */
+  /*    * Injected channels sequence length is set to parameter               */
+  /*      "InjectedNbrOfConversion".                                          */
+  /*    * Injected context register JSQR setting more complex: register is    */
+  /*      fully defined over successive calls of this function, for each      */
+  /*      injected channel rank. It is entered into queue only when all       */
+  /*      injected ranks have been set.                                       */
+  /*   Note: Scan mode is not present by hardware on this device, but used    */
+  /*   by software for alignment over all STM32 devices.                      */
+
+  if ((hadc->Init.ScanConvMode == ADC_SCAN_DISABLE)  ||
+      (sConfigInjected->InjectedNbrOfConversion == 1U))
+  {
+    /* Configuration of context register JSQR:                                */
+    /*  - number of ranks in injected group sequencer: fixed to 1st rank      */
+    /*    (scan mode disabled, only rank 1 used)                              */
+    /*  - external trigger to start conversion                                */
+    /*  - external trigger polarity                                           */
+    /*  - channel set to rank 1 (scan mode disabled, only rank 1 can be used) */
+
+    if (sConfigInjected->InjectedRank == ADC_INJECTED_RANK_1)
+    {
+      /* Enable external trigger if trigger selection is different of         */
+      /* software start.                                                      */
+      /* Note: This configuration keeps the hardware feature of parameter     */
+      /*       ExternalTrigInjecConvEdge "trigger edge none" equivalent to    */
+      /*       software start.                                                */
+      if (sConfigInjected->ExternalTrigInjecConv != ADC_INJECTED_SOFTWARE_START)
+      {
+        tmp_JSQR_ContextQueueBeingBuilt = (ADC_JSQR_RK(sConfigInjected->InjectedChannel, ADC_INJECTED_RANK_1)
+                                           | (sConfigInjected->ExternalTrigInjecConv & ADC_JSQR_JEXTSEL)
+                                           | sConfigInjected->ExternalTrigInjecConvEdge
+                                          );
+      }
+      else
+      {
+        tmp_JSQR_ContextQueueBeingBuilt = (ADC_JSQR_RK(sConfigInjected->InjectedChannel, ADC_INJECTED_RANK_1));
+      }
+
+      MODIFY_REG(hadc->Instance->JSQR, ADC_JSQR_FIELDS, tmp_JSQR_ContextQueueBeingBuilt);
+      /* For debug and informative reasons, hadc handle saves JSQR setting */
+      hadc->InjectionConfig.ContextQueue = tmp_JSQR_ContextQueueBeingBuilt;
+
+    }
+  }
+  else
+  {
+    /* Case of scan mode enabled, several channels to set into injected group */
+    /* sequencer.                                                             */
+    /*                                                                        */
+    /* Procedure to define injected context register JSQR over successive     */
+    /* calls of this function, for each injected channel rank:                */
+    /* 1. Start new context and set parameters related to all injected        */
+    /*    channels: injected sequence length and trigger.                     */
+
+    /* if hadc->InjectionConfig.ChannelCount is equal to 0, this is the first */
+    /*   call of the context under setting                                    */
+    if (hadc->InjectionConfig.ChannelCount == 0U)
+    {
+      /* Initialize number of channels that will be configured on the context */
+      /*  being built                                                         */
+      hadc->InjectionConfig.ChannelCount = sConfigInjected->InjectedNbrOfConversion;
+      /* Handle hadc saves the context under build up over each HAL_ADCEx_InjectedConfigChannel()
+         call, this context will be written in JSQR register at the last call.
+         At this point, the context is merely reset  */
+      hadc->InjectionConfig.ContextQueue = 0x00000000U;
+
+      /* Configuration of context register JSQR:                              */
+      /*  - number of ranks in injected group sequencer                       */
+      /*  - external trigger to start conversion                              */
+      /*  - external trigger polarity                                         */
+
+      /* Enable external trigger if trigger selection is different of         */
+      /* software start.                                                      */
+      /* Note: This configuration keeps the hardware feature of parameter     */
+      /*       ExternalTrigInjecConvEdge "trigger edge none" equivalent to    */
+      /*       software start.                                                */
+      if (sConfigInjected->ExternalTrigInjecConv != ADC_INJECTED_SOFTWARE_START)
+      {
+        tmp_JSQR_ContextQueueBeingBuilt = ((sConfigInjected->InjectedNbrOfConversion - 1U)
+                                           | (sConfigInjected->ExternalTrigInjecConv & ADC_JSQR_JEXTSEL)
+                                           | sConfigInjected->ExternalTrigInjecConvEdge
+                                          );
+      }
+      else
+      {
+        tmp_JSQR_ContextQueueBeingBuilt = ((sConfigInjected->InjectedNbrOfConversion - 1U));
+      }
+
+    }
+
+    /* 2. Continue setting of context under definition with parameter       */
+    /*    related to each channel: channel rank sequence                    */
+    /* Clear the old JSQx bits for the selected rank */
+    tmp_JSQR_ContextQueueBeingBuilt &= ~ADC_JSQR_RK(ADC_SQR3_SQ10, sConfigInjected->InjectedRank);
+
+    /* Set the JSQx bits for the selected rank */
+    tmp_JSQR_ContextQueueBeingBuilt |= ADC_JSQR_RK(sConfigInjected->InjectedChannel, sConfigInjected->InjectedRank);
+
+    /* Decrease channel count  */
+    hadc->InjectionConfig.ChannelCount--;
+
+    /* 3. tmp_JSQR_ContextQueueBeingBuilt is fully built for this HAL_ADCEx_InjectedConfigChannel()
+          call, aggregate the setting to those already built during the previous
+          HAL_ADCEx_InjectedConfigChannel() calls (for the same context of course)  */
+    hadc->InjectionConfig.ContextQueue |= tmp_JSQR_ContextQueueBeingBuilt;
+
+    /* 4. End of context setting: if this is the last channel set, then write context
+        into register JSQR and make it enter into queue                   */
+    if (hadc->InjectionConfig.ChannelCount == 0U)
+    {
+      MODIFY_REG(hadc->Instance->JSQR, ADC_JSQR_FIELDS, hadc->InjectionConfig.ContextQueue);
+    }
+  }
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on injected group:                                   */
+  /*  - Injected context queue: Queue disable (active context is kept) or     */
+  /*    enable (context decremented, up to 2 contexts queued)                 */
+  /*  - Injected discontinuous mode: can be enabled only if auto-injected     */
+  /*    mode is disabled.                                                     */
+  if (LL_ADC_INJ_IsConversionOngoing(hadc->Instance) == 0UL)
+  {
+    if (!(__LL_ADC_IS_CHANNEL_INTERNAL(sConfigInjected->InjectedChannel)))
+    {
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance != ADC3)
+      {
+        /* ADC channels preselection */
+        hadc->Instance->PCSEL_RES0 |= (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel) & 0x1FUL));
+      }
+#else
+      /* ADC channels preselection */
+      hadc->Instance->PCSEL |= (1UL << (__LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel) & 0x1FUL));
+#endif /* ADC_VER_V5_V90 */
+    }
+
+    /* If auto-injected mode is disabled: no constraint                       */
+    if (sConfigInjected->AutoInjectedConv == DISABLE)
+    {
+      MODIFY_REG(hadc->Instance->CFGR,
+                 ADC_CFGR_JQM | ADC_CFGR_JDISCEN,
+                 ADC_CFGR_INJECT_CONTEXT_QUEUE((uint32_t)sConfigInjected->QueueInjectedContext)           |
+                 ADC_CFGR_INJECT_DISCCONTINUOUS((uint32_t)sConfigInjected->InjectedDiscontinuousConvMode));
+    }
+    /* If auto-injected mode is enabled: Injected discontinuous setting is    */
+    /* discarded.                                                             */
+    else
+    {
+      MODIFY_REG(hadc->Instance->CFGR,
+                 ADC_CFGR_JQM | ADC_CFGR_JDISCEN,
+                 ADC_CFGR_INJECT_CONTEXT_QUEUE((uint32_t)sConfigInjected->QueueInjectedContext));
+    }
+
+  }
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular and injected groups:                      */
+  /*  - Automatic injected conversion: can be enabled if injected group       */
+  /*    external triggers are disabled.                                       */
+  /*  - Channel sampling time                                                 */
+  /*  - Channel offset                                                        */
+  tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+  tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
+
+  if ((tmp_adc_is_conversion_on_going_regular == 0UL)
+      && (tmp_adc_is_conversion_on_going_injected == 0UL)
+     )
+  {
+    /* If injected group external triggers are disabled (set to injected      */
+    /* software start): no constraint                                         */
+    if ((sConfigInjected->ExternalTrigInjecConv == ADC_INJECTED_SOFTWARE_START)
+        || (sConfigInjected->ExternalTrigInjecConvEdge == ADC_EXTERNALTRIGINJECCONV_EDGE_NONE))
+    {
+      if (sConfigInjected->AutoInjectedConv == ENABLE)
+      {
+        SET_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO);
+      }
+      else
+      {
+        CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO);
+      }
+    }
+    /* If Automatic injected conversion was intended to be set and could not  */
+    /* due to injected group external triggers enabled, error is reported.    */
+    else
+    {
+      if (sConfigInjected->AutoInjectedConv == ENABLE)
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+        tmp_hal_status = HAL_ERROR;
+      }
+      else
+      {
+        CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_JAUTO);
+      }
+    }
+
+    if (sConfigInjected->InjecOversamplingMode == ENABLE)
+    {
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance == ADC3)
+      {
+        assert_param(IS_ADC_OVERSAMPLING_RATIO_ADC3(sConfigInjected->InjecOversampling.Ratio));
+      }
+      else
+      {
+        assert_param(IS_ADC_OVERSAMPLING_RATIO(sConfigInjected->InjecOversampling.Ratio));
+      }
+#else
+      assert_param(IS_ADC_OVERSAMPLING_RATIO(sConfigInjected->InjecOversampling.Ratio));
+#endif
+      assert_param(IS_ADC_RIGHT_BIT_SHIFT(sConfigInjected->InjecOversampling.RightBitShift));
+
+      /*  JOVSE must be reset in case of triggered regular mode  */
+      assert_param(!(READ_BIT(hadc->Instance->CFGR2, ADC_CFGR2_ROVSE | ADC_CFGR2_TROVS) == (ADC_CFGR2_ROVSE | ADC_CFGR2_TROVS)));
+
+      /* Configuration of Injected Oversampler:                                 */
+      /*  - Oversampling Ratio                                                  */
+      /*  - Right bit shift                                                     */
+
+      /* Enable OverSampling mode */
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance != ADC3)
+      {
+        MODIFY_REG(hadc->Instance->CFGR2,
+                   ADC_CFGR2_JOVSE |
+                   ADC_CFGR2_OVSR  |
+                   ADC_CFGR2_OVSS,
+                   ADC_CFGR2_JOVSE                                  |
+                  ((sConfigInjected->InjecOversampling.Ratio - 1UL) << ADC_CFGR2_OVSR_Pos) |
+                   sConfigInjected->InjecOversampling.RightBitShift
+                  );
+      }
+      else
+      {
+        MODIFY_REG(hadc->Instance->CFGR2,
+                   ADC_CFGR2_JOVSE |
+                   ADC3_CFGR2_OVSR  |
+                   ADC_CFGR2_OVSS,
+                   ADC_CFGR2_JOVSE                                  |
+                  (sConfigInjected->InjecOversampling.Ratio)        |
+                   sConfigInjected->InjecOversampling.RightBitShift
+                  );
+      }
+#else
+      MODIFY_REG(hadc->Instance->CFGR2,
+           ADC_CFGR2_JOVSE |
+           ADC_CFGR2_OVSR  |
+           ADC_CFGR2_OVSS,
+           ADC_CFGR2_JOVSE                                  |
+          ((sConfigInjected->InjecOversampling.Ratio - 1UL) << ADC_CFGR2_OVSR_Pos) |
+           sConfigInjected->InjecOversampling.RightBitShift
+          );
+#endif
+    }
+    else
+    {
+      /* Disable Regular OverSampling */
+      CLEAR_BIT(hadc->Instance->CFGR2, ADC_CFGR2_JOVSE);
+    }
+
+    /* Set sampling time of the selected ADC channel */
+    LL_ADC_SetChannelSamplingTime(hadc->Instance, sConfigInjected->InjectedChannel, sConfigInjected->InjectedSamplingTime);
+
+    /* Configure the offset: offset enable/disable, channel, offset value */
+
+    /* Shift the offset with respect to the selected ADC resolution. */
+    /* Offset has to be left-aligned on bit 11, the LSB (right bits) are set to 0 */
+#if defined(ADC_VER_V5_V90)
+    if (hadc->Instance == ADC3)
+    {
+      tmpOffsetShifted = ADC3_OFFSET_SHIFT_RESOLUTION(hadc, sConfigInjected->InjectedOffset);
+    }
+    else
+#endif /* ADC_VER_V5_V90 */
+    {
+      tmpOffsetShifted = ADC_OFFSET_SHIFT_RESOLUTION(hadc, sConfigInjected->InjectedOffset);
+    }
+
+    if (sConfigInjected->InjectedOffsetNumber != ADC_OFFSET_NONE)
+    {
+      /* Set ADC selected offset number */
+      LL_ADC_SetOffset(hadc->Instance, sConfigInjected->InjectedOffsetNumber, sConfigInjected->InjectedChannel, tmpOffsetShifted);
+
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance == ADC3)
+      {
+        /* Set ADC selected offset sign & saturation */
+        LL_ADC_SetOffsetSign(hadc->Instance, sConfigInjected->InjectedOffsetNumber, sConfigInjected->InjectedOffsetSign);
+        LL_ADC_SetOffsetSaturation(hadc->Instance, sConfigInjected->InjectedOffsetNumber, (sConfigInjected->InjectedOffsetSaturation == ENABLE) ? LL_ADC_OFFSET_SATURATION_ENABLE : LL_ADC_OFFSET_SATURATION_DISABLE);
+      }
+      else
+#endif /* ADC_VER_V5_V90 */
+      {
+        /* Set ADC selected offset signed saturation */
+        LL_ADC_SetOffsetSignedSaturation(hadc->Instance, sConfigInjected->InjectedOffsetNumber, (sConfigInjected->InjectedOffsetSignedSaturation == ENABLE) ? LL_ADC_OFFSET_SIGNED_SATURATION_ENABLE : LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE);
+      }
+
+    }
+    else
+    {
+#if defined(ADC_VER_V5_V90)
+      if (hadc->Instance == ADC3)
+      {
+        /* Scan each offset register to check if the selected channel is targeted. */
+        /* If this is the case, the corresponding offset number is disabled.       */
+        if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_1)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel))
+        {
+          LL_ADC_SetOffsetState(hadc->Instance, LL_ADC_OFFSET_1, LL_ADC_OFFSET_DISABLE);
+        }
+        if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_2)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel))
+        {
+          LL_ADC_SetOffsetState(hadc->Instance, LL_ADC_OFFSET_2, LL_ADC_OFFSET_DISABLE);
+        }
+        if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_3)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel))
+        {
+          LL_ADC_SetOffsetState(hadc->Instance, LL_ADC_OFFSET_3, LL_ADC_OFFSET_DISABLE);
+        }
+        if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_4)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel))
+        {
+          LL_ADC_SetOffsetState(hadc->Instance, LL_ADC_OFFSET_4, LL_ADC_OFFSET_DISABLE);
+        }
+      }
+      else
+#endif /* ADC_VER_V5_V90 */
+      {
+        /* Scan each offset register to check if the selected channel is targeted. */
+        /* If this is the case, the corresponding offset number is disabled.       */
+        if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_1)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel))
+        {
+          LL_ADC_SetOffset(hadc->Instance, LL_ADC_OFFSET_1, sConfigInjected->InjectedChannel, LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE);
+        }
+        if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_2)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel))
+        {
+          LL_ADC_SetOffset(hadc->Instance, LL_ADC_OFFSET_2, sConfigInjected->InjectedChannel, LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE);
+        }
+        if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_3)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel))
+        {
+          LL_ADC_SetOffset(hadc->Instance, LL_ADC_OFFSET_4, sConfigInjected->InjectedChannel, LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE);
+        }
+        if (__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_GetOffsetChannel(hadc->Instance, LL_ADC_OFFSET_4)) == __LL_ADC_CHANNEL_TO_DECIMAL_NB(sConfigInjected->InjectedChannel))
+        {
+          LL_ADC_SetOffset(hadc->Instance, LL_ADC_OFFSET_4, sConfigInjected->InjectedChannel, LL_ADC_OFFSET_SIGNED_SATURATION_DISABLE);
+        }
+      }
+    }
+
+  }
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated only when ADC is disabled:                */
+  /*  - Single or differential mode                                           */
+  /*  - Internal measurement channels: Vbat/VrefInt/TempSensor                */
+  if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+  {
+    /* Set mode single-ended or differential input of the selected ADC channel */
+    LL_ADC_SetChannelSingleDiff(hadc->Instance, sConfigInjected->InjectedChannel, sConfigInjected->InjectedSingleDiff);
+
+    /* Configuration of differential mode */
+    /* Note: ADC channel number masked with value "0x1F" to ensure shift value within 32 bits range */
+    if (sConfigInjected->InjectedSingleDiff == ADC_DIFFERENTIAL_ENDED)
+    {
+      /* Set ADC channel preselection of corresponding negative channel */
+      LL_ADC_SetChannelPreselection(hadc->Instance, ADC_CHANNEL_DIFF_NEG_INPUT(hadc, sConfigInjected->InjectedChannel));
+    }
+
+    /* Management of internal measurement channels: Vbat/VrefInt/TempSensor   */
+    /* internal measurement paths enable: If internal channel selected,       */
+    /* enable dedicated internal buffers and path.                            */
+    /* Note: these internal measurement paths can be disabled using           */
+    /* HAL_ADC_DeInit().                                                      */
+
+    if (__LL_ADC_IS_CHANNEL_INTERNAL(sConfigInjected->InjectedChannel))
+    {
+      /* Configuration of common ADC parameters (continuation)                */
+      /* Software is allowed to change common parameters only when all ADCs   */
+      /* of the common group are disabled.                                    */
+      if (__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) == 0UL)
+      {
+        tmp_config_internal_channel = LL_ADC_GetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance));
+
+        /* If the requested internal measurement path has already been enabled, */
+        /* bypass the configuration processing.                                 */
+        if ((sConfigInjected->InjectedChannel == ADC_CHANNEL_TEMPSENSOR) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_TEMPSENSOR) == 0UL))
+        {
+          if (ADC_TEMPERATURE_SENSOR_INSTANCE(hadc))
+          {
+            LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_TEMPSENSOR | tmp_config_internal_channel);
+
+            /* Delay for temperature sensor stabilization time */
+            /* Wait loop initialization and execution */
+            /* Note: Variable divided by 2 to compensate partially              */
+            /*       CPU processing cycles, scaling in us split to not          */
+            /*       exceed 32 bits register capacity and handle low frequency. */
+            wait_loop_index = ((LL_ADC_DELAY_TEMPSENSOR_STAB_US / 10UL) * ((SystemCoreClock / (100000UL * 2UL)) + 1UL));
+            while (wait_loop_index != 0UL)
+            {
+              wait_loop_index--;
+            }
+          }
+        }
+        else if ((sConfigInjected->InjectedChannel == ADC_CHANNEL_VBAT) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_VBAT) == 0UL))
+        {
+          if (ADC_BATTERY_VOLTAGE_INSTANCE(hadc))
+          {
+            LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_VBAT | tmp_config_internal_channel);
+          }
+        }
+        else if ((sConfigInjected->InjectedChannel == ADC_CHANNEL_VREFINT) && ((tmp_config_internal_channel & LL_ADC_PATH_INTERNAL_VREFINT) == 0UL))
+        {
+          if (ADC_VREFINT_INSTANCE(hadc))
+          {
+            LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(hadc->Instance), LL_ADC_PATH_INTERNAL_VREFINT | tmp_config_internal_channel);
+          }
+        }
+        else
+        {
+          /* nothing to do */
+        }
+      }
+      /* If the requested internal measurement path has already been enabled  */
+      /* and other ADC of the common group are enabled, internal              */
+      /* measurement paths cannot be enabled.                                 */
+      else
+      {
+        /* Update ADC state machine to error */
+        SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+        tmp_hal_status = HAL_ERROR;
+      }
+    }
+
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Enable ADC multimode and configure multimode parameters
+  * @note   Possibility to update parameters on the fly:
+  *         This function initializes multimode parameters, following
+  *         calls to this function can be used to reconfigure some parameters
+  *         of structure "ADC_MultiModeTypeDef" on the fly, without resetting
+  *         the ADCs.
+  *         The setting of these parameters is conditioned to ADC state.
+  *         For parameters constraints, see comments of structure
+  *         "ADC_MultiModeTypeDef".
+  * @note   To move back configuration from multimode to single mode, ADC must
+  *         be reset (using function HAL_ADC_Init() ).
+  * @param hadc Master ADC handle
+  * @param multimode Structure of ADC multimode configuration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_MultiModeConfigChannel(ADC_HandleTypeDef *hadc, ADC_MultiModeTypeDef *multimode)
+{
+  HAL_StatusTypeDef tmp_hal_status = HAL_OK;
+  ADC_Common_TypeDef *tmpADC_Common;
+  ADC_HandleTypeDef  tmphadcSlave;
+  uint32_t tmphadcSlave_conversion_on_going;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_MULTIMODE_MASTER_INSTANCE(hadc->Instance));
+  assert_param(IS_ADC_MULTIMODE(multimode->Mode));
+  if (multimode->Mode != ADC_MODE_INDEPENDENT)
+  {
+    assert_param(IS_ADC_DUAL_DATA_MODE(multimode->DualModeData));
+    assert_param(IS_ADC_SAMPLING_DELAY(multimode->TwoSamplingDelay));
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hadc);
+
+  tmphadcSlave.State = HAL_ADC_STATE_RESET;
+  tmphadcSlave.ErrorCode = HAL_ADC_ERROR_NONE;
+
+  ADC_MULTI_SLAVE(hadc, &tmphadcSlave);
+
+  if (tmphadcSlave.Instance == NULL)
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+    /* Process unlocked */
+    __HAL_UNLOCK(hadc);
+
+    return HAL_ERROR;
+  }
+
+  /* Parameters update conditioned to ADC state:                              */
+  /* Parameters that can be updated when ADC is disabled or enabled without   */
+  /* conversion on going on regular group:                                    */
+  /*  - Multimode DATA Format configuration                                   */
+  tmphadcSlave_conversion_on_going = LL_ADC_REG_IsConversionOngoing((&tmphadcSlave)->Instance);
+  if ((LL_ADC_REG_IsConversionOngoing(hadc->Instance) == 0UL)
+      && (tmphadcSlave_conversion_on_going == 0UL))
+  {
+    /* Pointer to the common control register */
+    tmpADC_Common = __LL_ADC_COMMON_INSTANCE(hadc->Instance);
+
+    /* If multimode is selected, configure all multimode parameters.          */
+    /* Otherwise, reset multimode parameters (can be used in case of          */
+    /* transition from multimode to independent mode).                        */
+    if (multimode->Mode != ADC_MODE_INDEPENDENT)
+    {
+      MODIFY_REG(tmpADC_Common->CCR, ADC_CCR_DAMDF, multimode->DualModeData);
+
+      /* Parameters that can be updated only when ADC is disabled:              */
+      /*  - Multimode mode selection                                            */
+      /*  - Multimode delay                                                     */
+      /*    Note: Delay range depends on selected resolution:                   */
+      /*      from 1 to 9 clock cycles for 16 bits                              */
+      /*      from 1 to 9 clock cycles for 14 bits,                             */
+      /*      from 1 to 8 clock cycles for 12 bits                              */
+      /*      from 1 to 6 clock cycles for 10 and 8 bits                        */
+      /*    If a higher delay is selected, it will be clipped to maximum delay  */
+      /*    range                                                               */
+
+      if (__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) == 0UL)
+      {
+        MODIFY_REG(tmpADC_Common->CCR,
+                   ADC_CCR_DUAL |
+                   ADC_CCR_DELAY,
+                   multimode->Mode |
+                   multimode->TwoSamplingDelay
+                  );
+      }
+    }
+    else /* ADC_MODE_INDEPENDENT */
+    {
+      CLEAR_BIT(tmpADC_Common->CCR, ADC_CCR_DAMDF);
+
+      /* Parameters that can be updated only when ADC is disabled:                */
+      /*  - Multimode mode selection                                              */
+      /*  - Multimode delay                                                       */
+      if (__LL_ADC_IS_ENABLED_ALL_COMMON_INSTANCE(__LL_ADC_COMMON_INSTANCE(hadc->Instance)) == 0UL)
+      {
+        CLEAR_BIT(tmpADC_Common->CCR, ADC_CCR_DUAL | ADC_CCR_DELAY);
+      }
+    }
+  }
+  /* If one of the ADC sharing the same common group is enabled, no update    */
+  /* could be done on neither of the multimode structure parameters.          */
+  else
+  {
+    /* Update ADC state machine to error */
+    SET_BIT(hadc->State, HAL_ADC_STATE_ERROR_CONFIG);
+
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  /* Process unlocked */
+  __HAL_UNLOCK(hadc);
+
+  /* Return function status */
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Enable Injected Queue
+  * @note   This function resets CFGR register JQDIS bit in order to enable the
+  *         Injected Queue. JQDIS can be written only when ADSTART and JDSTART
+  *         are both equal to 0 to ensure that no regular nor injected
+  *         conversion is ongoing.
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_EnableInjectedQueue(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  uint32_t tmp_adc_is_conversion_on_going_regular;
+  uint32_t tmp_adc_is_conversion_on_going_injected;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+  tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
+
+  /* Parameter can be set only if no conversion is on-going */
+  if ((tmp_adc_is_conversion_on_going_regular == 0UL)
+      && (tmp_adc_is_conversion_on_going_injected == 0UL)
+     )
+  {
+    CLEAR_BIT(hadc->Instance->CFGR, ADC_CFGR_JQDIS);
+
+    /* Update state, clear previous result related to injected queue overflow */
+    CLEAR_BIT(hadc->State, HAL_ADC_STATE_INJ_JQOVF);
+
+    tmp_hal_status = HAL_OK;
+  }
+  else
+  {
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Disable Injected Queue
+  * @note   This function sets CFGR register JQDIS bit in order to disable the
+  *         Injected Queue. JQDIS can be written only when ADSTART and JDSTART
+  *         are both equal to 0 to ensure that no regular nor injected
+  *         conversion is ongoing.
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_DisableInjectedQueue(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+  uint32_t tmp_adc_is_conversion_on_going_regular;
+  uint32_t tmp_adc_is_conversion_on_going_injected;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  tmp_adc_is_conversion_on_going_regular = LL_ADC_REG_IsConversionOngoing(hadc->Instance);
+  tmp_adc_is_conversion_on_going_injected = LL_ADC_INJ_IsConversionOngoing(hadc->Instance);
+
+  /* Parameter can be set only if no conversion is on-going */
+  if ((tmp_adc_is_conversion_on_going_regular == 0UL)
+      && (tmp_adc_is_conversion_on_going_injected == 0UL)
+     )
+  {
+    LL_ADC_INJ_SetQueueMode(hadc->Instance, LL_ADC_INJ_QUEUE_DISABLE);
+    tmp_hal_status = HAL_OK;
+  }
+  else
+  {
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Disable ADC voltage regulator.
+  * @note   Disabling voltage regulator allows to save power. This operation can
+  *         be carried out only when ADC is disabled.
+  * @note   To enable again the voltage regulator, the user is expected to
+  *         resort to HAL_ADC_Init() API.
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_DisableVoltageRegulator(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Setting of this feature is conditioned to ADC state: ADC must be ADC disabled */
+  if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+  {
+    LL_ADC_DisableInternalRegulator(hadc->Instance);
+    tmp_hal_status = HAL_OK;
+  }
+  else
+  {
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  return tmp_hal_status;
+}
+
+/**
+  * @brief  Enter ADC deep-power-down mode
+  * @note   This mode is achieved in setting DEEPPWD bit and allows to save power
+  *         in reducing leakage currents. It is particularly interesting before
+  *         entering stop modes.
+  * @note   Setting DEEPPWD automatically clears ADVREGEN bit and disables the
+  *         ADC voltage regulator. This means that this API encompasses
+  *         HAL_ADCEx_DisableVoltageRegulator(). Additionally, the internal
+  *         calibration is lost.
+  * @note   To exit the ADC deep-power-down mode, the user is expected to
+  *         resort to HAL_ADC_Init() API as well as to relaunch a calibration
+  *         with HAL_ADCEx_Calibration_Start() API or to re-apply a previously
+  *         saved calibration factor.
+  * @param hadc ADC handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_ADCEx_EnterADCDeepPowerDownMode(ADC_HandleTypeDef *hadc)
+{
+  HAL_StatusTypeDef tmp_hal_status;
+
+  /* Check the parameters */
+  assert_param(IS_ADC_ALL_INSTANCE(hadc->Instance));
+
+  /* Setting of this feature is conditioned to ADC state: ADC must be ADC disabled */
+  if (LL_ADC_IsEnabled(hadc->Instance) == 0UL)
+  {
+    LL_ADC_EnableDeepPowerDown(hadc->Instance);
+    tmp_hal_status = HAL_OK;
+  }
+  else
+  {
+    tmp_hal_status = HAL_ERROR;
+  }
+
+  return tmp_hal_status;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_ADC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+


### PR DESCRIPTION
# Summary
Added ADC HAL files for the STM32H755 from vendor, enabled ADC in the hal config header, and added the new source files to the makefile for STM32. 

# Changes
Added:
- `lt/platforms/st/thirdparty/vendor-sdk/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc.h`
- `lt/platforms/st/thirdparty/vendor-sdk/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_adc_ex.h`
- `lt/platforms/st/thirdparty/vendor-sdk/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_adc.h`
- `lt/platforms/st/thirdparty/vendor-sdk/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_adc.c`
- `lt/platforms/st/thirdparty/vendor-sdk/stm32-H755ZI-nucleo-144/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_adc_ex.c`

Modified:
- `lt/platforms/st/thirdparty/vendor-sdk/stm32-H755ZI-nucleo-144/CM7/Core/Inc/stm32h75xx_hal_conf.h`
- `lt/platforms/st/build/project/stm32_sdk.mk`