### PR TITLE
Sync LT core updates (02-Sep-2026)

### DIFF
--- a/lt/lt/include/lt/device/wifi/LTDeviceWiFi.h
+++ b/lt/lt/include/lt/device/wifi/LTDeviceWiFi.h
@@ -460,7 +460,7 @@ struct LTDeviceWiFi {
          * @return true on success
          */
 
-    void (*ScanWithVendorIE)(LTWiFi_ScanWithIE const *params, LTDeviceWiFi_ScanCallback *cb, void *callback_data);
+    bool (*ScanWithVendorIE)(LTWiFi_ScanWithIE const *params, LTDeviceWiFi_ScanCallback *cb, void *callback_data);
         /**<
          * @brief Scan with a vendor IE injected into probe requests.
          *
@@ -469,6 +469,20 @@ struct LTDeviceWiFi {
          * @param[in] params: scan spec + vendor IE
          * @param[in] cb: called for each result, NULL when done
          * @param[in] callback_data: data passed to callback
+         * @return true when the request was accepted (the callback WILL fire,
+         *         ending with the NULL end-of-scan marker); false when it was
+         *         dropped and no callback of any kind follows
+         */
+
+    bool (*GetChannelPlan)(LTWiFi_ChannelPlan *plan);
+        /**<
+         * @brief Report the channels the active regulatory domain permits.
+         *
+         * DFS channels are included; a caller that transmits during discovery
+         * must stay passive on them until it has heard a beacon.
+         *
+         * @param[out] plan: channel list, 2.4 GHz first then 5 GHz
+         * @return true when the plan was filled in
          */
 };
 LT_EXTERN_C_END

--- a/lt/lt/include/lt/device/wifi/LTDriverWiFi.h
+++ b/lt/lt/include/lt/device/wifi/LTDriverWiFi.h
@@ -484,6 +484,18 @@ struct LTDriverWiFiApi {
      * @param[in] callback: called for each result, NULL when done
      */
 
+    bool (*GetChannelPlan)(LTDeviceUnit unit, LTWiFi_ChannelPlan *plan);
+    /**<
+     * @brief Report the channels the active regulatory domain permits.
+     *
+     * DFS channels are included -- the caller decides how to treat them.
+     * Requires the driver to be up (the plan comes from the radio country code).
+     *
+     * @param[in] unit: specifies the driver unit instance
+     * @param[out] plan: channel list, 2.4 GHz first then 5 GHz
+     * @return TRUE when the plan was filled in
+     */
+
 };
 LT_EXTERN_C_END
 #endif /* LTDRIVERWIFI_H */

--- a/lt/lt/include/lt/device/wifi/LTWiFi.h
+++ b/lt/lt/include/lt/device/wifi/LTWiFi.h
@@ -121,6 +121,22 @@ typedef struct LTWiFi_ScanSpec {
     u8 home_dwell;              ///< home channel dwell time (milliseconds)
 } LTWiFi_ScanSpec;
 
+/** Maximum channels in a regulatory channel plan (2.4 GHz + 5 GHz, any country). */
+#define kLTWiFi_Max_ChannelPlan 48
+
+/**
+ * @brief Channels the radio may scan under the active regulatory domain.
+ *
+ * Includes DFS channels: they are legal to scan passively, and a host AP can
+ * beacon on one.  Callers that transmit during discovery must classify DFS
+ * themselves and stay passive there until a beacon is heard.
+ * @ingroup ltdevice_wifi_struct
+ */
+typedef struct LTWiFi_ChannelPlan {
+    u8 count;                             ///< valid entries in channel[]
+    u8 channel[kLTWiFi_Max_ChannelPlan];  ///< 2.4 GHz first, then 5 GHz, ascending
+} LTWiFi_ChannelPlan;
+
 #define kLTWiFi_ScanSpec_Edition 0
 
 typedef u8 LTWiFi_ApSecurity;
@@ -497,9 +513,32 @@ typedef struct LTWiFi_MonitorConfig {
  *
  * Extends the standard scan to inject a vendor IE into probe requests.
  */
+/**
+ * @brief Raw Beacon / Probe Response received during a scan.
+ *
+ * Invoked synchronously in the driver's WiFi task context as the frame is
+ * received: filter and hand off, nothing more. It must not block or do slow
+ * work, and must not retain @p frame past the call -- the buffer belongs to
+ * the driver and is reused immediately afterwards.
+ *
+ * Unlike the parsed LTWiFi_ApInfo results, this exposes the frame body, so a
+ * caller can read the host's own primary-channel IE and tell a genuine
+ * detection from one bleeding in on an adjacent 20 MHz sub-channel.
+ *
+ * @param frame   802.11 management frame, from the start of the MAC header.
+ * @param len     Frame length in bytes.
+ * @param freqMhz Frequency the frame arrived on, in MHz.
+ * @param rssi    Signal strength in dBm.
+ * @param ctx     Caller context from LTWiFi_ScanWithIE::frameCtx.
+ */
+typedef void (LTWiFi_ScanFrameCallback)(void const *frame, u16 len, u16 freqMhz,
+                                        s8 rssi, void *ctx);
+
 typedef struct LTWiFi_ScanWithIE {
     LTWiFi_ScanSpec scan;       ///< Standard scan parameters
     LTWiFi_VendorIE vendorIE;   ///< Vendor IE to inject during scan
+    LTWiFi_ScanFrameCallback *frameCallback; ///< Raw frame sink, NULL = none
+    void *frameCtx;             ///< Caller context passed to frameCallback
 } LTWiFi_ScanWithIE;
 LT_EXTERN_C_END
 #endif /* LTWIFI_H */

--- a/lt/lt/source/lt/device/authentication/LTDeviceAuthenticationImpl.c
+++ b/lt/lt/source/lt/device/authentication/LTDeviceAuthenticationImpl.c
@@ -46,8 +46,23 @@ static LTDeviceEfuse *s_pLibEfuse = NULL;
 static ILTDriverEfuseDeviceUnit *s_iEfuse = NULL;
 
 /*******************************************************************************
+ * The chip ID carries a 5 bit platform number in its upper bits, which has to
+ * come off before the sequential part of the ID can be range checked:        */
+#define kChipIdSequenceMask 0x07FFFFFFu
+
+/*******************************************************************************
+ * Chip IDs below this are provisioned with the development keys.  Platforms
+ * that need a different limit set "devKeyChipIdLimit" in their
+ * LTDeviceAuthentication config section; BlueRidge does, because test parts
+ * were built past this limit before the range was settled on.               */
+#define kDefaultDevKeyChipIdLimit 0x200u
+
+static u32 s_devKeyChipIdLimit = kDefaultDevKeyChipIdLimit;
+
+/*******************************************************************************
  * Some needed forward declarations:                                          */
 static bool LTDeviceAuthentication_IsSecureDevice(void);
+static u32  LTDeviceAuthentication_GetChipID(void);
 
 /*******************************************************************************
  * The implementations of our functionality:                                  */
@@ -347,8 +362,18 @@ static bool LTDeviceAuthentication_IsUsingDevKeys(void) {
         return s_iAuth->IsUsingDevKeys();
     }
 
-    // Default to false (not using DEV keys)
-    return false;
+    // A secure part is running the development keys when the sequential portion
+    // of its chip ID falls below the platform's limit.  This mirrors how the
+    // host picks the development master key when deriving AES_KEY1, so that the
+    // flag reported here matches the keys the host will actually use.
+    u32 chipID = LTDeviceAuthentication_GetChipID();
+
+    // An unsecure part, or one whose chip ID could not be read, has no keys to
+    // report on.  GetChipID() already returns 0xffffffff unless the part is
+    // secure and the field could be read.
+    if (chipID == 0 || chipID == 0xffffffff) return false;
+
+    return (chipID & kChipIdSequenceMask) < s_devKeyChipIdLimit;
 }
 
 static u32 LTDeviceAuthentication_GetChipID(void) {
@@ -415,6 +440,19 @@ static void LTDeviceAuthenticationImpl_LibFini(void) {
  * will be used instead                                                       */
 static bool LTDeviceAuthenticationImpl_LibInit(void) {
     LTLOG("init.begin", NULL);
+
+    // Pick up this platform's development key chip ID limit, if it overrides
+    // the default.  Absent (or zero) leaves the default in place.
+    LTDeviceConfig *pDeviceConfig = lt_openlibrary(LTDeviceConfig);
+    if (pDeviceConfig) {
+        u32 section = pDeviceConfig->GetDeviceSection("LTDeviceAuthentication");
+        if (section) {
+            s64 limit = pDeviceConfig->ReadInteger(section, "devKeyChipIdLimit");
+            if (limit > 0) s_devKeyChipIdLimit = (u32)limit;
+        }
+        lt_closelibrary(pDeviceConfig);
+    }
+    LTLOG("init.devkey.limit", "devKeyChipIdLimit:0x%lx", LT_Pu32(s_devKeyChipIdLimit));
 
     // Attempt to open the authentication driver
     if ((s_pDriver = LTDeviceConfig_OpenDriverLibForDevice("LTDeviceAuthentication", 0))) {

--- a/lt/lt/source/lt/device/wifi/LTDeviceWiFi.c
+++ b/lt/lt/source/lt/device/wifi/LTDeviceWiFi.c
@@ -164,6 +164,7 @@ static const char *DEV_ApSecurityStrings[kLTWiFi_ApSecurity_Max] = { LTWiFi_Secu
 #define SETTINGS_KEY_CHANNEL  SETTINGS_PREFIX "channel"
 #define SETTINGS_KEY_AUTOJOIN SETTINGS_PREFIX "autojoin"
 #define SETTINGS_KEY_REJOIN   SETTINGS_PREFIX "rejoin"
+#define SETTINGS_KEY_COUNTRY  SETTINGS_PREFIX "country"
 
 /// @todo put in system config for dynamic changes
 #define METRICS_SAMPLING_PERIOD 10
@@ -305,6 +306,8 @@ struct WSM_Input {
     LTThread caller_thread;     // only dealloc WSM_Input when NULL
     LTEvent event;              // used to trigger callback
     LTWiFi_VendorIE scan_vendor_ie; // probe-request vendor IE for WS_ScanStart (length 0 = none)
+    LTWiFi_ScanFrameCallback *scan_frame_cb; // raw Beacon/Probe Resp sink for WS_ScanStart (NULL = none)
+    void *scan_frame_ctx;
     union {
         LTWiFi_ScanSpec scan_spec;
         LTWiFi_ApInfo   join_spec;
@@ -328,7 +331,7 @@ enum {
     WiFiConfig_StateMachineStackSize = 1536,
     WiFiConfig_StartTimeoutSeconds = 2,
     WiFiConfig_CheckDriverSeconds = 2,
-    WiFiConfig_ScanTimeoutSeconds = 10,
+    WiFiConfig_ScanTimeoutSeconds = 15,
     WiFiConfig_JoinTimeoutSeconds = 9,
     WiFiConfig_LinkCheckSeconds = 4,
 };
@@ -392,11 +395,12 @@ static void WSM_InitVars(void) {
 /** Forward references ********************************************************/
 
 static WSM_Input *WSM_CreateInput(u8 state);
-static void WSM_PostRequest(WSM_Input *request);
+static bool WSM_PostRequest(WSM_Input *request);
 static void WSM_GotTimer(void * pClientData);
 static void WSM_FreeInput(LTThread_ReleaseReason releaseReason, void *pClientData);
 static void WSM_ProcessInput(void *data);
 static bool API_LoadApSettings(LTWiFi_ApInfo *ap);
+static void DEV_PushCountryCode(void);
 
 /** Misc Utilities ************************************************************/
 
@@ -716,15 +720,17 @@ static WSM_Input *WSM_PopInput(WSM_Queue *queue) {
  * WSM_PostRequest -- Submit an API-created state request to the state machine.
  * If the request includes a callback, it will be called per the details
  * of the API. For example, callback on scan results and scan done.
+ * Returns false when the request was dropped (shutdown, bad state, or the WSM
+ * thread refused the queue entry); no callback of any kind follows a drop.
  */
-static void WSM_PostRequest(WSM_Input *request) {
+static bool WSM_PostRequest(WSM_Input *request) {
     if (!WSM_Thread || request->state >= WS_MaxState) {
         FREE(request);
-        return;
+        return false;
     }
     LTLOG_LEVEL(kLogDebug, "wsm.pst", "WSM PostRequest(%s)", WSM_StateNames_[request->state]);
     request->caller_thread = iThread->GetCurrentThread();
-    iThread->QueueTaskProc(WSM_Thread, WSM_ProcessInput, WSM_FreeInput, request);
+    return iThread->QueueTaskProc(WSM_Thread, WSM_ProcessInput, WSM_FreeInput, request);
 }
 
 /**
@@ -924,6 +930,7 @@ static void WSM_DoNext(WSM_Input *input) {
             INFO_GUARD(DRV_WiFi->GetDriverInfo(DRV_Unit, &DRV_Info));
             // if MAC_Library->IsZero(&DRV_Info.mac_address) indicate problem !!!
             LTLOG("wsm.sta.mac", "STA MAC: %s", MacToStr(&DRV_Info.mac_address));
+            DEV_PushCountryCode();
             iEvent->NotifyEvent(WSM_StatEvent, kLTDeviceWiFi_Status_Up, DRV_Unit);
             WSM_JoinSpec.pass = WSM_JoinPass;
             if (API_LoadApSettings(&WSM_JoinSpec)) {
@@ -1014,7 +1021,8 @@ static void WSM_DoNext(WSM_Input *input) {
             WSM_ScanActive = true;
             WSM_ScanEvent = WSM_ThisRequest.event;
             //LTLOG("event", "------scan event set %lx------", WSM_ScanEvent);
-            if (WSM_ThisRequest.scan_vendor_ie.length > 0 && DRV_WiFi->ScanWithVendorIE) {
+            if ((WSM_ThisRequest.scan_vendor_ie.length > 0 || WSM_ThisRequest.scan_frame_cb)
+                && DRV_WiFi->ScanWithVendorIE) {
                 // Probe-request vendor IE attached (find-host): run the scan via
                 // the driver's vendor-IE path. Routing it through the WSM (rather
                 // than a direct driver call) means the result callback is later
@@ -1022,8 +1030,10 @@ static void WSM_DoNext(WSM_Input *input) {
                 // per-channel find-host sweep can safely start the next scan from
                 // that callback without re-entering the driver's event thread.
                 LTWiFi_ScanWithIE swie;
-                swie.scan     = WSM_ThisRequest.scan_spec;
-                swie.vendorIE = WSM_ThisRequest.scan_vendor_ie;
+                swie.scan          = WSM_ThisRequest.scan_spec;
+                swie.vendorIE      = WSM_ThisRequest.scan_vendor_ie;
+                swie.frameCallback = WSM_ThisRequest.scan_frame_cb;
+                swie.frameCtx      = WSM_ThisRequest.scan_frame_ctx;
                 DRV_WiFi->ScanWithVendorIE(DRV_Unit, &swie, WSM_Scan_DriverCB);
             } else {
                 DRV_WiFi->ScanStart(DRV_Unit, &WSM_ThisRequest.scan_spec, WSM_Scan_DriverCB);
@@ -1133,7 +1143,12 @@ static void WSM_DoNext(WSM_Input *input) {
             break;
 
         case WS_JoinCheck: {
-            if (IS_TIMEOUT) {
+            /* Pull the driver's latest status before checking the timeout --
+             * otherwise a join that just succeeded this same tick reads as
+             * stale (still Authenticating) and a timeout at the same poll
+             * clobbers it into Failed before the callback below can land. */
+            DRV_WiFi->JoinCheck(DRV_Unit);
+            if (IS_TIMEOUT && LTAtomic_Load(&WSM_JoinStatus) < kLTWiFi_JoinStatus_Failed) {
                 LTAtomic_Store(&WSM_JoinStatus, kLTWiFi_JoinStatus_Failed);
             }
             // Sequence through the connection states:
@@ -1180,7 +1195,6 @@ static void WSM_DoNext(WSM_Input *input) {
                 LTAtomic_Store(&WSM_LastJoinStatus, LTAtomic_Load(&WSM_JoinStatus));
                 iEvent->NotifyEvent(WSM_JoinEvent, WSM_JoinStatus, WSM_CallbackData);
             }
-            DRV_WiFi->JoinCheck(DRV_Unit); // nudge driver if necessary
             return; // wait for state timer (even for JoinDone case it's more stable)
         }
 
@@ -1344,6 +1358,25 @@ static bool API_GetMacAddress(LTMacAddress *mac) {
     return true;
 }
 
+static void DEV_PushCountryCode(void) {
+    char cc[8] = "US";
+    if (DEV_OpenSettings()) {
+        LTString cc_setting = ltstring_create("");
+        if (SET_Library->GetStringValue(SETTINGS_KEY_COUNTRY, &cc_setting) && cc_setting[0]) {
+            lt_strncpyTerm(cc, cc_setting, sizeof(cc));
+        }
+        ltstring_destroy(cc_setting);
+    }
+    if (!DRV_WiFi->SetOption(DRV_Unit, "country_code", cc)) {
+        LTLOG("cc.unsup", "driver does not support country_code option");
+        return;
+    }
+    char readback[8] = {0};
+    if (DRV_WiFi->GetOption(DRV_Unit, "country_code", readback) && lt_strcmp(readback, cc) != 0) {
+        LTLOG("cc.mismatch", "set=%s readback=%s", cc, readback);
+    }
+}
+
 static bool API_SetMacAddress(LTMacAddress *mac) {
     if (!LTAtomic_Load(&WSM_DriverUp)) return false;
     bool result = false;
@@ -1403,6 +1436,14 @@ static u32 API_GetOption(char const *option) {
     u32 value = 0;
     if (DRV_WiFi && DRV_WiFi->GetOption(DRV_Unit, option, &value)) return value;
     return 0;
+}
+
+// Regulatory channel plan straight from the driver; DFS channels are included,
+// so a caller that transmits during discovery must stay passive on them until
+// it has heard a beacon.
+static bool API_GetChannelPlan(LTWiFi_ChannelPlan *plan) {
+    if (!plan || !DRV_WiFi || !DRV_WiFi->GetChannelPlan) return false;
+    return DRV_WiFi->GetChannelPlan(DRV_Unit, plan);
 }
 
 static void API_OnStatusChange(LTDeviceWiFi_StatusCallback func, LTThread_ClientDataReleaseProc *clientDataReleaseProc, void * clientData) {
@@ -1494,8 +1535,14 @@ static bool API_SaveApSettings(LTWiFi_ApInfo *ap) {
 
     bool bResult = false;
     if (!ap) {
-        // ap == NULL: Delete all wifi/* settings
+        // ap == NULL: Delete all wifi/* settings, but preserve the provisioned
+        // regulatory country -- forgetting the host credential must not move
+        // the device back to the US default plan.
+        LTString cc = ltstring_create("");
+        bool haveCc = SET_Library->GetStringValue(SETTINGS_KEY_COUNTRY, &cc) && cc[0];
         bResult = SET_Library->DeleteSettingsWithPrefix(SETTINGS_PREFIX);
+        if (haveCc && !SET_Library->SetStringValue(SETTINGS_KEY_COUNTRY, cc)) bResult = false;
+        ltstring_destroy(cc);
     } else if (ap->ssid[0] == '\0') {
         // ap->ssid == "": Delete wifi/{ssid,pass,security}
         bResult = (SET_Library->DeleteSetting(SETTINGS_KEY_SSID)
@@ -1527,17 +1574,73 @@ static bool API_SaveApSettings(LTWiFi_ApInfo *ap) {
     return bResult;
 }
 
+
+/* Deferred end-of-scan marker for a scan rejected before it reached the WSM.
+ * Runs from the API caller's own task queue, so delivery cannot recurse into
+ * a callback that immediately rescans. */
+typedef struct { LTDeviceWiFi_ScanCallback *cb; void *data; } WSM_ScanDoneCtx;
+
+static void WSM_ScanDoneProc(void *pClientData) {
+    WSM_ScanDoneCtx *ctx = (WSM_ScanDoneCtx *)pClientData;
+    ctx->cb(NULL, ctx->data);
+}
+
+static void WSM_ScanDoneRelease(LTThread_ReleaseReason releaseReason, void *pClientData) {
+    LT_UNUSED(releaseReason);
+    FREE(pClientData);
+}
+
+/* Queue the empty end-of-scan marker to the caller's own task queue: inline
+ * delivery can recurse when the callback rescans on the marker.  Falls back
+ * to inline delivery only when the deferral itself fails. */
+static void WSM_ScanDoneDeferred(LTDeviceWiFi_ScanCallback *callback, void *callback_data) {
+    WSM_ScanDoneCtx *ctx;
+    if (ALLOC(ctx)) {
+        ctx->cb   = callback;
+        ctx->data = callback_data;
+        if (iThread->QueueTaskProc(iThread->GetCurrentThread(),
+                                   WSM_ScanDoneProc, WSM_ScanDoneRelease, ctx)) {
+            return;
+        }
+        /* the release proc already freed ctx */
+    }
+    callback(NULL, callback_data);
+}
+
 static void API_ScanAps(LTWiFi_ScanSpec *spec, LTDeviceWiFi_ScanCallback *callback, void *callback_data){
     WSM_Input *req = WSM_CreateInput(WS_ScanStart); // req is cleared
+    if (!req) {
+        /* ScanAps is void: the terminal marker is the caller's only signal,
+         * so even this allocation failure must fire it (as the paths below do). */
+        if (callback) WSM_ScanDoneDeferred(callback, callback_data);
+        return;
+    }
     if (spec) req->scan_spec = *spec; // copy spec
+    LTEvent event = 0;
     if (callback) {
         // Create an event used for the callback. It is created and registered
         // here, but because ScanAps is async, the unregister and destroy must
         // be part of the callback mechanism. See ScanEventProc().
-        req->event = pCore->CreateEvent(&WSM_ScanEventArgs, WSM_ScanEventProc, WSM_ScanEventCompleteProc, NULL, NULL);
-        iEvent->RegisterForEvent(req->event, callback, NULL, callback_data, false);
+        event = pCore->CreateEvent(&WSM_ScanEventArgs, WSM_ScanEventProc, WSM_ScanEventCompleteProc, NULL, NULL);
+        if (!event) {
+            /* A zero event still posts, but the WSM then treats the scan as a
+             * false alarm and never sends the terminal callback. */
+            FREE(req);
+            WSM_ScanDoneDeferred(callback, callback_data);
+            return;
+        }
+        iEvent->RegisterForEvent(event, callback, NULL, callback_data, false);
+        req->event = event;
     }
-    WSM_PostRequest(req);
+    if (WSM_PostRequest(req) || !event) return;
+    // The request never reached the WSM (req is already freed): no scan
+    // notification will fire, so the completion proc that normally
+    // unregisters and destroys the event never runs.  Do it here, and deliver
+    // the terminal marker -- ScanAps is void, so the marker is the only way
+    // the caller can learn the scan died.
+    iEvent->UnregisterFromEvent(event, WSM_ScanEventProc);
+    iEvent->Destroy(event);
+    WSM_ScanDoneDeferred(callback, callback_data);
 }
 
 static void API_JoinAp(LTWiFi_ApInfo *ap, LTDeviceWiFi_JoinCallback *callback, void *callback_data) {
@@ -1681,9 +1784,9 @@ static bool API_SetAutoRfOff(bool enable, u32 timeout_ms)
     return DRV_WiFi->SetAutoRfOff(DRV_Unit, enable, timeout_ms);
 }
 
-static void API_ScanWithVendorIE(LTWiFi_ScanWithIE const *params, LTDeviceWiFi_ScanCallback *cb, void *callback_data)
+static bool API_ScanWithVendorIE(LTWiFi_ScanWithIE const *params, LTDeviceWiFi_ScanCallback *cb, void *callback_data)
 {
-    if (!DRV_WiFi || !DRV_WiFi->ScanWithVendorIE || !params) return;
+    if (!DRV_WiFi || !DRV_WiFi->ScanWithVendorIE || !params) return false;
 
     // Route through the WSM exactly like API_ScanAps, additionally carrying the
     // probe-request vendor IE. The IE and the scan_spec's channel buffer must
@@ -1693,14 +1796,32 @@ static void API_ScanWithVendorIE(LTWiFi_ScanWithIE const *params, LTDeviceWiFi_S
     // the event below), so a per-channel sweep can advance from the result
     // callback without re-entering the driver's scan-done event thread.
     WSM_Input *req = WSM_CreateInput(WS_ScanStart); // req is cleared
-    if (!req) return;
+    if (!req) return false;
     req->scan_spec      = params->scan;
     req->scan_vendor_ie = params->vendorIE;
+    req->scan_frame_cb  = params->frameCallback;
+    req->scan_frame_ctx = params->frameCtx;
+    LTEvent event = 0;
     if (cb) {
-        req->event = pCore->CreateEvent(&WSM_ScanEventArgs, WSM_ScanEventProc, WSM_ScanEventCompleteProc, NULL, NULL);
-        iEvent->RegisterForEvent(req->event, cb, NULL, callback_data, false);
+        event = pCore->CreateEvent(&WSM_ScanEventArgs, WSM_ScanEventProc, WSM_ScanEventCompleteProc, NULL, NULL);
+        if (!event) {
+            /* See API_ScanAps: a zero event never fires the terminal callback.
+             * This entry point may simply reject instead. */
+            FREE(req);
+            return false;
+        }
+        iEvent->RegisterForEvent(event, cb, NULL, callback_data, false);
+        req->event = event;
     }
-    WSM_PostRequest(req);
+    if (WSM_PostRequest(req)) return true;
+    // The request never reached the WSM (req is already freed): no scan
+    // notification will fire, so the completion proc that normally
+    // unregisters and destroys the event never runs.  Do it here.
+    if (event) {
+        iEvent->UnregisterFromEvent(event, WSM_ScanEventProc);
+        iEvent->Destroy(event);
+    }
+    return false;
 }
 /*******************************************************************************
  * Library Standard Functions
@@ -1793,4 +1914,5 @@ define_LTDEVICE_LIBRARY_ROOT_INTERFACE(LTDeviceWiFi, LTDeviceWiFiImpl_Run, 1024)
     .TxMgmtFrame                = API_TxMgmtFrame,
     .SetAutoRfOff               = API_SetAutoRfOff,
     .ScanWithVendorIE           = API_ScanWithVendorIE,
+    .GetChannelPlan             = API_GetChannelPlan,
 LTLIBRARY_DEFINITION;

--- a/lt/lt/source/lt/driver/net/transport/lwipwifi/LTDriverNetTransportLwipWiFi.c
+++ b/lt/lt/source/lt/driver/net/transport/lwipwifi/LTDriverNetTransportLwipWiFi.c
@@ -1039,17 +1039,10 @@ PUB void NetIpWiFi_CloseTransport(LTTransportDriver *driverData) { // Called fro
         dhcp_stop(GET_NETIF(tran));
         dhcp_cleanup(GET_NETIF(tran));
     }
-    S.iThread->Sleep(LTTime_Milliseconds(500)); // hack to wait for disconnect !!!
-
     netif_set_link_down(GET_NETIF(tran));
     netif_remove(GET_NETIF(tran));
     sys_timeouts_destroy();
     UNLOCK_API;
-
-    // Terminate transport thread
-    S.iThread->Terminate(tran->hThread);
-    S.iThread->WaitUntilFinished(tran->hThread, LTTime_Seconds(10));
-    S.iThread->Destroy(tran->hThread);
 
     lt_lwip_sys_destroy();
     // Destroyed only here: sys_timeouts_destroy() above cancels the lwip cyclic

--- a/lt/lt/source/lt/ltk/LTKArchRISC_V.c
+++ b/lt/lt/source/lt/ltk/LTKArchRISC_V.c
@@ -14,8 +14,21 @@
  * TODO: __riscv_float_abi_soft / __riscv_float_abi_single - and Hard FP lazy context switch
  */
 
-/* Kernel ABI version */
+/* Kernel ABI version. Builds with hardware FP stack a larger trap frame, which the
+ * crashdump decoder must know about, so they report a distinct ABI version. */
+#if defined(__riscv_flen)
+#define LTK_ABI_VERSION     "RISC_V.2"
+#else
 #define LTK_ABI_VERSION     "RISC_V.1"
+#endif
+
+/* The trap handler stacks integer and FP context in one frame, so LTKStackFrame
+ * must match the stack pointer adjustment in LTKArchRISC_V_Vectors.S. */
+LT_STATIC_ASSERT(sizeof(LTKStackFrame) == LTK_ARCH_RISC_V_STACK_PTR_ADJ, "LTKStackFrame must cover the whole trap frame");
+LT_STATIC_ASSERT((LTK_ARCH_RISC_V_STACK_PTR_ADJ % 8) == 0, "Trap frame must keep the stack 8-byte aligned");
+#if defined(__riscv_flen)
+LT_STATIC_ASSERT(LTK_FRAME_WORD(FCSR) < sizeof(LTKStackFrame) / 4, "Saved FCSR must lie inside the trap frame");
+#endif
 
 /*****************
  * Configuration */
@@ -385,6 +398,8 @@ _LTKInitThread(LTKThread * pThread, u8 nPriority, void * pEntry, s32 nArg,
     pStackFrame->nRegister[LTK_FRAME_WORD(RA)]      = (u32)_LTKThreadExit;
 #if defined(__riscv_flen)
     pStackFrame->nRegister[LTK_FRAME_WORD(MSTATUS)] = LTK_ARCH_RISC_V_START_MSTATUS_FP;
+    // The first FP context restore writes this slot to FCSR, which needs a valid rounding mode.
+    pStackFrame->nRegister[LTK_FRAME_WORD(FCSR)]    = 0;
 #else
     pStackFrame->nRegister[LTK_FRAME_WORD(MSTATUS)] = LTK_ARCH_RISC_V_START_MSTATUS;
 #endif
@@ -393,10 +408,6 @@ _LTKInitThread(LTKThread * pThread, u8 nPriority, void * pEntry, s32 nArg,
     for (; pFill >= (u32 *)pStackBottom; pFill--) {
         *pFill = kLTKStackFillValue;
     }
-#if defined(__riscv_flen)
-    // Initialize the saved FCSR slot that the first FP context restore reads.
-    *(u32 *)((u8 *)pStackFrame + LTK_ARCH_RISC_V_FCSR_FRAME_OFFSET) = 0;
-#endif
     // Initialize context and state
     pThread->pStack           = (u8 *)pStackFrame;
     pThread->nCycleCount      = 0;

--- a/lt/lt/source/lt/ltk/LTKArchRISC_V.h
+++ b/lt/lt/source/lt/ltk/LTKArchRISC_V.h
@@ -41,15 +41,16 @@ typedef struct {
 } LTKStackFrame;
 
 #if defined(__riscv_flen)
-    #define LTK_ARCH_RISC_V_FP_RESERVE    LTK_ARCH_RISC_V_FP_STACK_PTR_ADJ
+    #define LTK_ARCH_THREAD_STACK_RESERVE    LTK_ARCH_RISC_V_FP_FRAME_SIZE
 #else
-    #define LTK_ARCH_RISC_V_FP_RESERVE    0
+    #define LTK_ARCH_THREAD_STACK_RESERVE    0
 #endif
 
 enum {
-    kLTK_IdleThreadStackSize    = sizeof(LTKStackFrame) + 128 + LTK_ARCH_RISC_V_FP_RESERVE,
+    /* LTKStackFrame already covers the FP context, so no extra reserve here. */
+    kLTK_IdleThreadStackSize    = sizeof(LTKStackFrame) + 128,
     /* RISC-V has more expensive stacking requirements than ARM. */
-    kLTK_DefaultThreadStackSize = 512 + 128 + LTK_ARCH_RISC_V_FP_RESERVE
+    kLTK_DefaultThreadStackSize = 512 + 128
 };
 
 LT_INLINE bool InterruptsAreDisabled(void) LT_ISR_SAFE {

--- a/lt/lt/source/lt/ltk/LTKArchRISC_V_Vectors.S
+++ b/lt/lt/source/lt/ltk/LTKArchRISC_V_Vectors.S
@@ -1,7 +1,6 @@
 /******************************************************************************
  * lt/source/lt/ltk/LTKArchRISC_V_Vectors.S                     LTK MicroKernel
  *
- *
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  * If a copy of the MPL was not distributed with this file, you can obtain one at
  * https://mozilla.org/MPL/2.0/.
@@ -46,7 +45,8 @@ _LTK_nTrapNestingCounter:
     .type     _LTKMachineTrapHandler, @function
     .balign   64, 0
 _LTKMachineTrapHandler:
-    /* Save Context */
+    /* Save Context: integer and FP context occupy one frame, so the saved stack
+     *   pointer is the thread's true low-water mark for _LTKStackCheck(). */
     addi      sp, sp, -LTK_ARCH_RISC_V_STACK_PTR_ADJ
     sw        a0, LTK_FRAME(A0)(sp)
     sw        a1,    4(sp)
@@ -79,42 +79,41 @@ _LTKMachineTrapHandler:
     sw        a0, LTK_FRAME(MSTATUS)(sp)
     sw        ra, LTK_FRAME(RA)(sp)
 #if defined(__riscv_flen)
-    addi                       sp, sp, -LTK_ARCH_RISC_V_FP_STACK_PTR_ADJ
-    LTK_ARCH_RISC_V_FP_STORE   f0,   1*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f1,   2*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f2,   3*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f3,   4*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f4,   5*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f5,   6*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f6,   7*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f7,   8*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f8,   9*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f9,  10*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f10, 11*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f11, 12*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f12, 13*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f13, 14*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f14, 15*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f15, 16*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f16, 17*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f17, 18*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f18, 19*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f19, 20*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f20, 21*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f21, 22*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f22, 23*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f23, 24*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f24, 25*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f25, 26*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f26, 27*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f27, 28*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f28, 29*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f29, 30*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f30, 31*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_STORE   f31, 32*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f0,  LTK_FP_FRAME(0)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f1,  LTK_FP_FRAME(1)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f2,  LTK_FP_FRAME(2)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f3,  LTK_FP_FRAME(3)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f4,  LTK_FP_FRAME(4)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f5,  LTK_FP_FRAME(5)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f6,  LTK_FP_FRAME(6)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f7,  LTK_FP_FRAME(7)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f8,  LTK_FP_FRAME(8)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f9,  LTK_FP_FRAME(9)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f10, LTK_FP_FRAME(10)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f11, LTK_FP_FRAME(11)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f12, LTK_FP_FRAME(12)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f13, LTK_FP_FRAME(13)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f14, LTK_FP_FRAME(14)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f15, LTK_FP_FRAME(15)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f16, LTK_FP_FRAME(16)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f17, LTK_FP_FRAME(17)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f18, LTK_FP_FRAME(18)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f19, LTK_FP_FRAME(19)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f20, LTK_FP_FRAME(20)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f21, LTK_FP_FRAME(21)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f22, LTK_FP_FRAME(22)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f23, LTK_FP_FRAME(23)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f24, LTK_FP_FRAME(24)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f25, LTK_FP_FRAME(25)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f26, LTK_FP_FRAME(26)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f27, LTK_FP_FRAME(27)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f28, LTK_FP_FRAME(28)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f29, LTK_FP_FRAME(29)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f30, LTK_FP_FRAME(30)(sp)
+    LTK_ARCH_RISC_V_FP_STORE   f31, LTK_FP_FRAME(31)(sp)
+    /* t0 was saved with the integer context above, so frcsr may clobber it */
     frcsr                      t0
-    sw                         t0,  33*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    addi                       sp, sp, LTK_ARCH_RISC_V_FP_STACK_PTR_ADJ
+    sw                         t0,  LTK_FRAME(FCSR)(sp)
 #endif
     mv        a0, sp
 
@@ -153,7 +152,7 @@ SystemCall:
     addi      t0, t0, 4
 
 Dispatch:
-    /* Interrupts remain disabled upon entering dispatcher, and shall be disabled after exit. */
+    /* Interrupts remain disabled upon entering dispatcher, and shall be disabled after exit. */ 
     sw        t0, LTK_FRAME(MEPC)(a0)
     call      _LTKDispatcher
 
@@ -169,42 +168,40 @@ Restore:
 
     /* Restore Context */
 #if defined(__riscv_flen)
-    addi                      sp, sp, -LTK_ARCH_RISC_V_FP_STACK_PTR_ADJ
-    LTK_ARCH_RISC_V_FP_LOAD   f0,   1*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f1,   2*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f2,   3*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f3,   4*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f4,   5*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f5,   6*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f6,   7*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f7,   8*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f8,   9*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f9,  10*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f10, 11*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f11, 12*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f12, 13*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f13, 14*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f14, 15*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f15, 16*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f16, 17*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f17, 18*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f18, 19*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f19, 20*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f20, 21*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f21, 22*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f22, 23*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f23, 24*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f24, 25*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f25, 26*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f26, 27*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f27, 28*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f28, 29*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f29, 30*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f30, 31*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    LTK_ARCH_RISC_V_FP_LOAD   f31, 32*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    lw                        t0,  33*LTK_ARCH_RISC_V_FP_REG_SIZE(sp)
-    fscsr                     t0
-    addi                      sp, sp, LTK_ARCH_RISC_V_FP_STACK_PTR_ADJ
+    LTK_ARCH_RISC_V_FP_LOAD    f0,  LTK_FP_FRAME(0)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f1,  LTK_FP_FRAME(1)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f2,  LTK_FP_FRAME(2)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f3,  LTK_FP_FRAME(3)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f4,  LTK_FP_FRAME(4)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f5,  LTK_FP_FRAME(5)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f6,  LTK_FP_FRAME(6)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f7,  LTK_FP_FRAME(7)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f8,  LTK_FP_FRAME(8)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f9,  LTK_FP_FRAME(9)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f10, LTK_FP_FRAME(10)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f11, LTK_FP_FRAME(11)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f12, LTK_FP_FRAME(12)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f13, LTK_FP_FRAME(13)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f14, LTK_FP_FRAME(14)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f15, LTK_FP_FRAME(15)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f16, LTK_FP_FRAME(16)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f17, LTK_FP_FRAME(17)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f18, LTK_FP_FRAME(18)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f19, LTK_FP_FRAME(19)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f20, LTK_FP_FRAME(20)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f21, LTK_FP_FRAME(21)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f22, LTK_FP_FRAME(22)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f23, LTK_FP_FRAME(23)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f24, LTK_FP_FRAME(24)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f25, LTK_FP_FRAME(25)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f26, LTK_FP_FRAME(26)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f27, LTK_FP_FRAME(27)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f28, LTK_FP_FRAME(28)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f29, LTK_FP_FRAME(29)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f30, LTK_FP_FRAME(30)(sp)
+    LTK_ARCH_RISC_V_FP_LOAD    f31, LTK_FP_FRAME(31)(sp)
+    lw                         t0,  LTK_FRAME(FCSR)(sp)
+    fscsr                      t0
 #endif
     lw        a0, LTK_FRAME(MSTATUS)(sp)
     csrw      mstatus, a0

--- a/lt/lt/source/lt/ltk/LTKArchRISC_V_Vectors.h
+++ b/lt/lt/source/lt/ltk/LTKArchRISC_V_Vectors.h
@@ -11,11 +11,8 @@
 #ifndef ROKU_LT_SOURCE_LT_LTK_LTKARCHRISC_V_VECTORS_H
 #define ROKU_LT_SOURCE_LT_LTK_LTKARCHRISC_V_VECTORS_H
 
-// Stack Frame Size
-#define LTK_ARCH_RISC_V_SF_SIZE            (30 * 4)
-
-// Stack frame adjustment for context switch
-#define LTK_ARCH_RISC_V_STACK_PTR_ADJ      LTK_ARCH_RISC_V_SF_SIZE
+// Integer context size (offsets 0 .. LTK_ARCH_RISC_V_FRAME_MEPC)
+#define LTK_ARCH_RISC_V_INT_SF_SIZE        (30 * 4)
 
 // Environment call (syscall) mcause code
 #define LTK_ARCH_RISC_V_MCAUSE_ECALL       11
@@ -38,11 +35,19 @@
 #define LTK_ARCH_RISC_V_FP_STORE           fsw
 #define LTK_ARCH_RISC_V_FP_REG_SIZE        4
 #endif // #if __riscv_flen == 64
-#define LTK_ARCH_RISC_V_FP_STACK_PTR_ADJ   (34 * LTK_ARCH_RISC_V_FP_REG_SIZE)
-// Saved FCSR is immediately below the integer frame base. Its slot is one FP
-// register wide, so this offset tracks both FLEN=32 and FLEN=64 frame layouts.
-#define LTK_ARCH_RISC_V_FCSR_FRAME_OFFSET (-LTK_ARCH_RISC_V_FP_REG_SIZE)
+// FP context is stacked above the integer context in the same frame, so the
+// saved stack pointer is the thread's true low-water mark. Slots hold f0-f31,
+// FCSR, and one pad keeping the frame size 8-byte aligned.
+#define LTK_ARCH_RISC_V_FP_FRAME_SIZE      (34 * LTK_ARCH_RISC_V_FP_REG_SIZE)
+#define LTK_FP_FRAME(N)                    (LTK_ARCH_RISC_V_INT_SF_SIZE + (N) * LTK_ARCH_RISC_V_FP_REG_SIZE)
+#define LTK_ARCH_RISC_V_FRAME_FCSR         LTK_FP_FRAME(32)
+#define LTK_ARCH_RISC_V_SF_SIZE            (LTK_ARCH_RISC_V_INT_SF_SIZE + LTK_ARCH_RISC_V_FP_FRAME_SIZE)
+#else
+#define LTK_ARCH_RISC_V_SF_SIZE            LTK_ARCH_RISC_V_INT_SF_SIZE
 #endif // #if defined(__riscv_flen)
+
+// Stack frame adjustment for context switch (whole integer + FP frame)
+#define LTK_ARCH_RISC_V_STACK_PTR_ADJ      LTK_ARCH_RISC_V_SF_SIZE
 
 #endif // #ifndef ROKU_LT_SOURCE_LT_LTK_LTKARCHRISC_V_VECTORS_H
 

--- a/lt/lt/source/lt/ltk/LTKernel.c
+++ b/lt/lt/source/lt/ltk/LTKernel.c
@@ -134,12 +134,16 @@ bool LTKThreadInitializeAndRun(void * pInstance, u8 nPriority, u32 nStackSize,
                                   const char * pName, void (* pThreadProc)(void * pClientData),
                                   void * pClientData) {
     bool bSuccess = false;
-    u8 * pStackBottom = LTKAllocStack(nStackSize);
+    u32 nAllocatedStackSize = nStackSize + LTK_ARCH_THREAD_STACK_RESERVE;
+    // Guard against u32 wraparound when the architecture reserve is added.
+    if (nAllocatedStackSize < nStackSize) return false;
+    u8 * pStackBottom = LTKAllocStack(nAllocatedStackSize);
     if (pStackBottom) {
         LTKThread * pThread = (LTKThread *)pInstance;
         pThread->pInstanceData = pThread;
         pThread->pName = pName;
-        if (InitAndRunThread(pThread, nPriority, pThreadProc, pClientData, pStackBottom, (LT_SIZE)nStackSize)) {
+        if (InitAndRunThread(pThread, nPriority, pThreadProc, pClientData, pStackBottom,
+                                (LT_SIZE)nAllocatedStackSize)) {
             bSuccess = true;
         } else {
             LTKFree(pStackBottom);

--- a/lt/lt/source/lt/ltk/LTKernel.h
+++ b/lt/lt/source/lt/ltk/LTKernel.h
@@ -85,6 +85,10 @@ typedef union {
   #error "LT_LTKERNEL_ARCHITECTURE must be defined in platform Makefile.config"
 #endif
 
+#ifndef LTK_ARCH_THREAD_STACK_RESERVE
+  #define LTK_ARCH_THREAD_STACK_RESERVE    0
+#endif
+
 /****************
  * Kernel Style *
  *  Style 1 - The scheduler is always invoked on interrupt return; unmaskable service calls are used

--- a/lt/lt/source/ltschell/wifi/LTSchellWiFi.c
+++ b/lt/lt/source/ltschell/wifi/LTSchellWiFi.c
@@ -256,13 +256,22 @@ static void /*LTDeviceWiFi_JoinCallback*/ SHL_JoinCallback(LTWiFi_JoinStatus sta
 static int SHL_Scan(LTSystemSchell *shell, int argc, const char *argv[]) {
     LTWiFi_ScanSpec spec = {};
     LTWiFi_ScanSpec *spec_ptr = NULL;
-    char target_ssid[256] = {0, };
-    u8 target_channels[16] = {0, };
+    // ScanAps copies the spec shallowly, so spec.ssid / spec.channel are still
+    // read on the WiFi state-machine thread after this frame returns and must
+    // not be stack buffers. Static is safe: the shell runs one scan at a time.
+    static char target_ssid[256];
+    static u8 target_channels[16];
     int pos = 0;
+    lt_memset(target_ssid, 0, sizeof(target_ssid));
+    lt_memset(target_channels, 0, sizeof(target_channels));
     SHL_ScanRepeat = 1;
     SHL_ScanProbes = false;
     if (HasArg(argc, argv, "-r")) SHL_ScanRepeat = 4;    // repeat a few times
     if (HasArg(argc, argv, "-p")) SHL_ScanProbes = true; // show probes
+    if (HasArg(argc, argv, "-P")) {  // passive: listen for beacons, send no probe request
+        spec.options |= kLTWiFi_ScanOption_Passive;
+        spec_ptr = &spec;
+    }
     if ((pos = HasArg(argc, argv, "-S")) && pos && pos + 1 < argc) { // target scan SSID
         lt_strncpyTerm(target_ssid, argv[pos + 1], 256);
         spec.ssid = target_ssid;
@@ -283,6 +292,13 @@ static int SHL_Scan(LTSystemSchell *shell, int argc, const char *argv[]) {
         } while(i < 15);
 
         spec.channel = target_channels;
+        spec_ptr = &spec;
+    }
+    if ((pos = HasArg(argc, argv, "-D")) && pos && pos + 1 < argc) { // per-channel dwell, ms
+        // The 2.4 GHz default dwell (40 ms) is well under a ~100 ms beacon
+        // interval, so use >=120 ms for beacon-only measurements. The driver
+        // floors 5 GHz dwell, so short dwells are not testable there.
+        spec.chan_dwell = (u8)(lt_strtos32(argv[pos + 1], NULL, 0) & 0xff);
         spec_ptr = &spec;
     }
     if ((pos = HasArg(argc, argv, "-R")) && pos && pos + 1 < argc) { // target scan, rssi
@@ -664,6 +680,8 @@ static const LTSystemShell_CommandDesc WiFi_Commands[] = {
                                             "\t\t-T target scan, scan -S <ssid>\n"
                                             "\t\t-C target scan, scan -C <1,2,3,...>\n"
                                             "\t\t-R target scan, scan -R <RSSI>\n"
+                                            "\t\t-P passive scan (beacons only, no probe request)\n"
+                                            "\t\t-D per-channel dwell ms, scan -D <40..255> (default 40)\n"
                                             "\t\t-r repeat scan\n"
                                             "\t\t-p show probes/beacons",            NULL },
     { "join",               SHL_Join,       "join <ssid> [<pass>] [bssid] [-r]\n"

--- a/lt/lt/source/unittest/lt/device/wifi/UnitTestLTDeviceWiFi.c
+++ b/lt/lt/source/unittest/lt/device/wifi/UnitTestLTDeviceWiFi.c
@@ -25,7 +25,7 @@
  ******************************************************************************/
 
 #include <lt/LT.h>
-#define TILT_LIBRARY_TIMEOUT 120
+#define TILT_LIBRARY_TIMEOUT 180
 /* JiltEngine (TILT 2.0) for direct ltrun support */
 #include <tilt/JiltEngine.h>
 /* Undef macros that Jilt.h and TiltImpl.h both define, so TiltImpl.h versions take effect */
@@ -214,7 +214,7 @@ static void HandleScanAps(LTWiFi_ApInfo *ap, void *clientData) {
 static void TestScanAps(const TiltImplReportingCallbacks *trc) {
     S.apCount = 0;
     S.wifiLib->ScanAps(NULL, HandleScanAps, (void*)trc);
-    trc->DeferCompletion(LTTime_Seconds(8), NULL, NULL);
+    trc->DeferCompletion(LTTime_Seconds(18), NULL, NULL);
 }
 
 static void TestFoundAp(const TiltImplReportingCallbacks *trc) {

--- a/lt/lt/source/unittest/lt/device/wifi/UnitTestLTDeviceWiFiMonitor.c
+++ b/lt/lt/source/unittest/lt/device/wifi/UnitTestLTDeviceWiFiMonitor.c
@@ -3,24 +3,33 @@
  * UnitTestLTDeviceWiFiMonitor
  * ---------------------------
  *
- * Monitor-mode smoke test.  Pure Jilt (TILT 2.0).
+ * Monitor-mode smoke test + directed-probe round trip.  Pure Jilt (TILT 2.0).
  *
- *   ltrun UnitTestLTDeviceWiFiMonitor [MON_CHANNEL=165] [MON_SECS=5]
+ *   ltrun UnitTestLTDeviceWiFiMonitor [MON_CHANNEL=165] [MON_SECS=5] \
+ *                                     [TARGET_BSSID=aa:bb:cc:dd:ee:ff] \
+ *                                     [TARGET_SSID=...] [PROBE_COUNT=3] \
+ *                                     [PROBE_WAIT_MS=500]
  *
- * Purpose: prove the BL61x monitor-mode RX path actually delivers raw 802.11
- * management frames (beacons / probe responses) to LTWiFi_MonitorRxCallback.
- * EnterMonitorMode is implemented but otherwise has zero callers, so this is
- * the gating check for the "directed probe + monitor RX"
- * find-host path (see hostlink-unified plan, "Host-roam gap").
+ * Purpose: prove the BL61x monitor-mode RX path delivers raw 802.11
+ * management frames and that management TX works while monitor RX is live.
+ * This independently validates a driver capability; the product find-host path
+ * currently uses scan plus raw Beacon/Probe Response delivery, not monitor mode.
  *
  * Procedure:
  *   1. Open LTDeviceWiFi, wait for Up, Disconnect (monitor is mutually
  *      exclusive with an STA connection).
- *   2. EnterMonitorMode(MON_CHANNEL).
- *   3. Listen MON_SECS; count frames by 802.11 type/subtype in the RX callback.
- *   4. Assert at least one frame arrived (beacons should be plentiful on a live
- *      channel); report beacon / probe-response / other counts.
- *   5. ExitMonitorMode.
+ *   2. EnterMonitorMode(MON_CHANNEL); time the request -> onStarted ->
+ *      first-RX transitions.  Baseline to beat: wl80211 needed ~9 s to first RX.
+ *   3. With monitor RX still live, TX PROBE_COUNT directed probe requests to
+ *      TARGET_BSSID and wait for a probe response from that BSSID; record the
+ *      TX -> response latency.  Skipped (not failed) when TARGET_BSSID is
+ *      unset, so the test still works as a plain RX smoke test.
+ *   4. ExitMonitorMode; assert monitor RX delivered frames and report every
+ *      measured number.
+ *
+ * A cloaked AP only answers a probe request whose SSID IE carries its exact
+ * SSID, so TARGET_SSID must be supplied to probe a hidden Roku GO.  With
+ * TARGET_SSID empty the probe goes out wildcard, which non-cloaked APs answer.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
  * If a copy of the MPL was not distributed with this file, you can obtain one at
@@ -31,11 +40,19 @@
  ******************************************************************************/
 
 #include <lt/LT.h>
+#include <lt/core/LTCountingSemaphore.h>
 #include <lt/device/wifi/LTDeviceWiFi.h>
 #include <tilt/JiltEngine.h>
 
-#define DEFAULT_MON_CHANNEL  165   /* 5 GHz: 2.4 GHz STA/PHY is broken on BL618D (plan Risk #9) */
+/* A paired Roku host operates on a 5 GHz non-DFS channel; 165 is UNII-3.
+ * 2.4 GHz works too and is much faster to park on (~13 ms vs ~185 ms). */
+#define DEFAULT_MON_CHANNEL  165
 #define DEFAULT_MON_SECS     5
+#define DEFAULT_PROBE_COUNT  3
+#define DEFAULT_PROBE_WAIT_MS 500
+
+/* 802.11 mgmt header (24 B) + SSID IE (2 + 32) + Supported Rates IE (2 + 8). */
+#define PROBE_REQ_MAX_LEN    68
 
 /** Module state *************************************************************/
 
@@ -45,8 +62,19 @@ static Tilt          *s_currentTilt;
 
 static bool           s_deviceIsUp;
 static bool           s_upDeferred;
+/* autojoin is a PERSISTED setting; saved on open, restored on teardown. */
+static u32            s_savedAutoJoin;
+static bool           s_haveSavedAutoJoin;
 static u8             s_monChannel;
 static u32            s_monSecs;
+
+/* Directed-probe target.  s_haveTarget is false when TARGET_BSSID was not
+ * supplied, which skips the probe round trip instead of failing it. */
+static bool           s_haveTarget;
+static u8             s_targetBssid[6];
+static char           s_targetSsid[33];
+static u32            s_probeCount;
+static u32            s_probeWaitMs;
 
 /* Touched from the (driver-thread) RX callback — keep volatile and do only
  * trivial counting there. */
@@ -56,12 +84,140 @@ static volatile u32   s_probeRespCount;
 static volatile u32   s_otherMgmtCount;
 static volatile bool  s_haveFirstBssid;
 static u8             s_firstBssid[6];
-static volatile bool  s_listenDeferred;
 
 /* Set from the driver-context onStarted completion callback: async
  * EnterMonitorMode result (the return value only means "request accepted"). */
 static volatile bool  s_monStarted;
 static volatile bool  s_monStartOk;
+
+/* Latency instrumentation.  All kernel-time (monotonic uptime) stamps; the ones
+ * written from the RX callback are volatile because the test thread reads them.
+ * LTTime is a struct, so a plain s64 of milliseconds is used to keep the
+ * cross-thread stores single-word. */
+static s64            s_tMonRequestMs;      /* EnterMonitorMode called */
+static volatile s64   s_tMonStartedMs;      /* onStarted fired */
+static volatile s64   s_tFirstRxMs;         /* first monitor frame delivered */
+static s64            s_tProbeTxMs;         /* last directed probe handed to the driver */
+static volatile s64   s_tProbeRspMs;        /* probe response from s_targetBssid */
+static volatile u32   s_probeRspFromTarget; /* matching probe responses seen */
+static volatile u32   s_probeRspFreq;       /* monitor_rx_freq of the match (MHz) */
+static int            s_probeTxRc[8];       /* TxMgmtFrame return per attempt */
+static u32            s_probeTxSent;
+
+/* Whole-suite budget.  MON_SECS sniff windows routinely exceed the engine
+ * default of 30 s, which aborts the run before it can report. */
+#define TILT_LIBRARY_TIMEOUT 240
+
+/* Frame capture: with CAPTURE_SA set, the first management frame of subtype
+ * CAPTURE_SUBTYPE sent BY that address (addr2) is copied and hex-dumped at the
+ * end of the run.  Intended for using one board as a sniffer while another
+ * associates, to see what a station actually puts on the air -- e.g. whether an
+ * association request (subtype 0) carries an expected vendor IE. */
+static bool           s_haveCaptureSa;
+static u8             s_captureSa[6];
+static u8             s_captureSubtype;
+static volatile bool  s_haveCaptured;
+static volatile u32   s_captureCount;   /* matches seen; the LAST is kept */
+static u16            s_capturedLen;
+static u8             s_capturedFrame[256];
+
+/* SSID of the first beacon seen, so a run tells you what is actually on the
+ * channel — which is how you pick TARGET_BSSID/TARGET_SSID for the probe. */
+static volatile bool  s_haveBeaconSsid;
+static char           s_beaconSsid[33];
+static u8             s_beaconBssid[6];
+
+/* One semaphore per wake condition: the test thread blocks on exactly the event
+ * it cares about, so a beacon cannot satisfy a wait for a probe response.
+ *
+ * LTCountingSemaphore rather than JiltEngine's DeferTestCompletion because a
+ * Jilt deferral that times out terminates the whole run and skips the remaining
+ * tests — but "no frame" and "no probe response" are results this test exists to
+ * MEASURE and report.  Wait() simply returns false on expiry.  Signal() is
+ * ISR-safe (a naked monitor Notify), so it is valid and cheap from the fhost RX
+ * callback and the driver's onStarted context. */
+static LTCountingSemaphore *s_semMonStarted;
+static LTCountingSemaphore *s_semFirstRx;
+static LTCountingSemaphore *s_semProbeRsp;
+static LTCountingSemaphore *s_semCapture;
+
+static s64 NowMs(void) {
+    return LTTime_GetMilliseconds(LT_GetCore()->GetKernelTime());
+}
+
+/* Discard any count left by a previous run.  Statics — including these
+ * semaphores — survive between ltrun invocations, and a stale count would make
+ * the next Wait() return true instantly without the event ever happening.
+ * maxCount is 1, so this loops at most once. */
+static void DrainSem(LTCountingSemaphore *sem) {
+    while (sem->API->TryWait(sem)) { }
+}
+
+static bool WaitSem(LTCountingSemaphore *sem, u32 timeoutMs) {
+    return sem->API->Wait(sem, LTTime_Milliseconds(timeoutMs));
+}
+
+/** Helpers ******************************************************************/
+
+/* Parse "aa:bb:cc:dd:ee:ff", "aa-bb-...", or "aabbccddeeff" into 6 octets. */
+static bool ParseMac(const char *s, u8 out[6]) {
+    u32 nibbles = 0;
+    u8  acc = 0;
+    if (!s) return false;
+    for (; *s; s++) {
+        char c = *s;
+        u8 v;
+        if (c == ':' || c == '-') continue;
+        if      (c >= '0' && c <= '9') v = (u8)(c - '0');
+        else if (c >= 'a' && c <= 'f') v = (u8)(c - 'a' + 10);
+        else if (c >= 'A' && c <= 'F') v = (u8)(c - 'A' + 10);
+        else return false;
+        acc = (u8)((acc << 4) | v);
+        if (++nibbles > 12) return false;
+        if ((nibbles & 1u) == 0u) {
+            out[(nibbles / 2u) - 1u] = acc;
+            acc = 0;
+        }
+    }
+    return nibbles == 12;
+}
+
+/* Build a directed probe request. A cloaked AP requires both its destination
+ * address and exact SSID to return a probe response.
+ * Returns the frame length, or 0 if it would not fit. */
+static u16 BuildProbeRequest(u8 *out, u16 cap, const u8 dst[6], const u8 src[6],
+                             const char *ssid, u8 channel) {
+    /* 5 GHz has no CCK, so advertise OFDM rates only there; on 2.4 GHz lead
+     * with the CCK basic rates (high bit = "basic rate"). */
+    static const u8 kRatesOfdm[] = { 0x0C, 0x12, 0x18, 0x24, 0x30, 0x48, 0x60, 0x6C };
+    static const u8 kRatesCck[]  = { 0x82, 0x84, 0x8B, 0x96, 0x24, 0x30, 0x48, 0x6C };
+
+    u32 ssidLen = ssid ? (u32)lt_strlen(ssid) : 0u;
+    if (ssidLen > 32u) ssidLen = 32u;
+
+    u16 need = (u16)(24u + 2u + ssidLen + 2u + sizeof(kRatesOfdm));
+    if (cap < need) return 0;
+
+    u8 *p = out;
+    *p++ = 0x40;                 /* frame control: mgmt (type 0), probe req (subtype 4) */
+    *p++ = 0x00;
+    *p++ = 0x00; *p++ = 0x00;    /* duration */
+    lt_memcpy(p, dst, 6); p += 6;   /* addr1: destination */
+    lt_memcpy(p, src, 6); p += 6;   /* addr2: source (our MAC) */
+    lt_memcpy(p, dst, 6); p += 6;   /* addr3: BSSID */
+    *p++ = 0x00; *p++ = 0x00;    /* sequence control (the MAC fills this in) */
+
+    *p++ = 0x00;                 /* IE 0: SSID (zero length = wildcard) */
+    *p++ = (u8)ssidLen;
+    if (ssidLen) { lt_memcpy(p, ssid, ssidLen); p += ssidLen; }
+
+    *p++ = 0x01;                 /* IE 1: Supported Rates */
+    *p++ = (u8)sizeof(kRatesOfdm);
+    lt_memcpy(p, (channel >= 36u) ? kRatesOfdm : kRatesCck, sizeof(kRatesOfdm));
+    p += sizeof(kRatesOfdm);
+
+    return (u16)(p - out);
+}
 
 /** Callbacks ****************************************************************/
 
@@ -80,8 +236,10 @@ static void OnWiFiStatus(LTDeviceWiFi_Status status, LTDeviceUnit unit, void *cl
 /* Async EnterMonitorMode completion.  Driver context: stage flags only. */
 static void OnMonitorStarted(bool ok, void *ctx) {
     LT_UNUSED(ctx);
+    s_tMonStartedMs = NowMs();
     s_monStartOk = ok;
     s_monStarted = true;
+    s_semMonStarted->API->Signal(s_semMonStarted);
 }
 
 
@@ -95,11 +253,11 @@ static void OnMonitorRx(void const *frame, u16 len, s8 rssi, void *ctx) {
     const u8 *f = (const u8 *)frame;
     if (!f || len < 1) return;
 
-    s_frameCount++;
-    if (s_listenDeferred) {
-        s_listenDeferred = false;
-        s_engine->API->SignalTestCompletion(s_engine, NULL);
+    if (s_frameCount == 0) {
+        s_tFirstRxMs = NowMs();
+        s_semFirstRx->API->Signal(s_semFirstRx);
     }
+    s_frameCount++;
 
     u8 fc      = f[0];
     u8 type    = (u8)((fc >> 2) & 0x3);
@@ -110,11 +268,116 @@ static void OnMonitorRx(void const *frame, u16 len, s8 rssi, void *ctx) {
         else if (subtype == 5) s_probeRespCount++;
         else                   s_otherMgmtCount++;
 
+        /* Capture-by-source. addr2 (transmitter) is at offset 10. Copy only —
+         * the hex dump happens on the owner thread in TestVerifyFrames. */
+        /* Keep the LAST match, not the first: a station's first association
+         * attempt often differs from later ones (e.g. an IE installed only after
+         * the supplicant interface exists), and the newest attempt is the
+         * interesting one. The sniff window therefore always runs to MON_SECS. */
+        if (s_haveCaptureSa && subtype == s_captureSubtype &&
+            len >= 24 && lt_memcmp(&f[10], s_captureSa, 6) == 0) {
+            u16 n = (len > sizeof(s_capturedFrame)) ? (u16)sizeof(s_capturedFrame) : len;
+            lt_memcpy(s_capturedFrame, f, n);
+            s_capturedLen  = n;
+            s_captureCount++;
+            s_haveCaptured = true;
+        }
+
         if (!s_haveFirstBssid && len >= 22) {
             lt_memcpy(s_firstBssid, &f[16], 6);
             s_haveFirstBssid = true;
         }
+
+        /* Capture the SSID of a beacon or probe response.  Both carry a 12-byte
+         * fixed body after the 24-byte header (timestamp 8 + interval/status 2 +
+         * capability 2), so the IE list starts at 36 and the SSID IE (id 0) is
+         * first.  A cloaked AP beacons a zero-length SSID — an empty result here
+         * is itself the signal that TARGET_SSID must come from elsewhere. */
+        if (!s_haveBeaconSsid && (subtype == 8 || subtype == 5) && len >= 38) {
+            u8 ieId  = f[36];
+            u8 ieLen = f[37];
+            if (ieId == 0 && ieLen <= 32 && (u16)(38 + ieLen) <= len) {
+                lt_memcpy(s_beaconSsid, &f[38], ieLen);
+                s_beaconSsid[ieLen] = '\0';
+                lt_memcpy(s_beaconBssid, &f[16], 6);
+                s_haveBeaconSsid = true;
+            }
+        }
+
+        /* The measurement that matters: a probe RESPONSE whose BSSID (addr3) is
+         * the station we just directed a probe request at. */
+        if (subtype == 5 && s_haveTarget && len >= 22 &&
+            lt_memcmp(&f[16], s_targetBssid, 6) == 0) {
+            s_probeRspFromTarget++;
+            if (s_probeRspFromTarget == 1) {
+                s_tProbeRspMs = NowMs();
+                /* Read inside the callback: the driver latches the frame's own
+                 * primary-channel frequency, and it is only unambiguous here. */
+                s_probeRspFreq = s_pWiFi->GetOption("monitor_rx_freq");
+                /* Publish everything before the signal: the waiter validates
+                 * the counter as soon as it wakes. */
+                s_semProbeRsp->API->Signal(s_semProbeRsp);
+            }
+        }
     }
+}
+
+/* Hex-dump the captured frame and, for frame types whose IE list position is
+ * known, enumerate its information elements.  Vendor-specific elements (id 221)
+ * are called out with their OUI, which is the point of the exercise: it shows
+ * whether a station put an expected vendor IE on the air. */
+static void DumpCapturedFrame(Tilt *tilt) {
+    const u8 *f = s_capturedFrame;
+    u16 len = s_capturedLen;
+    u8 subtype = (u8)((f[0] >> 4) & 0xf);
+
+    TILT_INFO(tilt, "captured mgmt subtype %u (match %lu of the run), %u bytes, from "
+                    "%02X:%02X:%02X:%02X:%02X:%02X",
+              (unsigned)subtype, LT_Pu32(s_captureCount), (unsigned)len,
+              f[10], f[11], f[12], f[13], f[14], f[15]);
+
+    char line[3 * 16 + 1];
+    for (u16 off = 0; off < len; off += 16) {
+        u16 n = ((u16)(len - off) < 16u) ? (u16)(len - off) : 16u;
+        u32 pos = 0;
+        for (u16 i = 0; i < n; i++) {
+            pos += (u32)lt_snprintf(line + pos, sizeof(line) - pos, "%02X ", f[off + i]);
+        }
+        TILT_INFO(tilt, "  %04X: %s", (unsigned)off, line);
+    }
+
+    /* IE list offset past the 24-byte header: assoc request (0) has capability +
+     * listen interval; reassoc request (2) adds the current AP address; probe
+     * request (4) has no fixed body. */
+    u16 ieOff;
+    if      (subtype == 0) ieOff = 24 + 4;
+    else if (subtype == 2) ieOff = 24 + 10;
+    else if (subtype == 4) ieOff = 24;
+    else {
+        TILT_INFO(tilt, "  (no IE walk for subtype %u)", (unsigned)subtype);
+        return;
+    }
+
+    bool sawVendor = false;
+    while ((u16)(ieOff + 2) <= len) {
+        u8 id     = f[ieOff];
+        u8 ieLen  = f[ieOff + 1];
+        if ((u16)(ieOff + 2 + ieLen) > len) {
+            TILT_INFO(tilt, "  IE %u truncated (len %u, %u bytes left)",
+                      (unsigned)id, (unsigned)ieLen, (unsigned)(len - ieOff - 2));
+            break;
+        }
+        if (id == 221 && ieLen >= 3) {
+            sawVendor = true;
+            TILT_INFO(tilt, "  IE 221 vendor len %u OUI %02X:%02X:%02X",
+                      (unsigned)ieLen, f[ieOff + 2], f[ieOff + 3], f[ieOff + 4]);
+        } else {
+            TILT_INFO(tilt, "  IE %u len %u", (unsigned)id, (unsigned)ieLen);
+        }
+        ieOff = (u16)(ieOff + 2 + ieLen);
+    }
+    if (!sawVendor)
+        TILT_INFO(tilt, "  NO vendor-specific (221) element present");
 }
 
 /** Tests ********************************************************************/
@@ -124,10 +387,20 @@ static void TestOpenDevice(Tilt *tilt) {
     s_pWiFi = lt_openlibrary(LTDeviceWiFi);
     TILT_ASSERT_TRUE(tilt, s_pWiFi != NULL, "cannot open LTDeviceWiFi");
     if (!s_pWiFi) return;
-    /* Monitor mode is mutually exclusive with an STA connection. */
+    /* Register before touching the device: opening the library starts the WiFi
+     * state machine, so an Up status can land during the calls below and would
+     * be missed if registration came last (leaving TestWiFiUp to time out). */
+    s_pWiFi->OnStatusChange(OnWiFiStatus, NULL, NULL);
+    /* Monitor mode is mutually exclusive with an STA connection.
+     *
+     * SetOption("autojoin") PERSISTS to LT settings, so leaving it at 0 would
+     * silently stop the device reconnecting long after this test finished --
+     * save it here and restore it in AfterAllTests (the pattern
+     * UnitTestLTDeviceWiFi already follows). */
+    s_savedAutoJoin = s_pWiFi->GetOption("autojoin");
+    s_haveSavedAutoJoin = true;
     s_pWiFi->SetOption("autojoin", 0);
     s_pWiFi->Disconnect();
-    s_pWiFi->OnStatusChange(OnWiFiStatus, NULL, NULL);
 }
 
 static void TestWiFiUp(Tilt *tilt) {
@@ -146,8 +419,17 @@ static void TestEnterMonitor(Tilt *tilt) {
 
     s_frameCount = s_beaconCount = s_probeRespCount = s_otherMgmtCount = 0;
     s_haveFirstBssid = false;
+    /* Must be reset per run: statics persist between ltrun invocations, so a
+     * leftover capture from a previous run on a DIFFERENT channel would be
+     * reported as this channel's AP. */
+    s_haveBeaconSsid = false;
+    s_beaconSsid[0] = '\0';
     s_monStarted = false;
     s_monStartOk = false;
+    s_tMonStartedMs = 0;
+    s_tFirstRxMs = 0;
+    DrainSem(s_semMonStarted);
+    DrainSem(s_semFirstRx);
 
     LTWiFi_MonitorConfig cfg;
     lt_memset(&cfg, 0, sizeof(cfg));
@@ -160,13 +442,106 @@ static void TestEnterMonitor(Tilt *tilt) {
     /* Async: true only means the request was accepted; the actual start
      * result arrives via onStarted (asserted in TestVerifyFrames, after the
      * listen window has long absorbed the driver-side confirm wait). */
+    s_tMonRequestMs = NowMs();
     bool ok = s_pWiFi->EnterMonitorMode(&cfg);
     TILT_ASSERT_TRUE(tilt, ok, "EnterMonitorMode request accepted");
     if (!ok) return;
 
-    TILT_INFO(tilt, "Monitoring ch %u for %lu s...", (unsigned)s_monChannel, LT_Pu32(s_monSecs));
-    s_listenDeferred = true;
-    s_engine->API->DeferTestCompletion(s_engine, LTTime_Seconds(s_monSecs), NULL, NULL);
+    TILT_INFO(tilt, "Monitoring ch %u for up to %lu s...", (unsigned)s_monChannel,
+              LT_Pu32(s_monSecs));
+    /* Wakes on the first frame, which makes this window a measurement of
+     * monitor-start -> first-RX rather than a fixed dwell.  A timeout is NOT a
+     * failure here: TestVerifyFrames reports it. */
+    (void)WaitSem(s_semFirstRx, s_monSecs * 1000u);
+
+    /* Then wait for the start completion itself.  The vendor begins delivering
+     * RX before wifi_mgmr_sniffer_enable returns, so first-RX genuinely precedes
+     * onStarted (measured: 191 ms vs 192 ms).  Returning on the frame alone
+     * leaves TestProbeRoundTrip's s_monStartOk check racing that ~1 ms gap and
+     * skipping the probe experiment when it loses. */
+    (void)WaitSem(s_semMonStarted, 2000u);
+
+    /* Sniffer mode: the waits above return on the first frame of any kind (a
+     * beacon, within ~200 ms), which is far too early to catch a specific frame
+     * from another station.  Keep listening for the full MON_SECS, or until the
+     * frame we were asked to capture arrives. */
+    if (s_haveCaptureSa) {
+        TILT_INFO(tilt, "sniffing for mgmt subtype %u from "
+                        "%02X:%02X:%02X:%02X:%02X:%02X (up to %lu s)...",
+                  (unsigned)s_captureSubtype,
+                  s_captureSa[0], s_captureSa[1], s_captureSa[2],
+                  s_captureSa[3], s_captureSa[4], s_captureSa[5],
+                  LT_Pu32(s_monSecs));
+        (void)WaitSem(s_semCapture, s_monSecs * 1000u);   /* never signalled: full dwell */
+    }
+}
+
+/* Validate that management TX works while monitor RX is live. The current
+ * product discovery path does not depend on this capability. */
+static void TestProbeRoundTrip(Tilt *tilt) {
+    s_currentTilt = tilt;
+
+    if (!s_haveTarget) {
+        TILT_INFO(tilt, "TARGET_BSSID not set - skipping directed-probe round trip");
+        return;
+    }
+    TILT_ASSERT_TRUE(tilt, s_monStartOk, "monitor must be started to probe from it");
+    if (!s_monStartOk) return;
+
+    LTMacAddress mac;
+    lt_memset(&mac, 0, sizeof(mac));
+    TILT_ASSERT_TRUE(tilt, s_pWiFi->GetMacAddress(&mac), "GetMacAddress");
+    u8 frame[PROBE_REQ_MAX_LEN];
+    u16 len = BuildProbeRequest(frame, (u16)sizeof(frame), s_targetBssid,
+                                mac.octet, s_targetSsid, s_monChannel);
+    TILT_ASSERT_TRUE(tilt, len > 0, "probe request built");
+    if (len == 0) return;
+
+    s_probeRspFromTarget = 0;
+    s_probeRspFreq       = 0;
+    s_tProbeRspMs        = 0;
+    s_probeTxSent        = 0;
+    /* Drain before the TX below, so an unsolicited probe response to the target
+     * that arrived during the listen window cannot be mistaken for a reply to
+     * our probe. */
+    DrainSem(s_semProbeRsp);
+
+    u32 attempts = s_probeCount;
+    if (attempts > (u32)(sizeof(s_probeTxRc) / sizeof(s_probeTxRc[0]))) {
+        attempts = (u32)(sizeof(s_probeTxRc) / sizeof(s_probeTxRc[0]));
+    }
+
+    TILT_INFO(tilt, "TX %lu directed probe(s) -> %02X:%02X:%02X:%02X:%02X:%02X ssid=\"%s\" (%u B)",
+              LT_Pu32(attempts),
+              s_targetBssid[0], s_targetBssid[1], s_targetBssid[2],
+              s_targetBssid[3], s_targetBssid[4], s_targetBssid[5],
+              s_targetSsid, (unsigned)len);
+    /* The valid calls name the channel on which monitor mode parked the radio. */
+    u8 wrongChannel = (s_monChannel == 1u) ? 6u : 1u;
+    int wrongChannelRc = s_pWiFi->TxMgmtFrame(frame, len, wrongChannel);
+    TILT_ASSERT_TRUE(tilt, wrongChannelRc < 0,
+                     "TxMgmtFrame rejects a channel other than the parked channel");
+
+    s_tProbeTxMs = NowMs();
+    for (u32 i = 0; i < attempts; i++) {
+        s_probeTxRc[i] = s_pWiFi->TxMgmtFrame(frame, len, s_monChannel);
+        s_probeTxSent++;
+    }
+
+    bool anyAccepted = false;
+    for (u32 i = 0; i < s_probeTxSent; i++) {
+        if (s_probeTxRc[i] == 0) anyAccepted = true;
+        else TILT_INFO(tilt, "probe %lu rejected rc=%d", LT_Pu32(i), s_probeTxRc[i]);
+    }
+    /* A refusal here is the finding to escalate to Bouffalo: it would mean fhost
+     * declines mgmt TX while the sniffer holds the radio, exactly as wl80211
+     * did. */
+    TILT_ASSERT_TRUE(tilt, anyAccepted, "TxMgmtFrame accepted while monitor RX live");
+    if (!anyAccepted) return;
+
+    /* No response within the window is a RESULT, not a harness failure — it is
+     * reported by TestVerifyFrames alongside the TX outcome. */
+    (void)WaitSem(s_semProbeRsp, s_probeWaitMs);
 }
 
 static void TestVerifyFrames(Tilt *tilt) {
@@ -184,17 +559,80 @@ static void TestVerifyFrames(Tilt *tilt) {
                   s_firstBssid[0], s_firstBssid[1], s_firstBssid[2],
                   s_firstBssid[3], s_firstBssid[4], s_firstBssid[5]);
     }
+    if (s_haveBeaconSsid) {
+        /* FIRST AP seen this run, not necessarily the probe target -- name it
+         * that way so its cloaked/not verdict is never read as the target's.
+         * Feed the pair back in as TARGET_BSSID / TARGET_SSID to probe it. */
+        TILT_INFO(tilt, "first AP on ch %u: %02X:%02X:%02X:%02X:%02X:%02X ssid=\"%s\"%s",
+                  (unsigned)s_monChannel,
+                  s_beaconBssid[0], s_beaconBssid[1], s_beaconBssid[2],
+                  s_beaconBssid[3], s_beaconBssid[4], s_beaconBssid[5],
+                  s_beaconSsid, s_beaconSsid[0] ? "" : " (cloaked)");
+    }
+
+    /* Baselines these numbers exist to beat, measured on the wl80211 driver
+     * against a cloaked Roku GO on ch 165: monitor start -> first RX ~9 s, and a
+     * directed probe -> response round trip that was not possible at all, since
+     * frame injection was rejected while monitor mode held the radio. */
+    if (s_tMonStartedMs) {
+        TILT_INFO(tilt, "T monitor request -> onStarted: %lu ms",
+                  LT_Pu32((u32)(s_tMonStartedMs - s_tMonRequestMs)));
+    }
+    if (s_tFirstRxMs) {
+        TILT_INFO(tilt, "T monitor request -> first RX:  %lu ms",
+                  LT_Pu32((u32)(s_tFirstRxMs - s_tMonRequestMs)));
+    } else {
+        TILT_INFO(tilt, "T monitor request -> first RX:  no frame within %lu s",
+                  LT_Pu32(s_monSecs));
+    }
+
+    if (s_haveTarget) {
+        if (s_probeRspFromTarget > 0) {
+            TILT_INFO(tilt, "T probe TX -> probe RSP: %lu ms (%lu responses, freq %lu MHz)",
+                      LT_Pu32((u32)(s_tProbeRspMs - s_tProbeTxMs)),
+                      LT_Pu32(s_probeRspFromTarget), LT_Pu32(s_probeRspFreq));
+        } else {
+            /* Distinguish the two negatives: the driver logs txmgmt.cfm with an
+             * acked flag per frame, so "TX accepted + acked=0 + no response"
+             * means the target never heard us (wrong channel / out of range /
+             * cloaked and probed with a wildcard SSID), whereas "TX rejected"
+             * would be the vendor refusing to transmit while monitoring. */
+            TILT_INFO(tilt, "T probe TX -> probe RSP: none within %lu ms (%lu TX'd; see txmgmt.cfm acked=)",
+                      LT_Pu32(s_probeWaitMs), LT_Pu32(s_probeTxSent));
+        }
+    }
+
+    if (s_haveCaptureSa) {
+        if (s_haveCaptured) DumpCapturedFrame(tilt);
+        else TILT_INFO(tilt, "no mgmt subtype %u seen from the capture address",
+                       (unsigned)s_captureSubtype);
+    }
 
     /* The gating assertion: the monitor RX path must deliver frames at all.
      * A live channel beacons constantly, so zero frames means the RX bridge
      * is not wired / monitor mode is non-functional on this silicon. */
     TILT_ASSERT_TRUE(tilt, s_frameCount > 0, "monitor RX delivered at least one frame");
     TILT_INFO(tilt, "beacons observed: %lu", LT_Pu32(s_beaconCount));
+
+    /* Reported separately from the TX-accepted assertion above so a failure
+     * distinguishes "TX refused" from "TX went out, target silent". */
+    if (s_haveTarget) {
+        TILT_ASSERT_TRUE(tilt, s_probeRspFromTarget > 0,
+                         "probe response received from target on monitor RX");
+    }
 }
 
 /** Hooks ********************************************************************/
 
 static void BeforeAllTests(Tilt *tilt) {
+    /* File-scope state survives between ltrun invocations in one boot (statics
+     * are initialized at image load, not per run), and AfterAllTests brings the
+     * device back down.  Without this reset a second run in the same boot sees
+     * a stale "already up" and drives monitor mode into a still-initializing
+     * driver ("monitor requested before driver up"). */
+    s_deviceIsUp = false;
+    s_upDeferred = false;
+
     const char *chStr = tilt->API->GetProperty("MON_CHANNEL", "");
     u32 ch = (chStr && chStr[0]) ? lt_strtou32(chStr, NULL, 10) : 0;
     s_monChannel = (ch > 0 && ch < 256) ? (u8)ch : DEFAULT_MON_CHANNEL;
@@ -202,12 +640,50 @@ static void BeforeAllTests(Tilt *tilt) {
     const char *sStr = tilt->API->GetProperty("MON_SECS", "");
     u32 secs = (sStr && sStr[0]) ? lt_strtou32(sStr, NULL, 10) : 0;
     s_monSecs = (secs > 0) ? secs : DEFAULT_MON_SECS;
+
+    const char *bssidStr = tilt->API->GetProperty("TARGET_BSSID", "");
+    s_haveTarget = (bssidStr && bssidStr[0]) ? ParseMac(bssidStr, s_targetBssid) : false;
+    if (bssidStr && bssidStr[0] && !s_haveTarget) {
+        TILT_INFO(tilt, "TARGET_BSSID \"%s\" is not a MAC address - probe test disabled",
+                  bssidStr);
+    }
+
+    lt_strncpyTerm(s_targetSsid, tilt->API->GetProperty("TARGET_SSID", ""),
+                   sizeof(s_targetSsid));
+
+    const char *cStr = tilt->API->GetProperty("PROBE_COUNT", "");
+    u32 cnt = (cStr && cStr[0]) ? lt_strtou32(cStr, NULL, 10) : 0;
+    s_probeCount = (cnt > 0) ? cnt : DEFAULT_PROBE_COUNT;
+
+    const char *wStr = tilt->API->GetProperty("PROBE_WAIT_MS", "");
+    u32 wait = (wStr && wStr[0]) ? lt_strtou32(wStr, NULL, 10) : 0;
+    s_probeWaitMs = (wait > 0) ? wait : DEFAULT_PROBE_WAIT_MS;
+
+    /* Sniffer mode: capture one mgmt frame of CAPTURE_SUBTYPE sent by CAPTURE_SA.
+     * Default subtype 0 = association request. */
+    const char *capStr = tilt->API->GetProperty("CAPTURE_SA", "");
+    s_haveCaptureSa = (capStr && capStr[0]) ? ParseMac(capStr, s_captureSa) : false;
+    if (capStr && capStr[0] && !s_haveCaptureSa)
+        TILT_INFO(tilt, "CAPTURE_SA \"%s\" is not a MAC address - capture disabled", capStr);
+    const char *cstStr = tilt->API->GetProperty("CAPTURE_SUBTYPE", "");
+    s_captureSubtype = (cstStr && cstStr[0]) ? (u8)lt_strtou32(cstStr, NULL, 10) : 0;
+    s_haveCaptured = false;
+    s_capturedLen  = 0;
+    s_captureCount = 0;
+    DrainSem(s_semCapture);
 }
 
 static void AfterAllTests(Tilt *tilt) {
     LT_UNUSED(tilt);
     if (s_pWiFi) {
         s_pWiFi->ExitMonitorMode();
+        /* Put the persisted autojoin setting back before closing, or the device
+         * stops reconnecting for every boot after this test ran. */
+        if (s_haveSavedAutoJoin) {
+            s_pWiFi->SetOption("autojoin", (s32)s_savedAutoJoin);
+            s_haveSavedAutoJoin = false;
+            TILT_INFO(tilt, "autojoin restored to %lu", LT_Pu32(s_savedAutoJoin));
+        }
         s_pWiFi->NoStatusChange(OnWiFiStatus);
         lt_closelibrary(s_pWiFi);
         s_pWiFi = NULL;
@@ -222,27 +698,47 @@ static const TiltEngineTestHooks s_hooks = {
 };
 
 static const TiltEngineTest s_tests[] = {
-    { TestOpenDevice,   "OpenDevice",   "open LTDeviceWiFi",                 0 },
-    { TestWiFiUp,       "WiFiUp",       "wait for radio Up",                 0 },
-    { TestEnterMonitor, "EnterMonitor", "enter monitor + listen",            0 },
-    { TestVerifyFrames, "VerifyFrames", "monitor RX delivered frames",       0 },
+    { TestOpenDevice,      "OpenDevice",      "open LTDeviceWiFi",                    0 },
+    { TestWiFiUp,          "WiFiUp",          "wait for radio Up",                    0 },
+    { TestEnterMonitor,    "EnterMonitor",    "enter monitor + listen",               0 },
+    { TestProbeRoundTrip,  "ProbeRoundTrip",  "directed probe TX while monitoring",   0 },
+    { TestVerifyFrames,    "VerifyFrames",    "monitor RX delivered frames",          0 },
 };
 
 /** Library entry point ******************************************************/
 
 static int UnitTestLTDeviceWiFiMonitorImpl_Run(int argc, const char **argv) {
+    s_engine->API->SetTestSuiteTimeout(s_engine, LTTime_Seconds(TILT_LIBRARY_TIMEOUT));
     s_engine->API->ConfigureTestSuite(s_engine, s_tests,
                                       sizeof(s_tests)/sizeof(s_tests[0]),
                                       &s_hooks);
     return s_engine->API->RunTestSuite(s_engine, argc, argv);
 }
 
+/* maxCount 1: these are binary "the event happened" signals, so repeated
+ * Signals (e.g. every matching probe response) must not accumulate a count that
+ * a later Wait would consume without the event recurring. */
+static LTCountingSemaphore *CreateSignalSem(void) {
+    LTCountingSemaphore *sem = lt_createobject(LTCountingSemaphore);
+    if (sem) sem->API->Init(sem, 1, 0);
+    return sem;
+}
+
 static bool UnitTestLTDeviceWiFiMonitorImpl_LibInit(void) {
-    s_engine = lt_createobject(JiltEngine);
-    return s_engine != NULL;
+    s_engine        = lt_createobject(JiltEngine);
+    s_semMonStarted = CreateSignalSem();
+    s_semFirstRx    = CreateSignalSem();
+    s_semProbeRsp   = CreateSignalSem();
+    s_semCapture    = CreateSignalSem();
+    return s_engine && s_semMonStarted && s_semFirstRx && s_semProbeRsp &&
+           s_semCapture;
 }
 
 static void UnitTestLTDeviceWiFiMonitorImpl_LibFini(void) {
+    lt_destroyobject(s_semCapture);
+    lt_destroyobject(s_semProbeRsp);
+    lt_destroyobject(s_semFirstRx);
+    lt_destroyobject(s_semMonStarted);
     lt_destroyobject(s_engine);
 }
 

--- a/lt/lt/source/unittest/lt/device/wifi/UnitTestLTDeviceWiFiWpsPbc.c
+++ b/lt/lt/source/unittest/lt/device/wifi/UnitTestLTDeviceWiFiWpsPbc.c
@@ -16,7 +16,8 @@
  *   1. Open LTDeviceWiFi, LTDeviceWiFiPairing and LTDeviceAuthentication.
  *   2. Wait for the device to come Up.
  *   3. Scan and select the Roku host AP (policy lives here in the test/app
- *      layer: SSID-prefix match, best RSSI).  Override the prefix with the
+ *      layer: SSID-prefix match, WSC IE reporting an active PBC walk, then
+ *      best RSSI among those).  Override the prefix with the
  *      HOST_SSID_PREFIX=<str> property.
  *   4. Build the Roku WPS M1 vendor IE and call LTDeviceWiFiPairing::
  *      StartPbc(timeout, m1Ie, assocIe, target) with the chosen AP.  The
@@ -43,6 +44,12 @@
 #include <tilt/JiltEngine.h>
 
 #define DEFAULT_PBC_TIMEOUT_SEC  120
+
+/* Whole-suite budget.  Must clear the PBC walk plus scan, reconnect and
+ * teardown; the engine default of 30 s aborts the run mid-walk. */
+#define TILT_LIBRARY_TIMEOUT     240
+/* Setup, scan, reconnect and teardown share the suite budget with the walk. */
+#define PBC_SUITE_MARGIN_SEC     60
 /* Roku hosts advertise their WiFi-Direct SSID as "DIRECT-roku-xxx-xxxxxx" in
  * pairing mode; match that prefix by default. */
 #define DEFAULT_HOST_SSID_PREFIX "DIRECT-roku-"
@@ -74,6 +81,9 @@ static LTCore                  *s_pCore;
 static LTDeviceWiFi            *s_pWiFi;
 static LTDeviceWiFiPairing     *s_pPairing;
 static LTDeviceAuthentication  *s_pAuth;
+/* autojoin is a PERSISTED setting; saved on open, restored on teardown. */
+static u32                      s_savedAutoJoin;
+static bool                     s_haveSavedAutoJoin;
 static JiltEngine              *s_engine;
 
 /** Module state *************************************************************/
@@ -97,6 +107,13 @@ static char          s_hostPrefix[MAX_SSID_PREFIX];
 static bool          s_hostFound;
 static LTWiFi_ApInfo s_hostAp;        ///< best matching Roku host AP
 static s8            s_hostBestRssi;
+
+/* BSSIDs seen advertising an ACTIVE PBC walk (see OnScanFrame).  Written from
+ * the driver's WiFi task as frames arrive, read from the scan-result callback
+ * after the scan has finished, so the two never overlap. */
+#define MAX_PBC_HOSTS 8
+static u8  s_pbcBssid[MAX_PBC_HOSTS][6];
+static u8  s_pbcCount;
 
 /** Callbacks ****************************************************************/
 
@@ -127,6 +144,84 @@ static void OnWiFiStatus(LTDeviceWiFi_Status status, LTDeviceUnit unit, void *cl
     }
 }
 
+/* Note the BSSID of a host whose WSC IE says a PBC walk is running now. */
+static void NotePbcHost(const u8 *bssid) {
+    for (u8 i = 0; i < s_pbcCount; i++)
+        if (lt_memcmp(s_pbcBssid[i], bssid, 6) == 0) return;
+    if (s_pbcCount < MAX_PBC_HOSTS)
+        lt_memcpy(s_pbcBssid[s_pbcCount++], bssid, 6);
+}
+
+static bool IsPbcHost(const u8 *bssid) {
+    for (u8 i = 0; i < s_pbcCount; i++)
+        if (lt_memcmp(s_pbcBssid[i], bssid, 6) == 0) return true;
+    return false;
+}
+
+/**
+ * Raw Beacon / Probe Response sink -- decide which hosts are ACTUALLY walking.
+ *
+ * The parsed LTWiFi_ApInfo::wps flag only says "this AP has a WSC IE", which
+ * every Roku host carries all the time.  With two hosts in range that leaves
+ * RSSI as the only discriminator, and a few dB of drift is enough to start
+ * pairing with a box nobody armed.  The distinguishing state is inside the WSC
+ * IE: an AP with a PBC walk running sets Selected Registrar = 1 and Device
+ * Password ID = PBC (0x0004), and clears them when the walk ends.  Reading it
+ * needs the frame body, which is exactly what the raw-frame scan sink exists
+ * for (BOUFFALO-80).
+ *
+ * Runs in the driver's WiFi task as the frame arrives: parse and return, no
+ * blocking work, and do not retain @p frame.
+ */
+static void OnScanFrame(void const *frame, u16 len, u16 freqMhz, s8 rssi, void *ctx) {
+    LT_UNUSED(freqMhz);
+    LT_UNUSED(rssi);
+    LT_UNUSED(ctx);
+    const u8 *f = (const u8 *)frame;
+
+    /* 802.11 mgmt header (24) + beacon/probe-resp fixed fields (12). */
+    if (!f || len < 36) return;
+    u8 subtype = (u8)((f[0] >> 4) & 0x0F);
+    if (subtype != 0x08 /* Beacon */ && subtype != 0x05 /* Probe Response */)
+        return;
+    const u8 *bssid = f + 16;           /* addr3 */
+
+    /* Walk the IE list.  The WSC attributes may be split across several
+     * vendor elements, so keep scanning after a match rather than stopping at
+     * the first WSC IE. */
+    bool selectedRegistrar = false;
+    bool pbcPasswordId     = false;
+    const u8 *p   = f + 36;
+    const u8 *end = f + len;
+    while (p + 2 <= end) {
+        u8 id = p[0], ieLen = p[1];
+        const u8 *body = p + 2;
+        if (body + ieLen > end) break;
+        /* Vendor specific, WFA WSC: OUI 00:50:F2 type 0x04. */
+        if (id == 0xDD && ieLen >= 4 &&
+            body[0] == 0x00 && body[1] == 0x50 && body[2] == 0xF2 && body[3] == 0x04) {
+            /* WSC attributes: 2-byte id, 2-byte length, both big endian. */
+            const u8 *a    = body + 4;
+            const u8 *aEnd = body + ieLen;
+            while (a + 4 <= aEnd) {
+                u16 attrId  = (u16)((a[0] << 8) | a[1]);
+                u16 attrLen = (u16)((a[2] << 8) | a[3]);
+                const u8 *val = a + 4;
+                if (val + attrLen > aEnd) break;
+                if (attrId == 0x1041 && attrLen == 1)          /* Selected Registrar */
+                    selectedRegistrar = (val[0] != 0);
+                else if (attrId == 0x1012 && attrLen == 2)     /* Device Password ID */
+                    pbcPasswordId = (((val[0] << 8) | val[1]) == 0x0004); /* PBC */
+                a = val + attrLen;
+            }
+        }
+        p = body + ieLen;
+    }
+
+    if (selectedRegistrar && pbcPasswordId)
+        NotePbcHost(bssid);
+}
+
 /* Scan result callback (policy layer): match the Roku host by SSID prefix and
  * keep the strongest-RSSI candidate.  A NULL ap marks end-of-scan. */
 static void OnScanResult(LTWiFi_ApInfo *ap, void *callback_data) {
@@ -139,6 +234,12 @@ static void OnScanResult(LTWiFi_ApInfo *ap, void *callback_data) {
 
     u32 prefixLen = (u32)lt_strlen(s_hostPrefix);
     if (prefixLen == 0 || lt_strncmp(ap->ssid, s_hostPrefix, prefixLen) != 0)
+        return;
+
+    /* Only hosts actively walking are candidates; RSSI merely breaks ties
+     * among them.  Without this, the nearer of two idle-but-WPS-capable Roku
+     * boxes wins and the walk times out against a box that was never armed. */
+    if (!IsPbcHost(ap->bssid.octet))
         return;
 
     if (!s_hostFound || ap->rssi > s_hostBestRssi) {
@@ -159,7 +260,11 @@ static void TestOpenDevice(Tilt *tilt) {
     TILT_ASSERT_TRUE(tilt, s_pAuth != NULL, "cannot open LTDeviceAuthentication");
     s_pPairing = lt_createobject(LTDeviceWiFiPairing);
     TILT_ASSERT_TRUE(tilt, s_pPairing != NULL, "cannot open LTDeviceWiFiPairing");
-    /* WPS drives association itself; disable autojoin to avoid races. */
+    /* WPS drives association itself; disable autojoin to avoid races.  autojoin
+     * is a PERSISTED setting, so save it and restore in AfterAllTests -- leaving
+     * it at 0 stops the device auto-reconnecting on every later boot. */
+    s_savedAutoJoin = s_pWiFi->GetOption("autojoin");
+    s_haveSavedAutoJoin = true;
     s_pWiFi->SetOption("autojoin", 0);
     s_pWiFi->Disconnect();
     s_pWiFi->OnStatusChange(OnWiFiStatus, NULL, NULL);
@@ -179,16 +284,22 @@ static void TestScanForHost(Tilt *tilt) {
     s_currentTilt  = tilt;
     s_hostFound    = false;
     s_hostBestRssi = -128;
+    s_pbcCount     = 0;
 
     TILT_INFO(tilt, "Scanning for Roku host AP (SSID prefix \"%s\")...", s_hostPrefix);
-    /* Default wildcard scan; OnScanResult applies the host-match policy and
-     * signals completion when it receives the end-of-scan (NULL) marker. */
-    s_pWiFi->ScanAps(NULL, OnScanResult, NULL);
+    /* Wildcard scan with the raw-frame sink attached: OnScanFrame records which
+     * hosts are actively walking, then OnScanResult applies the host-match
+     * policy and signals completion on the end-of-scan (NULL) marker. */
+    LTWiFi_ScanWithIE scan;
+    lt_memset(&scan, 0, sizeof(scan));
+    scan.frameCallback = OnScanFrame;
+    s_pWiFi->ScanWithVendorIE(&scan, OnScanResult, NULL);
     s_engine->API->DeferTestCompletion(s_engine, LTTime_Seconds(15), NULL, NULL);
 }
 
 static void TestHostFound(Tilt *tilt) {
     s_currentTilt = tilt;
+    TILT_INFO(tilt, "%u host(s) advertising an active PBC walk", (unsigned)s_pbcCount);
     TILT_ASSERT_TRUE(tilt, s_hostFound, "found a Roku host AP in PBC pairing mode");
     TILT_INFO(tilt, "Selected host \"%s\" bssid=%02X:%02X:%02X:%02X:%02X:%02X ch=%u rssi=%d",
               s_hostAp.ssid,
@@ -223,7 +334,7 @@ static void TestStartWps(Tilt *tilt) {
         return;
     }
 
-    TILT_INFO(tilt, "Starting WPS open-assoc to host \"%s\" (chip id 0x%08lX), timeout %lu s.",
+    TILT_INFO(tilt, "Starting WPS PBC (WPA2-PSK) to host \"%s\" (chip id 0x%08lX), timeout %lu s.",
               s_hostAp.ssid, LT_Pu32(chipId), LT_Pu32(s_pbcTimeoutSec));
     /* Targeted WPS: pass the scanned host AP.  The driver performs
      * an OPEN association to this BSSID carrying the WPS assoc IE + the Roku
@@ -243,9 +354,23 @@ static void TestStartWps(Tilt *tilt) {
      * a Connected event.
      */
     s_wpsCredsOk = false;
+    bool walkSeenActive = false;
     for (u32 elapsed = 0; elapsed < s_pbcTimeoutSec + 10; ++elapsed) {
         if (s_pPairing->API->GetCredentials(s_pPairing, &s_wpsCreds)) {
             s_wpsCredsOk = true;
+            break;
+        }
+        /* Stop once the walk is over: it ends on PBC overlap, on cancel and on
+         * the registrar's timeout, none of which produce a credential.  Only act
+         * on the transition after the walk has been seen running, since
+         * GetOption also returns 0 for an option a platform does not implement --
+         * that way the wait degrades to the plain timeout instead of exiting
+         * immediately. */
+        if (s_pWiFi->GetOption("wps_active")) {
+            walkSeenActive = true;
+        } else if (walkSeenActive) {
+            TILT_INFO(tilt, "WPS walk ended after %lus without a credential",
+                      LT_Pu32(elapsed));
             break;
         }
         s_pCore->GetCurrentThreadObject()->API->Sleep(LTTime_Seconds(1));
@@ -301,8 +426,24 @@ static void TestConnectWithCred(Tilt *tilt) {
      * retries with a settle delay; we do the same, waiting for Connected
      * between attempts.
      */
+    /* A Roku host admits an association only if it carries the Roku OUI IE --
+     * this holds for every association, not just the WPS enrolment, so the
+     * plain WPA2-PSK reconnect needs it too.  Without it the AP associates the
+     * STA and then never sends EAPOL-Key 1/4, and the join times out with the
+     * credential never being exercised.  StartWpsPbc()'s copy does not apply
+     * here: it feeds the driver's WPS assoc-IE buffer, while an ordinary join
+     * takes its extra IEs from the SetVendorIE() buffer. */
+    {
+        LTWiFi_VendorIE ie;
+        ie.data   = s_rokuAssocIe;
+        ie.length = (u16)sizeof(s_rokuAssocIe);
+        TILT_ASSERT_TRUE(tilt, s_pWiFi->SetVendorIE(&ie),
+                         "install the Roku assoc IE for the reconnect");
+    }
+
     const int kMaxAttempts = 5;
     s_connected = false;
+
     for (int attempt = 1; attempt <= kMaxAttempts && !s_connected; ++attempt) {
         TILT_INFO(tilt, "Reconnect attempt %d/%d to \"%s\" (WPA2-PSK)...",
                   attempt, kMaxAttempts, s_connectAp.ssid);
@@ -360,6 +501,14 @@ static void BeforeAllTests(Tilt *tilt) {
     const char *tStr = tilt->API->GetProperty("PBC_TIMEOUT_SEC", "");
     u32 t = (tStr && tStr[0]) ? lt_strtou32(tStr, NULL, 10) : 0;
     s_pbcTimeoutSec = (t > 0) ? t : DEFAULT_PBC_TIMEOUT_SEC;
+    /* A walk that cannot fit in the hard suite budget makes the harness abort
+     * with no test result at all -- clamp it to the usable window instead. */
+    if (s_pbcTimeoutSec > TILT_LIBRARY_TIMEOUT - PBC_SUITE_MARGIN_SEC) {
+        TILT_INFO(tilt, "PBC_TIMEOUT_SEC %lu exceeds the suite budget; clamped to %u",
+                  LT_Pu32(s_pbcTimeoutSec),
+                  (unsigned)(TILT_LIBRARY_TIMEOUT - PBC_SUITE_MARGIN_SEC));
+        s_pbcTimeoutSec = TILT_LIBRARY_TIMEOUT - PBC_SUITE_MARGIN_SEC;
+    }
 
     const char *prefix = tilt->API->GetProperty("HOST_SSID_PREFIX", DEFAULT_HOST_SSID_PREFIX);
     lt_strncpyTerm(s_hostPrefix, (prefix && prefix[0]) ? prefix : DEFAULT_HOST_SSID_PREFIX,
@@ -375,6 +524,12 @@ static void AfterAllTests(Tilt *tilt) {
         s_pPairing = NULL;
     }
     if (s_pWiFi) {
+        /* Drop the Roku assoc IE so it does not ride on later joins. */
+        if (s_pWiFi->ClearVendorIE) s_pWiFi->ClearVendorIE();
+        if (s_haveSavedAutoJoin) {
+            s_pWiFi->SetOption("autojoin", (s32)s_savedAutoJoin);
+            s_haveSavedAutoJoin = false;
+        }
         s_pWiFi->NoStatusChange(OnWiFiStatus);
         s_pWiFi->Disconnect();
         lt_closelibrary(s_pWiFi);
@@ -408,6 +563,7 @@ static const TiltEngineTest s_tests[] = {
 /** Library entry point ******************************************************/
 
 static int UnitTestLTDeviceWiFiWpsPbcImpl_Run(int argc, const char **argv) {
+    s_engine->API->SetTestSuiteTimeout(s_engine, LTTime_Seconds(TILT_LIBRARY_TIMEOUT));
     s_engine->API->ConfigureTestSuite(s_engine, s_tests,
                                       sizeof(s_tests)/sizeof(s_tests[0]),
                                       &s_hooks);


### PR DESCRIPTION
File-level sync of core LT changes into the lt-sdk layout (lt/lt/).

Contents:
- WiFi device/driver API: GetChannelPlan (regulatory channel plan incl. DFS), raw scan frame callback during scans, ScanWithVendorIE now returns bool, WiFi stack migrated to fhost; expanded monitor-mode and WPS unit tests
- RISC-V: unified integer+FP stack frame and versioned crashdump ABI (supersedes the separate FP_RESERVE scheme)
- Authentication: dev-key reporting for early-revision secure parts
- LTShellNet/LTShellWiFi ported to LTSystemSchell; net speed test
- New lwipstat shell command for lwIP pool statistics; static RAM reductions
- WiFi transport teardown ordering fix

License banners and contributor naming follow the existing repository conventions.

Address review comments on LT core sync (02-Sep-2026)

- Keep the s_pAesCbc / s_pEntropy names in LTDeviceAuthenticationImpl.c; they are objects, not libraries
- Drop the ltshell/lwipstat duplicate; LTSchellLwipStat under ltschell/ already provides it
- Keep LTShellNet.c and LTShellWiFi.c on LTSystemShell; the LTSystemSchell versions live under ltschell/
- Port passive scan (-P), per-channel dwell (-D) and the static scan-buffer fix into ltschell/wifi/LTSchellWiFi.c; apply the buffer fix to ltshell/wifi/LTShellWiFi.c as well
- Comment the u32 wraparound guard in LTKThreadInitializeAndRun